### PR TITLE
Support running installer from other locations

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -126,3 +126,6 @@ if [ ! -d "$WORKING_DIR" ]; then
 fi
 sudo chown "${USER}:${USER}" "$WORKING_DIR"
 chmod 755 "$WORKING_DIR"
+
+# Allow overriding openshift-install binary location, to e.g. build from git
+export OPENSHIFT_INSTALLER=${OPENSHIFT_INSTALLER:-"ocp/openshift-install"}

--- a/config_example.sh
+++ b/config_example.sh
@@ -10,6 +10,9 @@ set -x
 #export IRONIC_INSPECTOR_IMAGE=https://github.com/metal3-io/ironic-inspector
 #export IRONIC_IMAGE=https://github.com/metal3-io/ironic
 
+# Uncomment to use a local copy of kni-installer instead
+#export OPENSHIFT_INSTALLER="~/go/src/github.com/openshift-metalkube/kni-installer/bin/kni-install"
+
 # SSH key used to ssh into deployed hosts.  This must be the contents of the
 # variable, not the filename. The contents of ~/.ssh/id_rsa.pub are used by
 # default.

--- a/utils.sh
+++ b/utils.sh
@@ -39,7 +39,7 @@ function create_cluster() {
     export TF_LOG=DEBUG
 
     cp ${assets_dir}/install-config.yaml{,.tmp}
-    "${assets_dir}/openshift-install" --dir "${assets_dir}" --log-level=debug create manifests
+    $OPENSHIFT_INSTALLER --dir "${assets_dir}" --log-level=debug create manifests
 
     # TODO - consider adding NTP server config to install-config.yaml instead
     if host clock.redhat.com ; then
@@ -51,14 +51,14 @@ function create_cluster() {
     cp -rf assets/generated/*.yaml ${assets_dir}/openshift
 
     cp ${assets_dir}/install-config.yaml{.tmp,}
-    "${assets_dir}/openshift-install" --dir "${assets_dir}" --log-level=debug create cluster
+    $OPENSHIFT_INSTALLER --dir "${assets_dir}" --log-level=debug create cluster
 }
 
 function wait_for_cvo_finish() {
     local assets_dir
 
     assets_dir="$1"
-    "${assets_dir}/openshift-install" --dir "${assets_dir}" --log-level=debug wait-for install-complete
+    $OPENSHIFT_INSTALLER --dir "${assets_dir}" --log-level=debug wait-for install-complete
 }
 
 function wait_for_json() {


### PR DESCRIPTION
If one wants to test an installer they built from git, a developer can override the installer by saying:

```console
export OPENSHIFT_INSTALLER="~/go/src/github.com/openshift-metalkube/kni-installer/bin/kni-install"
make
```

This could also be a little more helpful, like actually building the installer.  This PR would require the user to have already built it.