### PR TITLE
Add dnsVIP to install-config

### DIFF
--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -7,6 +7,7 @@ export CLUSTER_NAME=${CLUSTER_NAME:-ostest}
 export CLUSTER_DOMAIN="${CLUSTER_NAME}.${BASE_DOMAIN}"
 export SSH_PUB_KEY="${SSH_PUB_KEY:-$(cat $HOME/.ssh/id_rsa.pub)}"
 export EXTERNAL_SUBNET="192.168.111.0/24"
+export DNS_VIP=${DNS_VIP:-"192.168.111.2"}
 
 #
 # See https://origin-release.svc.ci.openshift.org/ for release details
@@ -74,6 +75,7 @@ controlPlane:
     baremetal: {}
 platform:
   baremetal:
+    dnsVIP: ${DNS_VIP}
     hosts:
 $(master_node_map_to_install_config $NUM_MASTERS)
     image:


### PR DESCRIPTION
In order to generate the configuration for keepalived and coredns
(see keepalived.sh and coredns.sh) we currently determine the
DNS VIP that has been configured by querying the
ns1.$cluster_name.$base_domain record. This implies that users
must configure this record before beginning installation. In order to
reduce the pre-installation configuration requirements, we can
instead require the cluster administrator to provide the DNS VIP
as part of the configuration supplied in install-config.

Before proposing a change to the installer to support the DNS
VIP configuration, add it here to the install-config we generate,
so that the installer change can be tested.