### PR TITLE
Allow the Hardware profile for master nodes to be configured

### DIFF
--- a/utils.sh
+++ b/utils.sh
@@ -147,7 +147,7 @@ function master_node_map_to_install_config() {
           username: ${username}
           password: ${password}
         bootMACAddress: ${mac}
-        hardwareProfile: default
+        hardwareProfile: ${MASTER_HARDWARE_PROFILE:-default}
 EOF
 
     done


### PR DESCRIPTION
Hardcoding to default doesn't work in BM nodes where /dev/sda
doesn't work.