### PR TITLE
Add 'openshift-kni-infra' namespace during install

### DIFF
--- a/assets/templates/99_openshift-kni-infra-namespace.yaml
+++ b/assets/templates/99_openshift-kni-infra-namespace.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-kni-infra
+  annotations:
+    openshift.io/description: ""
+    openshift.io/display-name: ""
+spec:
+  finalizers:
+  - kubernetes


### PR DESCRIPTION
Namespace 'openshift-kni-infra' doesn't exists.
```
  $ oc get project openshift-kni-infra
  Error from server (NotFound): namespaces "openshift-kni-infra" not found
  $ oc get namespace openshift-kni-infra
  Error from server (NotFound): namespaces "openshift-kni-infra" not found
```