### PR TITLE
Add record for api-int to baremetal bridge

### DIFF
--- a/vm-setup/roles/common/tasks/main.yml
+++ b/vm-setup/roles/common/tasks/main.yml
@@ -68,6 +68,7 @@
                 - ip: "{{ baremetal_network_cidr | nthhost(5) }}"
                   hostnames:
                     - "api"
+                    - "api-int"
                 - ip: "{{ baremetal_network_cidr | nthhost(2) }}"
                   hostnames:
                     - "ns1"


### PR DESCRIPTION
In 4.1, api-int is used by ignition so the record needs to exist in the baremetal network.