### PR TITLE
Use openshift-install instead of kni-install

### DIFF
--- a/06_create_cluster.sh
+++ b/06_create_cluster.sh
@@ -69,11 +69,9 @@ fi
 # https://github.com/openshift-metalkube/dev-scripts/issues/260
 sudo systemd-run --on-active=30s --on-unit-active=1m --unit=fix_certs.service $(dirname $0)/fix_certs.sh
 
-# Call kni-installer to deploy the bootstrap node and masters
+# Call openshift-installer to deploy the bootstrap node and masters
 create_cluster ocp
 
-# TODO: remove this once the early exit is dropped from the installer
-wait_for_cvo_finish ocp
 echo "Cluster up, you can interact with it via oc --config ${KUBECONFIG} <command>"
 
 # The deployment is complete, but we must manually add the IPs for the masters,

--- a/README.md
+++ b/README.md
@@ -12,11 +12,7 @@ installer needs to do for bare metal provisioning. As that logic is ironed out,
 we are moving it into the [facet wrapper
 API](https://github.com/openshift-metalkube/facet/tree/master/pkg/server), or
 the [go-based
-kni-installer](https://github.com/openshift-metalkube/kni-installer).
-Eventually that kni-installer fork of
-[openshift-installer](https://github.com/openshift/installer) will be merged
-back, and we won't need much or any of this. For now, these tools are the
-canonical way to set up a metalkube cluster.
+openshift-installer](https://github.com/openshift/installer).
 
 # Pre-requisites
 

--- a/docs/developing-installer.md
+++ b/docs/developing-installer.md
@@ -1,8 +1,8 @@
-# Developing kni-installer
+# Developing openshift-install
 
 In the normal workflow, dev-scripts extracts the installer binary out of
 a [release image](release-payload.md).  If you would like to develop and
-test changes to kni-install locally, set the `KNI_INSTALL_FROM_GIT`
+test changes to openshift-install locally, set the `KNI_INSTALL_FROM_GIT`
 environment variable:
 
 ```console
@@ -10,7 +10,7 @@ $ KNI_INSTALL_FROM_GIT=true make
 ```
 
 If you have a copy of the installer already in
-`$GOPATH/src/github.com/openshift-metalkube/kni-installer`, it will build
+`$GOPATH/src/github.com/openshift/installer`, it will build
 on whatever branch you currently have checked out. If there is not
 already a checkout of the installer, it will clone the repo from GitHub
 and build from the master branch.

--- a/docs/release-payload.md
+++ b/docs/release-payload.md
@@ -68,7 +68,7 @@ RELEASE_STREAM=release
 INSTALLER_STREAM=installer
 RELEASE_KUBECONFIG=release-kubeconfig
 RELEASE_PULLSECRET=release-pullsecret
-INSTALLER_GIT_URI=https://github.com/openshift-metal3/kni-installer.git
+INSTALLER_GIT_URI=https://github.com/openshift/installer.git
 INSTALLER_GIT_REF=master
 EOF
 ```
@@ -76,25 +76,16 @@ EOF
 ## Building an Installer and Payload
 
 When we want to move to a newer OpenShift release, we pick a release
-payload:
+payload, and then build an installer image with the baremetal platform
+enabled:
 
 ```
 $ oc adm release info quay.io/openshift-release-dev/ocp-release:4.1.0-rc.3 -a release-pullsecret -o json | jq -r .metadata.version
 4.1.0-rc.3
 ```
 
-Next, rebase ```openshift-metal3/kni-installer``` to the
-```openshift/installer``` commit referenced by that payload:
-
-```
-$ oc adm release info -a release-pullsecret -o json \
-    quay.io/openshift-release-dev/ocp-release:4.1.0-rc.3 | \
-    jq -r '.references.spec.tags[] | select(.name == "installer") | .annotations["io.openshift.build.commit.id"]'
-403a93d1f683384800597ac38e9c2fc0180b3a5d
-```
-
-And then kick off a build, with the resulting image tagged into the
-installer image stream using the supplied version as the tag:
+Kick off a build, with the resulting image tagged into the installer
+image stream using the supplied version as the tag:
 
 ```
 $ ./build_installer.sh 4.1.0-rc.3-kni.0

--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -1,6 +1,6 @@
 eval "$(go env)"
 
-export OPENSHIFT_INSTALL_PATH="$GOPATH/src/github.com/openshift-metalkube/kni-installer"
+export OPENSHIFT_INSTALL_PATH="$GOPATH/src/github.com/openshift/installer"
 export OPENSHIFT_INSTALL_DATA="$OPENSHIFT_INSTALL_PATH/data/data"
 export BASE_DOMAIN=${BASE_DOMAIN:-test.metalkube.org}
 export CLUSTER_NAME=${CLUSTER_NAME:-ostest}
@@ -12,10 +12,10 @@ export DNS_VIP=${DNS_VIP:-"192.168.111.2"}
 #
 # See https://origin-release.svc.ci.openshift.org/ for release details
 #
-# The release we default to here is pinned and known to work with our current
-# version of kni-installer.
+# The release we default to here is pinned and known to work with the
+# baremetal platform in openshift-installer
 #
-export OPENSHIFT_RELEASE_IMAGE="${OPENSHIFT_RELEASE_IMAGE:-registry.svc.ci.openshift.org/kni/release:4.2.0-0.nightly-2019-07-12-041904-kni.0}"
+export OPENSHIFT_RELEASE_IMAGE="${OPENSHIFT_RELEASE_IMAGE:-registry.svc.ci.openshift.org/kni/release:4.2.0-0.ci-2019-07-22-025130-kni.1}"
 
 function extract_installer() {
     local release_image
@@ -38,7 +38,7 @@ function extract_installer() {
 function clone_installer() {
   # Clone repo, if not already present
   if [[ ! -d $OPENSHIFT_INSTALL_PATH ]]; then
-    sync_repo_and_patch go/src/github.com/openshift-metalkube/kni-installer https://github.com/openshift-metalkube/kni-installer.git
+    sync_repo_and_patch go/src/github.com/openshift/installer https://github.com/openshift/installer.git
   fi
 }
 
@@ -49,7 +49,7 @@ function build_installer() {
   RELEASE_IMAGE="$OPENSHIFT_RELEASE_IMAGE" TAGS="libvirt baremetal" hack/build.sh
   popd
 
-  export OPENSHIFT_INSTALLER="$OPENSHIFT_INSTALL_PATH/bin/kni-install"
+  export OPENSHIFT_INSTALLER="$OPENSHIFT_INSTALL_PATH/bin/openshift-install"
 }
 
 function generate_ocp_install_config() {

--- a/release/build_installer.sh
+++ b/release/build_installer.sh
@@ -31,7 +31,7 @@ if [ -z "${INSTALLER_VERSION}" ]; then
     exit 1
 fi
 
-echo "Building kni-installer from ${INSTALLER_GIT_URI}:${INSTALLER_GIT_REF} to ${INSTALLER_STREAM}:${INSTALLER_VERSION}"
+echo "Building openshift-installer from ${INSTALLER_GIT_URI}:${INSTALLER_GIT_REF} to ${INSTALLER_STREAM}:${INSTALLER_VERSION}"
 
 # Check prerequisites
 if [ $(oc --config "${RELEASE_KUBECONFIG}" project -q) != "${RELEASE_NAMESPACE}" ]; then
@@ -48,7 +48,7 @@ oc --config "${RELEASE_KUBECONFIG}" apply -f - <<EOF
 apiVersion: build.openshift.io/v1
 kind: Build
 metadata:
-  name: kni-installer-${INSTALLER_VERSION}
+  name: openshift-installer-${INSTALLER_VERSION}
 spec:
   source:
     type: Git
@@ -66,13 +66,13 @@ spec:
       name: ${INSTALLER_STREAM}:${INSTALLER_VERSION}
 EOF
 
-BUILD_POD=$(oc --config "${RELEASE_KUBECONFIG}" get build "kni-installer-${INSTALLER_VERSION}" -o json | jq -r '.metadata.annotations["openshift.io/build.pod-name"]')
+BUILD_POD=$(oc --config "${RELEASE_KUBECONFIG}" get build "openshift-installer-${INSTALLER_VERSION}" -o json | jq -r '.metadata.annotations["openshift.io/build.pod-name"]')
 oc --config "${RELEASE_KUBECONFIG}" wait --for condition=Ready pod "${BUILD_POD}"
 oc --config "${RELEASE_KUBECONFIG}" logs -f "${BUILD_POD}"
 
-BUILD_PHASE=$(oc --config release-kubeconfig get build "kni-installer-${INSTALLER_VERSION}" -o json | jq -r .status.phase)
+BUILD_PHASE=$(oc --config release-kubeconfig get build "openshift-installer-${INSTALLER_VERSION}" -o json | jq -r .status.phase)
 if [ "${BUILD_PHASE}" = "Complete" ]; then
-    BUILD_OUTPUT=$(oc --config release-kubeconfig get build "kni-installer-${INSTALLER_VERSION}" -o json | jq -r .status.output.to.imageDigest)
+    BUILD_OUTPUT=$(oc --config release-kubeconfig get build "openshift-installer-${INSTALLER_VERSION}" -o json | jq -r .status.output.to.imageDigest)
     echo "Installer built to ${BUILD_OUTPUT}"
 else
     echo "Installer build failed? Build phase is ${BUILD_PHASE}"

--- a/release/release_config_example.sh
+++ b/release/release_config_example.sh
@@ -13,10 +13,10 @@ RELEASE_KUBECONFIG=release-kubeconfig
 # images referenced by the payload - are hosted
 RELEASE_PULLSECRET=release-pullsecret
 
-# The imagestream in $RELEASE_NAMESPACE where kni-installer will be
+# The imagestream in $RELEASE_NAMESPACE where openshift-installer will be
 # published to
 INSTALLER_STREAM=installer
 
-# The git repository and ref (e.g. branch) to build kni-installer from
-INSTALLER_GIT_URI=https://github.com/openshift-metalkube/kni-installer.git
+# The git repository and ref (e.g. branch) to build openshift-installer from
+INSTALLER_GIT_URI=https://github.com/openshift/installer.git
 INSTALLER_GIT_REF=master

--- a/run_ci.sh
+++ b/run_ci.sh
@@ -74,15 +74,15 @@ for FILE in $FILESTOCACHE ; do
     [ -f $FILECACHEDIR/$(basename $FILE) ] && sudo cp -p $FILECACHEDIR/$(basename $FILE) $FILE
 done
 
-sudo mkdir -p /opt/data/yumcache /opt/data/installer-cache /home/notstack/.cache/kni-install/libvirt
+sudo mkdir -p /opt/data/yumcache /opt/data/installer-cache /home/notstack/.cache/openshift-install/libvirt
 sudo chown -R notstack /opt/dev-scripts/ironic /opt/data/installer-cache /home/notstack/.cache
 
 # Make yum store its cache on /opt so packages don't need to be downloaded for each job
 sudo sed -i -e '/keepcache=0/d' /etc/yum.conf
 sudo mount -o bind /opt/data/yumcache /var/cache/yum
 
-# Mount the kni-installer cache directory so we don't download a RHCOS image for each run
-sudo mount -o bind /opt/data/installer-cache /home/notstack/.cache/kni-install/libvirt
+# Mount the openshift-installer cache directory so we don't download a RHCOS image for each run
+sudo mount -o bind /opt/data/installer-cache /home/notstack/.cache/openshift-install/libvirt
 
 # Clone the project being tested, "dev-scripts" will have been cloned in the jenkins
 # job definition, for all others we do it here
@@ -117,12 +117,12 @@ fi
 # Project-specific actions. If these directories exist in $HOME, move
 # them to the correct $GOPATH locations. If installer, run some of
 # their CI checks.
-for PROJ in facet kni-installer ; do
+for PROJ in facet installer ; do
     [ ! -d /home/notstack/$PROJ ] && continue
 
-    if [ "$PROJ" == "kni-installer" ]; then
+    if [ "$PROJ" == "installer" ]; then
       export KNI_INSTALL_FROM_GIT=true
-      GITHUB_ORGANIZATION=openshift-metalkube
+      GITHUB_ORGANIZATION=openshift
 
       # Run some of openshift CI checks
       pushd .

--- a/utils.sh
+++ b/utils.sh
@@ -53,13 +53,6 @@ function create_cluster() {
     $OPENSHIFT_INSTALLER --dir "${assets_dir}" --log-level=debug create cluster
 }
 
-function wait_for_cvo_finish() {
-    local assets_dir
-
-    assets_dir="$1"
-    $OPENSHIFT_INSTALLER --dir "${assets_dir}" --log-level=debug wait-for install-complete
-}
-
 function wait_for_json() {
     local name
     local url

--- a/vm_setup_vars.yml
+++ b/vm_setup_vars.yml
@@ -2,7 +2,7 @@
 # playbooks/roles, ref https://github.com/metal3-io/metal3-dev-env
 
 # Currently this is required because of hard-coded node-name expectations in the
-# kni-installer terraform templates
+# openshift-installer terraform templates
 ironic_prefix: "openshift_"
 
 # We enable more memory and masters in dev-scripts compared to the minimal setup


### PR DESCRIPTION
This moves dev-scripts to use openshift/installer instead of the kni-installer fork.  We need the remaining platform PR's to be merged, but they should be soon, just waiting on CI.

What's not clear to me is how we get the baremetal platform built for openshift-install going forward (@markmc - do you know what we need to do there?).   I'm assuming in this PR we continue for at least a little while building custom KNI release payloads with an openshift-install binary that has the baremetal platform built, but at last we can discontinue use of the fork and build our installer image out of the official repos.

