### PR TITLE
create dedicated baremetal bridge on nodes

### DIFF
--- a/assets/files/etc/NetworkManager/dispatcher.d/98-brextscript
+++ b/assets/files/etc/NetworkManager/dispatcher.d/98-brextscript
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+IF=$(ip r | grep default | grep -Po '(?<=dev )(\S+)')
+if [ ! -f /etc/sysconfig/network-scripts/ifcfg-$IF ] ; then
+echo brext acting on $IF
+cat <<EOF > /etc/sysconfig/network-scripts/ifcfg-$IF
+DEVICE=$IF
+BRIDGE=brext
+ONBOOT=yes
+NM_CONTROLLED=yes
+BOOTPROTO=none
+EOF
+systemctl restart NetworkManager
+nmcli conn down $IF
+fi

--- a/assets/files/etc/sysconfig/network-scripts/ifcfg-brext
+++ b/assets/files/etc/sysconfig/network-scripts/ifcfg-brext
@@ -1,0 +1,6 @@
+DEVICE=brext
+NAME=brext
+TYPE=Bridge
+ONBOOT=yes
+NM_CONTROLLED=yes
+BOOTPROTO=dhcp

--- a/assets/templates/98_master-brext.yaml
+++ b/assets/templates/98_master-brext.yaml
@@ -1,0 +1,23 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  generation: 1
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: 98-master-brext
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          verification: {}
+        filesystem: root
+        mode: 420
+        path: /etc/sysconfig/network-scripts/ifcfg-brext
+      - contents:
+          verification: {}
+        filesystem: root
+        mode: 493
+        path: /etc/NetworkManager/dispatcher.d/98-brextscript

--- a/assets/templates/98_worker-brext.yaml
+++ b/assets/templates/98_worker-brext.yaml
@@ -1,0 +1,23 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  generation: 1
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 98-worker-brext
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          verification: {}
+        filesystem: root
+        mode: 420
+        path: /etc/sysconfig/network-scripts/ifcfg-brext
+      - contents:
+          verification: {}
+        filesystem: root
+        mode: 493
+        path: /etc/NetworkManager/dispatcher.d/98-brextscript


### PR DESCRIPTION
This makes sure that both masters and workers get created with a brext bridge where the nic providing external access is attached.
The nic to pick is detected by checking which one has the default route
This allows to then create kubevirt vms which leverage this same bridge and as such can be directly accessed from the outside (without a need to expose services)