### PR TITLE
Add bootkube_log.sh.

### DIFF
--- a/bootkube_log.sh
+++ b/bootkube_log.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+BOOTSTRAP_VM_IP=$(sudo virsh net-dhcp-leases baremetal | grep -v master | grep ipv4 | tail -n1 | sed -e 's/.*\(192.*\)\/.*/\1/')
+echo "Attempting to follow bootkube on ${BOOTSTRAP_VM_IP} ..."
+ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no core@${BOOTSTRAP_VM_IP} journalctl -b -f -u bootkube.service


### PR DESCRIPTION
A pretty common need is to follow the bootkube log from the bootstrap
VM.  I wrote this quick and dirty script to make that a little easier
on myself, at least for the standard dev-scripts setup that's using
the libvirt baremetal network.