### PR TITLE
Fix/rook resources not found

### DIFF
--- a/10_deploy_rook.sh
+++ b/10_deploy_rook.sh
@@ -27,6 +27,7 @@ sed -i "s@rook/ceph:master@rook/ceph:$ROOK_VERSION@" operator-openshift-modified
 sed -i '/ROOK_MON_HEALTHCHECK_INTERVAL/!b;n;c\          value: "30s"' operator-openshift-modified.yaml
 sed -i '/ROOK_MON_OUT_TIMEOUT/!b;n;c\          value: "40s"' operator-openshift-modified.yaml
 oc create -f operator-openshift-modified.yaml
+sleep 5
 
 oc wait --for condition=ready  pod -l app=rook-ceph-operator -n openshift-storage --timeout=120s
 oc wait --for condition=ready  pod -l app=rook-ceph-agent -n openshift-storage --timeout=120s
@@ -40,6 +41,7 @@ oc create -f cluster-modified.yaml
 sed 's/namespace: rook-ceph/namespace: openshift-storage/' toolbox.yaml > toolbox-modified.yaml
 sed -i "s@rook/ceph:master@rook/ceph:$ROOK_VERSION@" toolbox-modified.yaml
 oc create -f toolbox-modified.yaml
+sleep 5
 
 # enable pg_autoscaler
 oc wait --for condition=ready  pod -l app=rook-ceph-tools -n openshift-storage --timeout=180s


### PR DESCRIPTION
To solve this error:

```
+ oc create -f operator-openshift-modified.yaml
securitycontextconstraints.security.openshift.io/rook-ceph created
deployment.apps/rook-ceph-operator created
+ oc wait --for condition=ready pod -l app=rook-ceph-operator -n openshift-storage --timeout=120s
pod/rook-ceph-operator-ddf6764c7-sk6dd condition met
+ oc wait --for condition=ready pod -l app=rook-ceph-agent -n openshift-storage --timeout=120s
error: no matching resources found
```

in order to give some time to kubernetes to create the objects and then spin up.