### PR TITLE
Obtain worker machine_name from baremetalhost properties

### DIFF
--- a/11_register_hosts.sh
+++ b/11_register_hosts.sh
@@ -92,7 +92,9 @@ wait_for_worker() {
     oc wait node/$worker --for=condition=Ready --timeout=$[${TIMEOUT_MINUTES} * 60]s
 }
 
-wait_for_worker worker-0
+for worker in $(list_workers | awk {'print $1'} | sed s/openshift-// ); do
+    wait_for_worker $worker
+done
 
 # Ensures IPs get set on the worker Machine
 ./add-machine-ips.sh

--- a/add-machine-ips.sh
+++ b/add-machine-ips.sh
@@ -17,7 +17,7 @@ for node in $(oc --config ocp/auth/kubeconfig get nodes -o template --template='
     node_name=$(echo $node | cut -f2 -d':')
     machine_name=$CLUSTER_NAME-$node_name
     if [[ "$machine_name" == *"worker"* ]]; then
-        machine_name=$(oc --config ocp/auth/kubeconfig get machines -n openshift-machine-api | grep $node_name | cut -f1 -d' ')
+        machine_name=$(oc --config ocp/auth/kubeconfig -n openshift-machine-api get baremetalhosts/openshift-$node_name -o template --template='{{.spec.machineRef.name}}')
     fi
     $SCRIPTDIR/link-machine-and-node.sh "$machine_name" "$node"
 done


### PR DESCRIPTION
Currently all machine names include ostest-worker-0 so when more than one worker nodes are present the machine_name var in add-machine-ips.sh gets set to multiple values which causes a later failure as reported in #421 

This change obtains the machine_name from the baremetal hosts properties and assumes the nodes are registered with openshift-worker-* names 