### PR TITLE
Initial support for RHEL8 as a dev environment.

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -13,9 +13,20 @@ fi
 # Update to latest packages first
 sudo yum -y update
 
+if grep -q "Red Hat Enterprise Linux release 8" /etc/redhat-release 2>/dev/null ; then
+    RHEL8="True"
+fi
+
 # Install EPEL required by some packages
 if [ ! -f /etc/yum.repos.d/epel.repo ] ; then
-    if grep -q "Red Hat Enterprise Linux" /etc/redhat-release ; then
+    if [ "${RHEL8}" = "True" ] ; then
+        # TODO(russellb) Fix this when EPEL 8 is available
+        # sudo dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+        #
+        # It's also possible we never need EPEL and everything we would have pulled from there is
+        # available through OSP, instead.  There's no OSP release for RHEL 8 yet either, though.
+        :
+    elif grep -q "Red Hat Enterprise Linux" /etc/redhat-release ; then
         sudo yum -y install http://mirror.centos.org/centos/7/extras/x86_64/Packages/epel-release-7-11.noarch.rpm
     else
         sudo yum -y install epel-release --enablerepo=extras
@@ -24,8 +35,30 @@ fi
 
 # Install required packages
 # python-{requests,setuptools} required for tripleo-repos install
+if [ "${RHEL8}" = "True" ] ; then
+    sudo dnf install -y \
+        python36 \
+        python3-requests \
+        python3-setuptools
+    sudo alternatives --set python /usr/bin/python3
+
+    # TODO(russellb) - Install an rpm for this once OSP for RHEL8 is out
+    pushd ~
+    if [ ! -d crudini ] ; then
+        git clone https://github.com/pixelb/crudini
+    fi
+    pushd crudini
+    git pull -r
+    sudo pip3 install .
+    popd ; popd
+else
+    sudo yum -y install \
+        crudini \
+        python-pip \
+        python-requests \
+        python-setuptools
+fi
 sudo yum -y install \
-  crudini \
   curl \
   dnsmasq \
   golang \
@@ -33,55 +66,100 @@ sudo yum -y install \
   nmap \
   patch \
   psmisc \
-  python-pip \
-  python-requests \
-  python-setuptools \
   vim-enhanced \
   wget
 
-# We're reusing some tripleo pieces for this setup so clone them here
-cd
-if [ ! -d tripleo-repos ]; then
-  git clone https://git.openstack.org/openstack/tripleo-repos
+if [ "${RHEL8}" = "True" ] ; then
+    sudo subscription-manager repos --enable=ansible-2-for-rhel-8-x86_64-rpms
+
+    # make sure additional requirments are installed
+    sudo yum -y install \
+      ansible \
+      python3-netaddr \
+      redhat-lsb-core \
+      bind-utils \
+      jq \
+      libvirt \
+      libvirt-devel \
+      libvirt-daemon-kvm \
+      podman \
+      qemu-kvm \
+      virt-install \
+      unzip \
+      network-scripts \
+      ipmitool
+
+    sudo pip3 install yq
+
+    # TODO(russellb) - Install an rpm for this once OSP for RHEL8 is out
+    pushd ~
+    if [ ! -d virtualbmc ] ; then
+        git clone https://git.openstack.org/openstack/virtualbmc
+    fi
+    pushd virtualbmc
+    git pull -r
+    sudo pip3 install .
+    curl 'https://review.rdoproject.org/r/gitweb?p=openstack/virtualbmc-distgit.git;a=blob_plain;f=virtualbmc.service;hb=HEAD' > virtualbmc.service
+    sudo mv virtualbmc.service /etc/systemd/system/.
+    sudo systemctl daemon-reload
+    popd ; popd
+
+    # TODO(russellb) - Install an rpm for this once OSP for RHEL8 is out
+    sudo dnf groupinstall -y "Development Tools"
+    sudo dnf install -y python36-devel
+    pushd ~
+    if [ ! -d openstackclient ] ; then
+        git clone https://git.openstack.org/openstack/openstackclient
+    fi
+    pushd openstackclient
+    git pull -r
+    sudo pip3 install .
+    popd ; popd
+else
+    # We're reusing some tripleo pieces for this setup so clone them here
+    cd
+    if [ ! -d tripleo-repos ]; then
+      git clone https://git.openstack.org/openstack/tripleo-repos
+    fi
+    pushd tripleo-repos
+    sudo python setup.py install
+    popd
+
+    # Needed to get a recent python-virtualbmc package
+    sudo tripleo-repos current-tripleo
+
+    # There are some packages which are newer in the tripleo repos
+    sudo yum -y update
+
+    # Setup yarn and nodejs repositories
+    sudo curl -sL https://dl.yarnpkg.com/rpm/yarn.repo -o /etc/yum.repos.d/yarn.repo
+    curl -sL https://rpm.nodesource.com/setup_10.x | sudo bash -
+
+    # make sure additional requirments are installed
+    sudo yum -y install \
+      ansible \
+      bind-utils \
+      jq \
+      libvirt \
+      libvirt-devel \
+      libvirt-daemon-kvm \
+      nodejs \
+      podman \
+      python-ironicclient \
+      python-ironic-inspector-client \
+      python-lxml \
+      python-netaddr \
+      python-openstackclient \
+      python-virtualbmc \
+      qemu-kvm \
+      virt-install \
+      unzip \
+      yarn
+
+    # Install python packages not included as rpms
+    sudo pip install \
+      yq
 fi
