### PR TITLE
Remove apiVIP from install-config.yaml

### DIFF
--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -74,7 +74,6 @@ controlPlane:
     baremetal: {}
 platform:
   baremetal:
-    api_vip: ${API_VIP}
     hosts:
 $(master_node_map_to_install_config $NUM_MASTERS)
     image:


### PR DESCRIPTION
The installer is capable of looking up this info from DNS itself. I've
left the $API_VIP env variable declarations in place as they do seem
used in some of the template generation.