### PR TITLE
Add openshift prefix to kni infra namespace

### DIFF
--- a/assets/files/etc/kubernetes/manifests/coredns.yaml
+++ b/assets/files/etc/kubernetes/manifests/coredns.yaml
@@ -3,7 +3,7 @@ kind: Pod
 apiVersion: v1
 metadata:
   name: coredns
-  namespace: kni-infra
+  namespace: openshift-kni-infra
   creationTimestamp:
   deletionGracePeriodSeconds: 65
   labels:

--- a/assets/files/etc/kubernetes/manifests/haproxy.yaml
+++ b/assets/files/etc/kubernetes/manifests/haproxy.yaml
@@ -3,7 +3,7 @@ kind: Pod
 apiVersion: v1
 metadata:
   name: haproxy
-  namespace: kni-infra
+  namespace: openshift-kni-infra
   creationTimestamp:
   deletionGracePeriodSeconds: 65
   labels:

--- a/assets/files/etc/kubernetes/manifests/keepalived.yaml
+++ b/assets/files/etc/kubernetes/manifests/keepalived.yaml
@@ -3,7 +3,7 @@ kind: Pod
 apiVersion: v1
 metadata:
   name: keepalived
-  namespace: kni-infra
+  namespace: openshift-kni-infra
   creationTimestamp:
   deletionGracePeriodSeconds: 65
   labels:

--- a/assets/files/etc/kubernetes/manifests/mdns-publisher-worker.yaml
+++ b/assets/files/etc/kubernetes/manifests/mdns-publisher-worker.yaml
@@ -3,7 +3,7 @@ kind: Pod
 apiVersion: v1
 metadata:
   name: mdns-publisher
-  namespace: kni-infra
+  namespace: openshift-kni-infra
   creationTimestamp:
   deletionGracePeriodSeconds: 65
   labels:

--- a/assets/files/etc/kubernetes/manifests/mdns-publisher.yaml
+++ b/assets/files/etc/kubernetes/manifests/mdns-publisher.yaml
@@ -3,7 +3,7 @@ kind: Pod
 apiVersion: v1
 metadata:
   name: mdns-publisher
-  namespace: kni-infra
+  namespace: openshift-kni-infra
   creationTimestamp:
   deletionGracePeriodSeconds: 65
   labels:


### PR DESCRIPTION
Only pods in kube-system or openshift-* namespaces can be marked as
system-node-critical. This patch adapts us to that reality.

Fixes #371