### PR TITLE
Remove external api-int DNS entry

### DIFF
--- a/vm_setup_vars.yml
+++ b/vm_setup_vars.yml
@@ -16,7 +16,6 @@ dns_extrahosts:
   - ip: "{{ baremetal_network_cidr | nthhost(5) }}"
     hostnames:
       - "api"
-      - "api-int"
   - ip: "{{ baremetal_network_cidr | nthhost(2) }}"
     hostnames:
       - "ns1"


### PR DESCRIPTION
This should not be required. Once
https://github.com/openshift-metal3/kni-installer/pull/82 merges
it will no longer be.

Fixes #538