### PR TITLE
mkdir ~/go/bin before installing dep

### DIFF
--- a/03_ocp_repo_sync.sh
+++ b/03_ocp_repo_sync.sh
@@ -47,6 +47,7 @@ sync_go_repo_and_patch github.com/openshift-metalkube/kni-installer https://gith
 
 # Install Go dependency management tool
 # Using pre-compiled binaries instead of installing from source
+mkdir -p $GOPATH/bin
 curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 export PATH="${GOPATH}/bin:$PATH"
 


### PR DESCRIPTION
dep requires $GOBIN to exist before it will install.  Previously it was
implicitly created by some go things we installed.  Disabling facet
changed that, so let's create it explicitly.