### PR TITLE
Fix worker mdns-publisher-worker-0 pod failures

### DIFF
--- a/assets/files/etc/kubernetes/manifests/mdns-publisher-worker.yaml
+++ b/assets/files/etc/kubernetes/manifests/mdns-publisher-worker.yaml
@@ -64,7 +64,7 @@ spec:
       export CLUSTER_NAME
       /usr/libexec/platform-python -c "from __future__ import print_function
       import os
-      with open('/etc/kubernetes/static-pod-resources/config.template', 'r') as f:
+      with open('/etc/kubernetes/static-pod-resources/worker-config.template', 'r') as f:
           content = f.read()
       with open('/etc/mdns/config.hcl', 'w') as dest:
           print(os.path.expandvars(content), file=dest)"

--- a/assets/templates/99_worker-mdns-publisher.yaml
+++ b/assets/templates/99_worker-mdns-publisher.yaml
@@ -21,3 +21,8 @@ spec:
         filesystem: root
         mode: 0664
         path: /etc/kubernetes/static-pod-resources/mdns/worker-config.template
+      - contents:
+          verification: {}
+        filesystem: root
+        mode: 0775
+        path: /usr/local/bin/get_vip_subnet_cidr


### PR DESCRIPTION
This PR addresses two issues with the mdns-publisher-worker-0 pod:

1. add the missing `/usr/local/bin/get_vip_subnet_cidr` on the host
2. use the correct template in the render-config initContainer

With these commits and #453 the mdns-publisher-worker-0 pod in the openshift-kni-infra namespace gets into Running state.

Updates: #458