### PR TITLE
Add api-int DNS record to coredns

### DIFF
--- a/assets/files/etc/kubernetes/manifests/coredns.yaml
+++ b/assets/files/etc/kubernetes/manifests/coredns.yaml
@@ -44,6 +44,9 @@ spec:
       source /etc/kubernetes/static-pod-resources/clusterrc
       export DOMAIN
       export NAME
+      # This should eventually be looked up from the config
+      API_VIP="$(dig +noall +answer "api.${DOMAIN}" | awk '{print $NF}')"
+      export API_VIP
       /usr/libexec/platform-python -c "from __future__ import print_function
       import os
       with open('/etc/kubernetes/static-pod-resources/Corefile.template', 'r') as f:

--- a/assets/files/etc/kubernetes/static-pod-resources/coredns/Corefile.template
+++ b/assets/files/etc/kubernetes/static-pod-resources/coredns/Corefile.template
@@ -5,4 +5,8 @@
     forward . /etc/coredns/resolv.conf
     cache 30
     reload
+    hosts /etc/coredns/api-int.hosts $CLUSTER_DOMAIN {
+        $API_VIP api-int.$CLUSTER_DOMAIN
+        fallthrough
+    }
 }


### PR DESCRIPTION
Add a static mdns record that points to the API VIP. This is to
support the new required DNS record from OpenShift.