### PR TITLE
Fix oc wait timeout in 10_deploy_rook.sh

### DIFF
--- a/10_deploy_rook.sh
+++ b/10_deploy_rook.sh
@@ -27,11 +27,11 @@ sed -i "s@rook/ceph:master@rook/ceph:$ROOK_VERSION@" operator-openshift-modified
 sed -i '/ROOK_MON_HEALTHCHECK_INTERVAL/!b;n;c\          value: "30s"' operator-openshift-modified.yaml
 sed -i '/ROOK_MON_OUT_TIMEOUT/!b;n;c\          value: "40s"' operator-openshift-modified.yaml
 oc create -f operator-openshift-modified.yaml
-sleep 5
+sleep 10
 
-oc wait --for condition=ready  pod -l app=rook-ceph-operator -n openshift-storage --timeout=120s
-oc wait --for condition=ready  pod -l app=rook-ceph-agent -n openshift-storage --timeout=120s
-oc wait --for condition=ready  pod -l app=rook-discover -n openshift-storage --timeout=120s
+oc wait --for condition=ready  pod -l app=rook-ceph-operator -n openshift-storage --timeout=180s
+oc wait --for condition=ready  pod -l app=rook-ceph-agent -n openshift-storage --timeout=180s
+oc wait --for condition=ready  pod -l app=rook-discover -n openshift-storage --timeout=180s
 
 sed 's/# port: 8443/port: 8444/' cluster.yaml > cluster-modified.yaml
 sed -i 's/namespace: rook-ceph/namespace: openshift-storage/' cluster-modified.yaml
@@ -41,7 +41,7 @@ oc create -f cluster-modified.yaml
 sed 's/namespace: rook-ceph/namespace: openshift-storage/' toolbox.yaml > toolbox-modified.yaml
 sed -i "s@rook/ceph:master@rook/ceph:$ROOK_VERSION@" toolbox-modified.yaml
 oc create -f toolbox-modified.yaml
-sleep 5
+sleep 10
 
 # enable pg_autoscaler
 oc wait --for condition=ready  pod -l app=rook-ceph-tools -n openshift-storage --timeout=180s


### PR DESCRIPTION
Most 'oc wait' commands have a timeout of 180s.  This may not be sufficient for
other wait conditions which have a timeout of 120s.  Make all the timeouts 180s.