### PR TITLE
Allow OPENSHIFT_RELEASE_IMAGE to be overridden again

### DIFF
--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -14,7 +14,7 @@ export EXTERNAL_SUBNET="192.168.111.0/24"
 # The release we default to here is pinned and known to work with our current
 # version of kni-installer.
 #
-export OPENSHIFT_RELEASE_IMAGE="registry.svc.ci.openshift.org/kni/release:4.1.0-rc.5-kni.1"
+export OPENSHIFT_RELEASE_IMAGE="${OPENSHIFT_RELEASE_IMAGE:-registry.svc.ci.openshift.org/kni/release:4.1.0-rc.5-kni.1}"
 
 function extract_installer() {
     local release_image


### PR DESCRIPTION
I believe the OPENSHIFT_RELEASE_IMAGE should be a variable again so the pinned version can be overridden. This makes testing and CI with different openshift version easier and eliminates the need to modify the file (with essentially this change) in the ci system