### PR TITLE
use metalkube branch instead of before-rename tag for baremetal operator

### DIFF
--- a/03_ocp_repo_sync.sh
+++ b/03_ocp_repo_sync.sh
@@ -63,7 +63,7 @@ sync_go_repo_and_patch github.com/metalkube/baremetal-operator https://github.co
 # FIXME(dhellmann): Use the pre-rename version of the operator until
 # this repository is ready for the renamed version.
 pushd $GOPATH/src/github.com/metalkube/baremetal-operator
-git checkout before-rename
+git checkout metalkube
 popd
 
 # Install rook repository

--- a/08_deploy_bmo.sh
+++ b/08_deploy_bmo.sh
@@ -14,7 +14,7 @@ cp -r $BMOPATH/deploy ocp/.
 sed -i 's/namespace: .*/namespace: openshift-machine-api/g' ocp/deploy/role_binding.yaml
 # FIXME(dhellmann): Use the pre-rename operator until this repo
 # works with the renamed version.
-sed -i 's|image: quay.io/metalkube/baremetal-operator$|image: quay.io/metalkube/baremetal-operator:before-rename|' ocp/deploy/operator.yaml
+sed -i 's|image: quay.io/metalkube/baremetal-operator$|image: quay.io/metalkube/baremetal-operator:metalkube|' ocp/deploy/operator.yaml
 
 # Start deploying on the new cluster
 oc --config ocp/auth/kubeconfig apply -f ocp/deploy/service_account.yaml --namespace=openshift-machine-api


### PR DESCRIPTION
Use a branch name for the image tag instead of a git tag so that if we
add changes on the branch we get new images automatically.