### PR TITLE
Add api_vip to install-config.yaml

### DIFF
--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -69,6 +69,7 @@ controlPlane:
   replicas: ${NUM_MASTERS}
 platform:
   baremetal:
+    api_vip: ${API_VIP}
     nodes:
 $(master_node_map_to_install_config $NUM_MASTERS)
     master_configuration:


### PR DESCRIPTION
This is needed for us to properly support the api-int DNS name on
baremetal. It is a prerequisite to the installer change:
https://github.com/openshift-metal3/kni-installer/pull/82

See #538 for further details.