### PR TITLE
Update Custom MAO bringup documentation to let CVO manage MAO again

### DIFF
--- a/docs/custom-mao-and-capbm.md
+++ b/docs/custom-mao-and-capbm.md
@@ -94,6 +94,14 @@ Edit `custom-images.json` to have a modified image for the BareMetal case:
 
 ## 6) Now run the MAO
 
+Before running the MAO, we have to undo the change we did earlier by asking the
+cluster-version-operator to manage the machine-api-operator's deployment again.
+Without this, it will not scale the MAO back up.
+
+```sh
+oc patch clusterversion version --namespace openshift-cluster-version --type merge -p '{"spec":{"overrides":[{"kind":"Deployment","name":"machine-api-operator","namespace":"openshift-machine-api","unmanaged":false}]}}'
+```
+
 Change `custom-images.json` to `pkg/operator/fixtures/images.json` if you
 didn’t build a custom CAPBM.
 


### PR DESCRIPTION
While trying to bring up the custom MAO, the CVO was instructed to stop managing the MAO so that it doesn't immediately try to bring up the MAO that was stopped. When the new MAO is ready to be started, the CVO needs to be instructed to once again start managing the MAO for the new custom MAO to come up.