### PR TITLE
coredns-mdns: masters to always return SRV entries

### DIFF
--- a/assets/files/etc/kubernetes/static-pod-resources/coredns/Corefile.template
+++ b/assets/files/etc/kubernetes/static-pod-resources/coredns/Corefile.template
@@ -1,7 +1,7 @@
 . {
     errors
     health
-    mdns $DOMAIN 2 $NAME
+    mdns $DOMAIN 0 $NAME
     forward . /etc/coredns/resolv.conf
     cache 30
     reload


### PR DESCRIPTION
Keepalived health for the coredns-mdns VIP is determined from being able
to give out Etcd records. The problem with that is that if some master
goes down, we are, by definition, not able to give out the total amount
of masters, which is the minimum that used to be set before we moved it
to 2. The reason why it used to be TOTAL_AMOUNT_OF_MASTERS was because
that is the right setting at the bootstrap stage and we were moving the
DNS VIP to the masters as soon as possible.

With this change and a companion one in kni-installer, we keep the
TOTAL_AMOUNT_OF_MASTERS, but only in the bootstrap keepalived
configuration. Once the cluster is formed and the bootstrap node is
taken down, the masters will run coredns-mdns without the
TOTAL_AMOUNT_OF_MASTERS restriction when responding to etcd SRV queries.

Signed-off-by: Antoni Segura Puimedon <antoni@redhat.com>