### PR TITLE
Update to kubevirt 0.16.2

### DIFF
--- a/manifests/100_cnv_kubevirt_op.yaml
+++ b/manifests/100_cnv_kubevirt_op.yaml
@@ -492,12 +492,12 @@ spec:
         - "2"
         env:
         - name: OPERATOR_IMAGE
-          value: index.docker.io/kubevirt/virt-operator:v0.16.1
+          value: index.docker.io/kubevirt/virt-operator:v0.16.2
         - name: WATCH_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.annotations['olm.targetNamespaces']
-        image: index.docker.io/kubevirt/virt-operator:v0.16.1
+        image: index.docker.io/kubevirt/virt-operator:v0.16.2
         imagePullPolicy: IfNotPresent
         name: virt-operator
         ports:


### PR DESCRIPTION
The kubevirt operator is now more resilient in case that the discovery client can't fully resolve the host resources. Before this release, it was enough that one aggregated apiserver from extension is offline to block the kubevirt operator.