### PR TITLE
Reinstate mkdir for IRONIC_DATA_DIR

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -117,7 +117,13 @@ fi
 if [ ! -d "$WORKING_DIR" ]; then
   echo "Creating Working Dir"
   sudo mkdir "$WORKING_DIR"
+  sudo chown "${USER}:${USER}" "$WORKING_DIR"
+  chmod 755 "$WORKING_DIR"
 fi
-sudo chown "${USER}:${USER}" "$WORKING_DIR"
-chmod 755 "$WORKING_DIR"
 
+if [ ! -d "$IRONIC_DATA_DIR" ]; then
+  echo "Creating Ironic Data Dir"
+  sudo mkdir "$IRONIC_DATA_DIR"
+  sudo chown "${USER}:${USER}" "$IRONIC_DATA_DIR"
+  chmod 755 "$IRONIC_DATA_DIR"
+fi


### PR DESCRIPTION
In #564 we removed the mkdir like:

$ git show cdff373 | grep mkdir
-mkdir -p "$IRONIC_DATA_DIR/html/images"

But we still need IRONIC_DATA_DIR to exist, e.g to bind into the containers

We didn't catch this in CI or local testing because the images dir is cached.