### PR TITLE
Add sanity check to vip-prepender

### DIFF
--- a/assets/files/etc/NetworkManager/dispatcher.d/pre-up.d/dns-vip-prepender
+++ b/assets/files/etc/NetworkManager/dispatcher.d/pre-up.d/dns-vip-prepender
@@ -26,6 +26,11 @@ case "$STATUS" in
 
             logger -s "NM dns-vip-prepender: Looking for 'search $CLUSTER_DOMAIN' in /etc/resolv.conf to place 'nameserver $DNS_VIP'"
             sed -i "/^search .*$/a nameserver $DNS_VIP" /etc/resolv.conf
+            logger -s -f /etc/resolv.conf
+            if ! grep -q $DNS_VIP /etc/resolv.conf; then
+                logger -s "NM dns-vip-prepender: Failed to add DNS VIP to resolv.conf"
+                exit 1
+            fi
         fi
     fi
     ;;

--- a/assets/files/etc/NetworkManager/dispatcher.d/pre-up.d/dns-vip-prepender-worker
+++ b/assets/files/etc/NetworkManager/dispatcher.d/pre-up.d/dns-vip-prepender-worker
@@ -22,6 +22,11 @@ case "$STATUS" in
 
             logger -s "NM dns-vip-prepender-worker: Looking for 'search $CLUSTER_DOMAIN' in /etc/resolv.conf to place 'nameserver $DNS_VIP'"
             sed -i "/^search .*$/a nameserver $DNS_VIP" /etc/resolv.conf
+            logger -s -f /etc/resolv.conf
+            if ! grep -q $DNS_VIP /etc/resolv.conf; then
+                logger -s "NM dns-vip-prepender-worker: Failed to add DNS VIP to resolv.conf"
+                exit 1
+            fi
         fi
     fi
     ;;


### PR DESCRIPTION
We recently had a deployment where the DNS VIP was not properly added
to resolv.conf. There isn't enough detail in the logs from the script
to determine what went wrong, so this change adds some more logging
and a sanity check that we actually did the thing we were trying to do.