### PR TITLE
add kill proxy to host_cleanup.sh

### DIFF
--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -31,3 +31,5 @@ if [ "$MANAGE_BR_BRIDGE" == "y" ]; then
     sudo ifdown baremetal || true
     sudo rm -f /etc/sysconfig/network-scripts/ifcfg-baremetal
 fi
+# Kill any lingering proxy
+sudo pkill -f oc.*proxy


### PR DESCRIPTION
An error or interruption in `link-machine-and-node.sh` can leave a lingering `oc proxy` command. After a `make clean`, this proxy will still be running, and the `kill $proxy_pid` will error, aborting the deployment on the 06 script.

This simply adds a `pkill` to the `host_cleanup.sh` script to get that sucker out of there.