### PR TITLE
Ensure redhat-lsb-core is installed

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -152,6 +152,7 @@ else
       python-openstackclient \
       python-virtualbmc \
       qemu-kvm \
+      redhat-lsb-core \
       virt-install \
       unzip \
       yarn


### PR DESCRIPTION
Without lsb_release installed, I was getting:

  error while evaluating conditional (ansible_os_family == \"RedHat\"
  and ansible_lsb.major_release|int == 7): 'dict object' has no
  attribute 'major_release'

Introduced by RHEL8 support in commit c416cd1d