### PR TITLE
keepalived - extract the interface name only once

### DIFF
--- a/assets/files/etc/kubernetes/manifests/keepalived.yaml
+++ b/assets/files/etc/kubernetes/manifests/keepalived.yaml
@@ -53,7 +53,7 @@ spec:
       IFACE_CIDRS="$(ip addr show | grep -v "scope host" | grep -Po 'inet \K[\d.]+/[\d.]+' | xargs)"
       SUBNET_CIDR="$(/usr/local/bin/get_vip_subnet_cidr "$API_VIP" "$IFACE_CIDRS")"
       NET_MASK="$(echo $SUBNET_CIDR | cut -d "/" -f 2)"
-      INTERFACE="$(ip -o addr show to "$SUBNET_CIDR" | awk '{print $2}')"
+      INTERFACE="$(ip -o addr show to "$SUBNET_CIDR" | awk '{print $2;exit}')"
       DNS_VIP="$(dig +noall +answer "ns1.${DOMAIN}" | awk '{print $NF}')"
       INGRESS_VIP="$(dig +noall +answer "test.apps.${DOMAIN}" | awk '{print $NF}')"
 


### PR DESCRIPTION
In case the os has 2 interfaces, keepalived.conf would be rendered incorrectly because `INTERFACE` 
will contain 2 lines with the same name:
```
[root@dhcp-0-215 ~]# ip -o addr show to 10.35.0.0/23
2: ens3    inet 10.35.1.99/23 brd 10.35.1.255 scope global dynamic noprefixroute ens3\       valid_lft 86118sec preferred_lft 86118sec
2: ens3    inet 10.35.0.215/23 brd 10.35.1.255 scope global secondary dynamic noprefixroute ens3\       valid_lft 1700sec preferred_lft 1700sec
[root@dhcp-0-215 ~]# ip -o addr show to 10.35.0.0/23 | awk '{print $2}'
ens3
ens3
```

This fix would extract `ens3` even if we have 2 addresses on the same interface 

Review: @celebdor @yboaronn 

Related to:  https://github.com/openshift-metal3/dev-scripts/issues/512