### PR TITLE
Work around python-*zmq epel conflict

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -26,6 +26,9 @@ fi
 if ! grep -q zeromq /etc/yum.repos.d/epel.repo; then
   sudo sed -i '/enabled=1/a exclude=zeromq*' /etc/yum.repos.d/epel.repo
 fi
+if ! grep -q zmq /etc/yum.repos.d/epel.repo; then
+  sudo sed -i '/^exclude=zeromq/ s/$/,*zmq/' /etc/yum.repos.d/epel.repo
+fi
 
 # Install required packages
 # python-{requests,setuptools} required for tripleo-repos install


### PR DESCRIPTION
This version now conflicts with the one from the RDO repos, so add
it to the exclude list for epel.

Fixes: #581