### PR TITLE
Fix bug in ipmi address when not using port

### DIFF
--- a/utils.sh
+++ b/utils.sh
@@ -128,7 +128,7 @@ function master_node_map_to_install_config() {
       address=$(master_node_val ${master_idx} "driver_info.${driver_prefix}_address")
 
       bmc_uri=${driver}://${address}
-      if [ -n $port ]; then
+      if [ -n "$port" ]; then
         bmc_uri=$bmc_uri:${port}
       fi
 


### PR DESCRIPTION
If ironic-nodes.json doesn't specify a port for BMC, the address will be
constructed like `ipmi://192.168.1.1:` with a trailing colon.  $port
must be quoted when using -n, see the warning on -n at
http://tldp.org/LDP/abs/html/comparison-ops.html.