### PR TITLE
Compact pull secret onto one line

### DIFF
--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -77,7 +77,7 @@ $(master_node_map_to_install_config $NUM_MASTERS)
       image_checksum: $(curl http://172.22.0.1/images/$RHCOS_IMAGE_FILENAME_LATEST.md5sum)
       root_gb: 25
 pullSecret: |
-  ${PULL_SECRET}
+  $(echo $PULL_SECRET | jq -c .)
 sshKey: |
   ${SSH_PUB_KEY}
 EOF


### PR DESCRIPTION
If the pull secret isn't on a single line, it messes up the formatting in install-config.yaml resulting in errors like:

```
"level=fatal msg="failed to fetch Master Machines: failed to load asset \"Install Config\": failed to unmarshal: error converting YAML to JSON: yaml: line 103: did not find expected key""
```