### PR TITLE
fix bash pushd requires argument

### DIFF
--- a/run_ci.sh
+++ b/run_ci.sh
@@ -121,7 +121,7 @@ for PROJ in facet kni-installer ; do
       GITHUB_ORGANIZATION=openshift-metalkube
 
       # Run some of openshift CI checks
-      pushd
+      pushd .
       cd $PROJ
       ./hack/go-fmt.sh
       ./hack/go-lint.sh


### PR DESCRIPTION
bash's pushd built-in requires an argument.

On http://10.8.144.11:8080/job/dev-tools/798/console:
```
+ pushd
./run_ci.sh: line 124: pushd: no other directory
```

