### PR TITLE
Add VIP DNS entries to vm_setup_vars.yml

### DIFF
--- a/vm_setup_vars.yml
+++ b/vm_setup_vars.yml
@@ -9,3 +9,14 @@ ironic_prefix: "openshift_"
 # in metal3-dev-env
 default_memory: 16384
 num_masters: 3
+
+# For OpenShift we create some additional DNS records for the API/DNS VIPs
+baremetal_network_cidr: "{{ lookup('env', 'EXTERNAL_SUBNET') | default('192.168.111.0/24', true) }}"
+dns_extrahosts:
+  - ip: "{{ baremetal_network_cidr | nthhost(5) }}"
+    hostnames:
+      - "api"
+      - "api-int"
+  - ip: "{{ baremetal_network_cidr | nthhost(2) }}"
+    hostnames:
+      - "ns1"


### PR DESCRIPTION
These have been removed from metal3-dev-env so we need to set
them here