-pushd tripleo-repos
-sudo python setup.py install
-popd
-
-# Needed to get a recent python-virtualbmc package
-sudo tripleo-repos current-tripleo
-
-# There are some packages which are newer in the tripleo repos
-sudo yum -y update
-
-# Setup yarn and nodejs repositories
-sudo curl -sL https://dl.yarnpkg.com/rpm/yarn.repo -o /etc/yum.repos.d/yarn.repo
-curl -sL https://rpm.nodesource.com/setup_10.x | sudo bash -
-
-# make sure additional requirments are installed
-sudo yum -y install \
-  ansible \
-  bind-utils \
-  jq \
-  libvirt \
-  libvirt-devel \
-  libvirt-daemon-kvm \
-  nodejs \
-  podman \
-  python-ironicclient \
-  python-ironic-inspector-client \
-  python-lxml \
-  python-netaddr \
-  python-openstackclient \
-  python-virtualbmc \
-  qemu-kvm \
-  virt-install \
-  unzip \
-  yarn
-
-# Install python packages not included as rpms
-sudo pip install \
-  yq
 
 # Install oc client
 oc_version=4.2

--- a/common.sh
+++ b/common.sh
@@ -84,9 +84,14 @@ if [[ ! $(awk -F= '/^ID=/ { print $2 }' /etc/os-release | tr -d '"') =~ ^(centos
 fi
 
 # Check CentOS version
-if [[ $(awk -F= '/^VERSION_ID=/ { print $2 }' /etc/os-release | tr -d '"' | cut -f1 -d'.') -ne 7 ]]; then
-  echo "Required CentOS 7 or RHEL 7"
+VER=$(awk -F= '/^VERSION_ID=/ { print $2 }' /etc/os-release | tr -d '"' | cut -f1 -d'.')
+if [[ ${VER} -ne 7 ]] && [[ ${VER} -ne 8 ]]; then
+  echo "Required CentOS 7 / RHEL 7 / RHEL 8"
   exit 1
+fi
+
+if grep -q "Red Hat Enterprise Linux release 8" /etc/redhat-release 2>/dev/null ; then
+    export RHEL8="True"
 fi
 
 # Check d_type support


### PR DESCRIPTION
This PR and https://github.com/metal3-io/metal3-dev-env/pull/19 contain the changes I needed to make to get dev-scripts to run on top of RHEL8.  The types of changes include:

* A number of package names are different, mostly Python related.

* A number of packages aren't available.  There's no EPEL for RHEL8 and there's also not an OSP version we can subscribe to.  This isn't a big deal.  We install a few things from source until we can pull them from OSP, and none of these things are ones that would be needed on a production environment anyway.

* The firewall setup didn't work for me.  I found it easiest to fix it using firewalld.  I suspect this has to do with changes in behavior since RHEL8 uses nftables instead of iptables.  firewalld seems like a much nicer way to manage these rules anyway, even for the CentOS 7 environment, so I suggest we move everything to firewalld over time.

I have one remaining quirk that i haven't fixed.  I have to manually kill some `vbmc` processes after running `make clean` before running `make` again.  Otherwise, the cluster does come up successfully.

```sh
$ oc get nodes
NAME       STATUS   ROLES    AGE   VERSION
master-0   Ready    master   30m   v1.13.4+cb455d664
master-1   Ready    master   30m   v1.13.4+cb455d664
master-2   Ready    master   30m   v1.13.4+cb455d664
worker-0   Ready    worker   63s   v1.13.4+cb455d664
```