### PR TITLE
Remove machine-api-controllers restart.

### DIFF
--- a/08_deploy_bmo.sh
+++ b/08_deploy_bmo.sh
@@ -23,12 +23,3 @@ oc --config ocp/auth/kubeconfig apply -f ocp/deploy/role.yaml --namespace=opensh
 oc --config ocp/auth/kubeconfig apply -f ocp/deploy/role_binding.yaml
 oc --config ocp/auth/kubeconfig apply -f ocp/deploy/crds/metalkube_v1alpha1_baremetalhost_crd.yaml
 oc --config ocp/auth/kubeconfig apply -f ocp/deploy/operator.yaml --namespace=openshift-machine-api
-
-# Workaround for https://github.com/metalkube/cluster-api-provider-baremetal/issues/57
-oc --config ocp/auth/kubeconfig scale deployment -n openshift-machine-api machine-api-controllers --replicas=0
-while [ ! $(oc --config ocp/auth/kubeconfig get deployment -n openshift-machine-api machine-api-controllers -o json | jq .spec.replicas) ]
-do
-  echo "Scaling down machine-api-controllers ..."
-done
-echo "Scaling up machine-api-controllers ..."
-oc --config ocp/auth/kubeconfig scale deployment -n openshift-machine-api machine-api-controllers --replicas=1


### PR DESCRIPTION
This was a workaround that is no longer necessary since we're now
using a new enough release of OpenShift that includes the fix.

The upstream fix was here:
https://github.com/metal3-io/cluster-api-provider-baremetal/pull/58

and it was backported here:
https://github.com/openshift/cluster-api-provider-baremetal/pull/21

The current release we're using can be checked using:
oc adm release info quay.io/openshift-release-dev/ocp-release:4.1.0-rc.3 -a ~/pull-secret.json --commits | grep baremetal
  baremetal-machine-controllers https://github.com/openshift/cluster-api-provider-baremetal 8a27778353fb5f236593cdee112d4542e6f96929

This commit is past when the fix was merged into
openshift/cluster-api-provider-baremetal.