### PR TITLE
Update to kubevirt 0.16.1

### DIFF
--- a/manifests/100_cnv_kubevirt_op.yaml
+++ b/manifests/100_cnv_kubevirt_op.yaml
@@ -492,12 +492,12 @@ spec:
         - "2"
         env:
         - name: OPERATOR_IMAGE
-          value: index.docker.io/kubevirt/virt-operator:v0.16.0
+          value: index.docker.io/kubevirt/virt-operator:v0.16.1
         - name: WATCH_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.annotations['olm.targetNamespaces']
-        image: index.docker.io/kubevirt/virt-operator:v0.16.0
+        image: index.docker.io/kubevirt/virt-operator:v0.16.1
         imagePullPolicy: IfNotPresent
         name: virt-operator
         ports:


### PR DESCRIPTION
Update to kubevirt 0.16.1. This brings two fixes:

 * Ensure that VMI Pods are protected during the whole migration on drains
 * Allow disabling save-migration checks in libvirt. This allows to work around situations where libvirt does not properly recognise disks as migrateable, during development and testing.