### PR TITLE
Add api-int DNS entry to dnsmasq

### DIFF
--- a/06_create_cluster.sh
+++ b/06_create_cluster.sh
@@ -30,6 +30,7 @@ if [ "$MANAGE_BR_BRIDGE" == "y" ] ; then
     API_VIP=$(dig +noall +answer "api.${CLUSTER_DOMAIN}" @$(network_ip baremetal) | awk '{print $NF}')
     INGRESS_VIP=$(python -c "from ansible.plugins.filter import ipaddr; print(ipaddr.nthhost('"$EXTERNAL_SUBNET"', 4))")
     echo "address=/api.${CLUSTER_DOMAIN}/${API_VIP}" | sudo tee /etc/NetworkManager/dnsmasq.d/openshift.conf
+    echo "address=/api-int.${CLUSTER_DOMAIN}/${API_VIP}" | sudo tee -a /etc/NetworkManager/dnsmasq.d/openshift.conf
     echo "address=/.apps.${CLUSTER_DOMAIN}/${INGRESS_VIP}" | sudo tee -a /etc/NetworkManager/dnsmasq.d/openshift.conf
     sudo systemctl reload NetworkManager
 else


### PR DESCRIPTION
This addresses the need for an api-int name pointing at the api VIP.
However, it will only take effect when dev-scripts is managing the
baremetal bridge. With this method, real deployers would need to
add a CNAME to their DNS in addition to the regular api name.