### PR TITLE
FIx clusterinfo to work in worker nodes

### DIFF
--- a/assets/files/usr/local/bin/clusterinfo
+++ b/assets/files/usr/local/bin/clusterinfo
@@ -6,6 +6,7 @@ NAME=$(oc config view -o "jsonpath={.contexts[?(@.name == '""$CURRENT_CONTEXT""'
 APIURL=$(oc config view -o "jsonpath={.clusters[?(@.name == '""$NAME""')].cluster.server}")
 APIHOST=$(echo $APIURL | sed -e 's/.*\/\/\([^:]\+\).*/\1/g')
 DOMAIN=${APIHOST#*.}
+NAME_FROM_DOMAIN=${DOMAIN%%.*}
 BASE_DOMAIN=${DOMAIN#*.}
 
 echo ${!1}

--- a/assets/templates/99_worker-utils.yaml
+++ b/assets/templates/99_worker-utils.yaml
@@ -1,0 +1,28 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  generation: 1
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 00-worker-utils
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          verification: {}
+        filesystem: root
+        mode: 0775
+        path: /usr/local/bin/clusterinfo
+      - contents:
+          verification: {}
+        filesystem: root
+        mode: 0775
+        path: /usr/local/bin/get_vip_subnet_cidr
+      - contents:
+          verification: {}
+        filesystem: root
+        mode: 0775
+        path: /usr/local/bin/fletcher8


### PR DESCRIPTION
clusterinfo is used to set the DNS VIP in collaboration with
NetworkManager's dhclient. The problem is that it was missing in workers
and, on top of that, it was retrieving the cluster name from
kubeconfig's cluster-name, which on the worker nodes is just "local".

This patch fixes both things.

Signed-off-by: Antoni Segura Puimedon <antoni@redhat.com>