### PR TITLE
gather facts when tearing down

### DIFF
--- a/tripleo-quickstart-config/metalkube-teardown-playbook.yml
+++ b/tripleo-quickstart-config/metalkube-teardown-playbook.yml
@@ -2,6 +2,6 @@
 - name: Teardown previous libvirt setup
   hosts: virthost
   connection: local
-  gather_facts: false
+  gather_facts: true
   roles:
     - libvirt/teardown


### PR DESCRIPTION
Without fact gathering enabled the ansible_user_id variable is undefined
and the playbook fails with an error.

Signed-off-by: Doug Hellmann <doug@doughellmann.com>