### PR TITLE
haproxy: add /host volume to run commands on the host through chroot

### DIFF
--- a/assets/files/etc/kubernetes/manifests/haproxy.yaml
+++ b/assets/files/etc/kubernetes/manifests/haproxy.yaml
@@ -20,6 +20,9 @@ spec:
     empty-dir: {}
   - name: conf-dir
     empty-dir: {}
+  - name: chroot-host
+    hostPath:
+      path: "/"
   initContainers:
   - name: clusterrc-generation
     image: quay.io/openshift-metalkube/kubeconfig-extractor:latest
@@ -129,6 +132,8 @@ spec:
       mountPath: "/var/run/haproxy"
     - name: resource-dir
       mountPath: "/etc/kubernetes/static-pod-resources"
+    - name: chroot-host
+      mountPath: "/host"
     terminationMessagePolicy: FallbackToLogsOnError
     imagePullPolicy: IfNotPresent
   hostNetwork: true


### PR DESCRIPTION
The haproxy-monitor container tries to configure routes by executing
`iptables` commands from the host through a `chroot /host` environment.
Without the /host volume mapped to / on the host, these commands fail
and the haproxy-monitor container fails to start.

Note that this depends on #453 before the pods can be deployed.

Closes: #456 
