### PR TITLE
cleanup leaked bootstrap VM/volume after failure

### DIFF
--- a/ocp_cleanup.sh
+++ b/ocp_cleanup.sh
@@ -28,3 +28,10 @@ fi
 if test -f assets/templates/99_worker-chronyd-redhat.yaml ; then
     rm -f assets/templates/99_worker-chronyd-redhat.yaml
 fi
+
+# If the installer fails before terraform completes the destroy bootstrap
+# cleanup doesn't clean up the VM/volumes created..
+for vm in $(sudo virsh list --all --name | grep "^${CLUSTER_NAME}.*bootstrap"); do
+  sudo virsh destroy $vm
+  sudo virsh undefine $vm --remove-all-storage
+done


### PR DESCRIPTION
Reviving the PR initially pushed via #309 because I now see that
we leak bootstrap VMs/volumes when kni-installer fails while running
terraform.

This appears to be a limitation and/or design flaw with terraform as
it's not persisting state of created resources when exiting due to errors.

This is inconvenient when developing changes to the installer and/or
terraform pieces, so lets do some automated cleanup here.

Co-Authored-By: Alexander Chuzhoy achuzhoy@redhat.com