### PR TITLE
Only change selinux if needed.

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -3,9 +3,11 @@ set -ex
 
 source logging.sh
 
-# FIXME ocp-doit required this so leave permissive for now
-sudo setenforce permissive
-sudo sed -i "s/=enforcing/=permissive/g" /etc/selinux/config
+if selinuxenabled ; then
+    # FIXME ocp-doit required this so leave permissive for now
+    sudo setenforce permissive
+    sudo sed -i "s/=enforcing/=permissive/g" /etc/selinux/config
+fi
 
 # Update to latest packages first
 sudo yum -y update


### PR DESCRIPTION
If you run this script on a system that already has selinux disabled
via config, setenforce will return non-zero and cause this script to
fail.  Check to see if selinux is enabled first to avoid this problem.