### PR TITLE
Use tabs for indentation in ironic_cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ ocp_cleanup:
 	./ocp_cleanup.sh
 
 ironic_cleanup:
-    ./ironic_cleanup.sh
+	./ironic_cleanup.sh
 
 host_cleanup:
 	./host_cleanup.sh


### PR DESCRIPTION
Makefiles require the use of tabs. The spaces in this target cause
the following error:

Makefile:36: *** missing separator.  Stop.