### PR TITLE
have dev-scripts pin the baremetal-operator

### DIFF
--- a/03_ocp_repo_sync.sh
+++ b/03_ocp_repo_sync.sh
@@ -60,6 +60,11 @@ popd
 
 # Install baremetal-operator
 sync_go_repo_and_patch github.com/metalkube/baremetal-operator https://github.com/metalkube/baremetal-operator.git
+# FIXME(dhellmann): Use the pre-rename version of the operator until
+# this repository is ready for the renamed version.
+pushd $GOPATH/src/github.com/metalkube/baremetal-operator
+git checkout before-rename
+popd
 
 # Install rook repository
 sync_go_repo_and_patch github.com/rook/rook https://github.com/rook/rook.git

--- a/08_deploy_bmo.sh
+++ b/08_deploy_bmo.sh
@@ -12,6 +12,9 @@ export BMOPATH="$GOPATH/src/github.com/metalkube/baremetal-operator"
 # Make a local copy of the baremetal-operator code to make changes
 cp -r $BMOPATH/deploy ocp/.
 sed -i 's/namespace: .*/namespace: openshift-machine-api/g' ocp/deploy/role_binding.yaml
+# FIXME(dhellmann): Use the pre-rename operator until this repo
+# works with the renamed version.
+sed -i 's|image: quay.io/metalkube/baremetal-operator$|image: quay.io/metalkube/baremetal-operator:before-rename|' ocp/deploy/operator.yaml
 
 # Start deploying on the new cluster
 oc --config ocp/auth/kubeconfig apply -f ocp/deploy/service_account.yaml --namespace=openshift-machine-api


### PR DESCRIPTION
Use the metalkube name instead of the metal3-io name for now. Another
patch will update the scripts to work with master form metal3-io again.