### PR TITLE
Fix issues with additional slash in OS_URL

### DIFF
--- a/06_create_cluster.sh
+++ b/06_create_cluster.sh
@@ -53,7 +53,7 @@ fi
 
 # Make sure Ironic is up
 export OS_TOKEN=fake-token
-export OS_URL=http://localhost:6385/
+export OS_URL=http://localhost:6385
 
 wait_for_json ironic \
     "${OS_URL}/v1/nodes" \


### PR DESCRIPTION
some users reported issues with step06 because of an extra slash in the OS_URL

```

curl -g -X GET http://localhost:6385//v1/nodes '-H Accept: application/json -H Content-Type: application/json -H User-Agent: wait-for-json -H X-Auth-Token: fake-token'| jq .
 
{
  "error_message": "{\"debuginfo\": null, \"faultcode\": \"Client\", \"faultstring\": \"Invalid input for field/attribute chassis_uuid. Value: ''. unable to convert to uuid. Error: Expected a UUID but received .\"}"
}
 
curl -g -X GET http://localhost:6385/v1/nodes '-H Accept: application/json -H Content-Type: application/json -H User-Agent: wait-for-json -H X-Auth-Token: fake-token'| jq .
{
  "nodes": [
    {
      "instance_uuid": null,
      "uuid": "6b827bbe-4d87-4c0d-9698-019b9868d0d2",
      "links": [
        {
          "href": "http://localhost:6385/v1/nodes/6b827bbe-4d87-4c0d-9698-019b9868d0d2",
          "rel": "self"
        },
        {
          "href": "http://localhost:6385/nodes/6b827bbe-4d87-4c0d-9698-019b9868d0d2",
          "rel": "bookmark"
        }
      ],
      "maintenance": false,
      "provision_state": "inspecting",
      "power_state": "power
```