### PR TITLE
Run add-machine-ips.sh only with single worker deployments

### DIFF
--- a/11_register_hosts.sh
+++ b/11_register_hosts.sh
@@ -95,4 +95,7 @@ wait_for_worker() {
 wait_for_worker worker-0
 
 # Ensures IPs get set on the worker Machine
-./add-machine-ips.sh
+# Run only with single worker deployments as a workaround for issue #421
+if [ "$(list_workers | wc -l)" == 1 ]; then
+    ./add-machine-ips.sh
+fi


### PR DESCRIPTION
In order to avoid issue #421 run add-machine-ips.sh only when a single worker node is registered.   