### PR TITLE
Remove the zmq and zeromq workarounds

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -22,14 +22,6 @@ if [ ! -f /etc/yum.repos.d/epel.repo ] ; then
     fi
 fi
 
-# Work around a conflict with a newer zeromq from epel
-if ! grep -q zeromq /etc/yum.repos.d/epel.repo; then
-  sudo sed -i '/enabled=1/a exclude=zeromq*' /etc/yum.repos.d/epel.repo
-fi
-if ! grep -q zmq /etc/yum.repos.d/epel.repo; then
-  sudo sed -i '/^exclude=zeromq/ s/$/,*zmq/' /etc/yum.repos.d/epel.repo
-fi
-
 # Install required packages
 # python-{requests,setuptools} required for tripleo-repos install
 sudo yum -y install \


### PR DESCRIPTION
The zmq workaournd was added because of a problem
caused by the zeromq workaround. But it looks like neither
are required.