### PR TITLE
add externally provisioned flag when registering masters

### DIFF
--- a/11_register_hosts.sh
+++ b/11_register_hosts.sh
@@ -35,6 +35,7 @@ function make_bm_masters() {
            -machine-namespace openshift-machine-api \
            -machine  "$(echo $name | sed s/openshift/${CLUSTER_NAME}/)" \
            -boot-mac "$mac" \
+           -externally-provisioned \
            "$name"
     done
 }

--- a/make-bm-worker/main.go
+++ b/make-bm-worker/main.go
@@ -49,21 +49,24 @@ spec:
     kind: Machine
     apiVersion: machine.openshift.io/v1beta1
     namespace: {{ .MachineNamespace }}
-{{ end }}
+{{ end }}{{ if .ExternallyProvisioned }}
+  externallyProvisioned: true
+{{ end}}
 `
 
 // TemplateArgs holds the arguments to pass to the template.
 type TemplateArgs struct {
-	Name             string
-	BMCAddress       string
-	MAC              string
-	EncodedUsername  string
-	EncodedPassword  string
-	WithImage        bool
-	Checksum         string
-	ImageSourceURL   string
-	Machine          string
-	MachineNamespace string
+	Name                  string
+	BMCAddress            string
+	MAC                   string
+	EncodedUsername       string
+	EncodedPassword       string
+	WithImage             bool
+	Checksum              string
+	ImageSourceURL        string
+	Machine               string
+	MachineNamespace      string
+	ExternallyProvisioned bool
 }
 
 func encodeToSecret(input string) string {
@@ -82,6 +85,8 @@ func main() {
 		"machine-namespace", "", "specify namespace of a related, existing, Machine to link")
 	var bootMAC = flag.String(
 		"boot-mac", "", "specify boot MAC address of host")
+	var externallyProvisioned = flag.Bool("externally-provisioned", false,
+		"the host was externally provisioned (typically a master node)")
 
 	flag.Parse()
 
@@ -104,16 +109,17 @@ func main() {
 	}
 
 	args := TemplateArgs{
-		Name:             strings.Replace(hostName, "_", "-", -1),
-		BMCAddress:       *bmcAddress,
-		MAC:              *bootMAC,
-		EncodedUsername:  encodeToSecret(*username),
-		EncodedPassword:  encodeToSecret(*password),
-		WithImage:        *withImage,
-		Checksum:         instanceImageChecksumURL,
-		ImageSourceURL:   instanceImageSource,
-		Machine:          strings.TrimSpace(*machine),
-		MachineNamespace: strings.TrimSpace(*machineNamespace),
+		Name:                  strings.Replace(hostName, "_", "-", -1),
+		BMCAddress:            *bmcAddress,
+		MAC:                   *bootMAC,
+		EncodedUsername:       encodeToSecret(*username),
+		EncodedPassword:       encodeToSecret(*password),
+		WithImage:             *withImage,
+		Checksum:              instanceImageChecksumURL,
+		ImageSourceURL:        instanceImageSource,
+		Machine:               strings.TrimSpace(*machine),
+		MachineNamespace:      strings.TrimSpace(*machineNamespace),
+		ExternallyProvisioned: *externallyProvisioned,
 	}
 	if *verbose {
 		fmt.Fprintf(os.Stderr, "%v", args)


### PR DESCRIPTION
The host object API has changed to require a flag to explicitly mark hosts
as being externally provisioned. This change updates the command line tool
we use to register masters to add the flag.

Depends on https://github.com/metal3-io/baremetal-operator/pull/255