### PR TITLE
Ensure IPA images are up to date

### DIFF
--- a/get_images.sh
+++ b/get_images.sh
@@ -9,8 +9,15 @@ if [ ! -f "${RHCOS_IMAGE_FILENAME_OPENSTACK}" ]; then
     curl --insecure --compressed -L -o "${RHCOS_IMAGE_FILENAME_OPENSTACK}" "${RHCOS_IMAGE_URL}/${RHCOS_IMAGE_FILENAME_OPENSTACK}"
 fi
 
-if [ ! -f ironic-python-agent.initramfs ]; then
-    curl --insecure --compressed -L https://images.rdoproject.org/master/rdo_trunk/current-tripleo-rdo/ironic-python-agent.tar | tar -xf -
+initramfs="ironic-python-agent.initramfs"
+initramfs_min_date=$(date -d "June 4, 2019" +%s)
+initramfs_date=0
+if [ -f $initramfs ]; then
+  initramfs_date=$(date +%s -r ironic-python-agent.initramfs)
+fi
+
+if [ ! -f $initramfs ] || [ $initramfs_date -lt $initramfs_min_date ]; then
+    curl --insecure --compressed -L https://images.rdoproject.org/master/rdo_trunk/current-tripleo-rdo/ironic-python-agent.tar | tar --overwrite -xf -
 fi
 
 popd


### PR DESCRIPTION
The latest inspector image supports finding Ironic via mDNS, but this needs new IPA images.  We don't do any checks other than see if they exist; this change ensure they match a minimum supported time stamp.