### PR TITLE
Add kni-installer to projects that get moved to $GOPATH

### DIFF
--- a/run_ci.sh
+++ b/run_ci.sh
@@ -91,7 +91,7 @@ if [ -d "/home/notstack/metalkube-ironic-inspector" ] ; then
 fi
 
 # If directories for go projects exist, copy them to where go expects them
-for PROJ in facet ; do
+for PROJ in facet kni-installer ; do
     [ ! -d /home/notstack/$PROJ ] && continue
 
     # Set origin so that sync_repo_and_patch is rebasing against the correct source


### PR DESCRIPTION
This fixes testing installer PR's in CI.

In #558, I added the ability to run the installer from git, assuming
that CI would check out the repo to $GOPATH, but that was an incorrect
assumption. It gets checked out to $HOME. We need it in the list of
projects that gets moved to $GOPATH, if the path exists.

This does not affect the behavior of installation from release payloads
by default.