### PR TITLE
Check for cloud.openshift.com pull secret.

### DIFF
--- a/06_create_cluster.sh
+++ b/06_create_cluster.sh
@@ -15,6 +15,11 @@ if [[ "${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE}" == *"registry.svc.ci.openshi
     fi
 fi
 
+if [[ "${PULL_SECRET}" != *"cloud.openshift.com"* ]]; then
+    echo "Please get a valid pull secret for cloud.openshift.com."
+    exit 1
+fi
+
 if [ ! -d ocp ]; then
     mkdir -p ocp
 


### PR DESCRIPTION
After our 4.1 rc3 update, it appears we now also require the
cloud.openshift.com pull secret.  Validate that it is present before
attempting an install.