### PR TITLE
Remove unused BMOPATH variable.

### DIFF
--- a/11_register_hosts.sh
+++ b/11_register_hosts.sh
@@ -8,9 +8,6 @@ source logging.sh
 
 eval "$(go env)"
 
-# Get the latest bits for baremetal-operator
-export BMOPATH="$GOPATH/src/github.com/metalkube/baremetal-operator"
-
 function list_masters() {
     cat $MASTER_NODES_FILE | \
         jq '.nodes[] | {


### PR DESCRIPTION
I saw this when searching for remaining "metalkube" references.  This
appears to be unused, so just drop it.