### PR TITLE
Add worker nodes to the ironic_hosts.json.example and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ Make a copy of the `config_example.sh` to `config_$USER.sh`, and set the
 
 For baremetal test setups where you don't require the VM fake-baremetal nodes,
 you may also set `NODES_FILE` to reference a manually created json file with
-the node details (see [ironic_hosts.json.example](ironic_hosts.json.example)),
-and `NODES_PLATFORM` which can be set to e.g "baremetal" to disable the libvirt
+the node details (see [ironic_hosts.json.example](ironic_hosts.json.example) -
+make sure the ironic nodes names follow the openshift-master-* and openshift-worker-*
+format), and `NODES_PLATFORM` which can be set to e.g "baremetal" to disable the libvirt
 master/worker node setup. See [common.sh](common.sh) for other variables that
 can be overridden.
 

--- a/ironic_hosts.json.example
+++ b/ironic_hosts.json.example
@@ -40,7 +40,7 @@
         "cpu_arch": "x86_64"
       }
     },
-          {
+     {
       "name": "openshift-master-2",
       "driver": "ipmi",
       "resource_class": "baremetal",
@@ -53,6 +53,66 @@
       },
       "ports": [{
         "address": "8e:af:c4:d0:a3:b4",
+        "pxe_enabled": true
+      }],
+      "properties": {
+        "local_gb": "50",
+        "cpu_arch": "x86_64"
+      }
+    },
+     {
+      "name": "openshift-worker-0",
+      "driver": "ipmi",
+      "resource_class": "baremetal",
+      "driver_info": {
+        "ipmi_username": "root",
+        "ipmi_password": "passw0rd",
+        "ipmi_address": "1.1.1.4",
+        "deploy_kernel": "http://172.22.0.1/images/ironic-python-agent.kernel",
+        "deploy_ramdisk": "http://172.22.0.1/images/ironic-python-agent.initramfs"
+      },
+      "ports": [{
+        "address": "8e:af:c4:d0:a3:b5",
+        "pxe_enabled": true
+      }],
+      "properties": {
+        "local_gb": "50",
+        "cpu_arch": "x86_64"
+      }
+    },
+     {
+      "name": "openshift-worker-1",
+      "driver": "ipmi",
+      "resource_class": "baremetal",
+      "driver_info": {
+        "ipmi_username": "root",
+        "ipmi_password": "passw0rd",
+        "ipmi_address": "1.1.1.5",
+        "deploy_kernel": "http://172.22.0.1/images/ironic-python-agent.kernel",
+        "deploy_ramdisk": "http://172.22.0.1/images/ironic-python-agent.initramfs"
+      },
+      "ports": [{
+        "address": "8e:af:c4:d0:a3:b6",
+        "pxe_enabled": true
+      }],
+      "properties": {
+        "local_gb": "50",
+        "cpu_arch": "x86_64"
+      }
+    },
+     {
+      "name": "openshift-worker-2",
+      "driver": "ipmi",
+      "resource_class": "baremetal",
+      "driver_info": {
+        "ipmi_username": "root",
+        "ipmi_password": "passw0rd",
+        "ipmi_address": "1.1.1.6",
+        "deploy_kernel": "http://172.22.0.1/images/ironic-python-agent.kernel",
+        "deploy_ramdisk": "http://172.22.0.1/images/ironic-python-agent.initramfs"
+      },
+      "ports": [{
+        "address": "8e:af:c4:d0:a3:b7",
         "pxe_enabled": true
       }],
       "properties": {


### PR DESCRIPTION
In order to prevent issues like #593 let's add worker nodes in the ironic_hosts.json.example and add a note in the README regarding the ironic nodes names format.

Fixes #593