### PR TITLE
Delete ifcfg-baremetal too

### DIFF
--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -29,6 +29,10 @@ sudo rm -rf /etc/NetworkManager/dnsmasq.d/openshift.conf /etc/NetworkManager/con
 if [ "$MANAGE_PRO_BRIDGE" == "y" ]; then
     sudo rm -f /etc/sysconfig/network-scripts/ifcfg-provisioning
 fi
+# Leaving this around causes issues when the host is rebooted
+if [ "$MANAGE_BR_BRIDGE" == "y" ]; then
+    sudo rm -f /etc/sysconfig/network-scripts/ifcfg-baremetal
+fi
 sudo virsh net-list --name|grep -q baremetal
 if [ "$?" == "0" ]; then
     sudo virsh net-destroy baremetal


### PR DESCRIPTION
We already delete ifcfg-provisioning because of a previous bug, but
leaving the ifcfg-baremetal file is causing problems such as #375.
Deleting this file too when we do host cleanup avoids the problem.