### PR TITLE
[WIP] Generate clouds.yaml for ironic and ironic-inspector and document it

### DIFF
--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -78,3 +78,12 @@ sudo podman run -d --net host --privileged --name ironic --pod ironic-pod \
 # Start Ironic Inspector 
 sudo podman run -d --net host --privileged --name ironic-inspector \
      --pod ironic-pod -v $IRONIC_DATA_DIR:/shared "${IRONIC_INSPECTOR_IMAGE}"
+
+sudo mkdir -p /etc/openstack
+sudo cat > /etc/openstack/clouds.yaml <<EOF
+clouds:
+  metal3:
+    auth_type: none
+    baremetal_endpoint_override: http://127.0.0.1:6385
+    baremetal_introspection_endpoint_override: http://127.0.0.1:5050
+EOF

--- a/README.md
+++ b/README.md
@@ -113,9 +113,9 @@ master-2   Ready     master    20m       v1.12.4+50c2f2340a
 For manual debugging via openstackclient, you can use the following:
 
 ```
-export OS_TOKEN=fake-token
-export OS_URL=http://localhost:6385/
+export OS_CLOUD=metal3
 openstack baremetal node list
+openstack baremetal introspection list
 ...
 ```
 


### PR DESCRIPTION
The main benefit is that we'll be able to use ironic and ironic-inspector
simultaneously, without redefining OS_URL each time.

To actually work we need the following patches merged and released:
osc-lib: https://review.opendev.org/#/c/664830/
ironic-inspector-client: https://review.opendev.org/#/c/664835/
