### PR TITLE
Also delete the interface

### DIFF
--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -22,13 +22,17 @@ ANSIBLE_FORCE_COLOR=true ansible-playbook \
 
 sudo rm -rf /etc/NetworkManager/dnsmasq.d/openshift.conf /etc/NetworkManager/conf.d/dnsmasq.conf
 # There was a bug in this file, it may need to be recreated.
+# delete the interface as it can cause issues when not rebooting
 if [ "$MANAGE_PRO_BRIDGE" == "y" ]; then
     sudo ifdown provisioning || true
+    sudo ip link delete provisioning || true
     sudo rm -f /etc/sysconfig/network-scripts/ifcfg-provisioning
 fi
 # Leaving this around causes issues when the host is rebooted
+# delete the interface as it can cause issues when not rebooting
 if [ "$MANAGE_BR_BRIDGE" == "y" ]; then
     sudo ifdown baremetal || true
+    sudo ip link delete baremetal || true
     sudo rm -f /etc/sysconfig/network-scripts/ifcfg-baremetal
 fi
 # Kill any lingering proxy


### PR DESCRIPTION
When cleaning up the interface, remove the interface itself from the system.
The interface becomes unconfigured, though it won't delete the interface
from the system.  Ordinarily the next step would be to reboot the system,
at which time the interface would be deleted from the system.  However, not
rebooting the system could result in errors similar to: "error creating
bridge interface baremetal: File exists"
