### PR TITLE
make-bm-worker: Include consumer kind/version

### DIFF
--- a/11_register_hosts.sh
+++ b/11_register_hosts.sh
@@ -32,15 +32,15 @@ function make_bm_masters() {
            -address "$address" \
            -password "$password" \
            -user "$user" \
-           -consumer-namespace openshift-machine-api \
-           -consumer  "$(echo $name | sed s/openshift/${CLUSTER_NAME}/)" \
+           -machine-namespace openshift-machine-api \
+           -machine  "$(echo $name | sed s/openshift/${CLUSTER_NAME}/)" \
            -boot-mac "$mac" \
            "$name"
     done
 }
 
 function list_workers() {
-    # Includes -consumer and -consumer-namespace
+    # Includes -machine and -machine-namespace
     cat $NODES_FILE | \
         jq '.nodes[] | select(.name | contains("worker")) | {
            name,
@@ -60,7 +60,7 @@ function list_workers() {
 # Register the workers without a consumer reference so they are
 # available for provisioning.
 function make_bm_workers() {
-    # Does not include -consumer or -consumer-namespace
+    # Does not include -machine or -machine-namespace
     while read name address user password mac; do
         go run $SCRIPTDIR/make-bm-worker/main.go \
            -address "$address" \

--- a/make-bm-worker/main.go
+++ b/make-bm-worker/main.go
@@ -43,25 +43,27 @@ spec:
   image:
     url: "{{ .ImageSourceURL }}"
     checksum: "{{ .Checksum }}"
-{{ end -}}{{ if .Consumer }}
+{{ end -}}{{ if .Machine }}
   consumerRef:
-    name: {{ .Consumer }}
-    namespace: {{ .ConsumerNamespace }}
+    name: {{ .Machine }}
+    kind: Machine
+    apiVersion: machine.openshift.io/v1beta1
+    namespace: {{ .MachineNamespace }}
 {{ end }}
 `
 
 // TemplateArgs holds the arguments to pass to the template.
 type TemplateArgs struct {
-	Name              string
-	BMCAddress        string
-	MAC               string
-	EncodedUsername   string
-	EncodedPassword   string
-	WithImage         bool
-	Checksum          string
-	ImageSourceURL    string
-	Consumer          string
-	ConsumerNamespace string
+	Name             string
+	BMCAddress       string
+	MAC              string
+	EncodedUsername  string
+	EncodedPassword  string
+	WithImage        bool
+	Checksum         string
+	ImageSourceURL   string
+	Machine          string
+	MachineNamespace string
 }
 
 func encodeToSecret(input string) string {
@@ -74,10 +76,10 @@ func main() {
 	var bmcAddress = flag.String("address", "", "address URL for BMC")
 	var verbose = flag.Bool("v", false, "turn on verbose output")
 	var withImage = flag.Bool("image", false, "include the image settings to trigger deployment")
-	var consumer = flag.String(
-		"consumer", "", "specify name of a related, existing, consumer to link")
-	var consumerNamespace = flag.String(
-		"consumer-namespace", "", "specify namespace of a related, existing, consumer to link")
+	var machine = flag.String(
+		"machine", "", "specify name of a related, existing, Machine to link")
+	var machineNamespace = flag.String(
+		"machine-namespace", "", "specify namespace of a related, existing, Machine to link")
 	var bootMAC = flag.String(
 		"boot-mac", "", "specify boot MAC address of host")
 
@@ -102,16 +104,16 @@ func main() {
 	}
 
 	args := TemplateArgs{
-		Name:              strings.Replace(hostName, "_", "-", -1),
-		BMCAddress:        *bmcAddress,
-		MAC:               *bootMAC,
-		EncodedUsername:   encodeToSecret(*username),
-		EncodedPassword:   encodeToSecret(*password),
-		WithImage:         *withImage,
-		Checksum:          instanceImageChecksumURL,
-		ImageSourceURL:    instanceImageSource,
-		Consumer:          strings.TrimSpace(*consumer),
-		ConsumerNamespace: strings.TrimSpace(*consumerNamespace),
+		Name:             strings.Replace(hostName, "_", "-", -1),
+		BMCAddress:       *bmcAddress,
+		MAC:              *bootMAC,
+		EncodedUsername:  encodeToSecret(*username),
+		EncodedPassword:  encodeToSecret(*password),
+		WithImage:        *withImage,
+		Checksum:         instanceImageChecksumURL,
+		ImageSourceURL:   instanceImageSource,
+		Machine:          strings.TrimSpace(*machine),
+		MachineNamespace: strings.TrimSpace(*machineNamespace),
 	}
 	if *verbose {
 		fmt.Fprintf(os.Stderr, "%v", args)


### PR DESCRIPTION
The consumerRef should include not only the name of the consumer, but
also it's Kind and apiVersion.

Since in practice this script is used only for referencing
machine.openshift.io/v1beta1 Machine objects, just hard-code this and
revert the change of argument names from machine to consumer.