### PR TITLE
Use 4.2.0-0.ci-2019-06-19-140700-kni.3 release image

### DIFF
--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -14,7 +14,7 @@ export EXTERNAL_SUBNET="192.168.111.0/24"
 # The release we default to here is pinned and known to work with our current
 # version of kni-installer.
 #
-export OPENSHIFT_RELEASE_IMAGE="${OPENSHIFT_RELEASE_IMAGE:-registry.svc.ci.openshift.org/kni/release:4.2.0-0.ci-2019-06-19-140700-kni.2}"
+export OPENSHIFT_RELEASE_IMAGE="${OPENSHIFT_RELEASE_IMAGE:-registry.svc.ci.openshift.org/kni/release:4.2.0-0.ci-2019-06-19-140700-kni.3}"
 
 function extract_installer() {
     local release_image


### PR DESCRIPTION
This image uses the openshift-metal3 quay org for the coredns-mdns
container.

See: https://github.com/openshift-metal3/kni-installer/pull/134