### PR TITLE
Install operator-sdk from a release build.

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -177,3 +177,9 @@ if [ ! -f ${oc_tools_dir}/${oc_tools_local_file} ] || [ $oc_date -lt 1559308936 
   tar xvzf ${oc_tools_local_file}
   sudo cp oc /usr/local/bin/
 fi
+
+# Install operator-sdk
+if ! which operator-sdk 2>&1 >/dev/null ; then
+    sudo wget https://github.com/operator-framework/operator-sdk/releases/download/v0.9.0/operator-sdk-v0.9.0-x86_64-linux-gnu -O /usr/local/bin/operator-sdk
+    sudo chmod 755 /usr/local/bin/operator-sdk
+fi

--- a/03_ocp_repo_sync.sh
+++ b/03_ocp_repo_sync.sh
@@ -25,14 +25,5 @@ mkdir -p $GOPATH/bin
 curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 export PATH="${GOPATH}/bin:$PATH"
 
-# Install operator-sdk for use by the baremetal-operator
-sync_repo_and_patch github.com/operator-framework/operator-sdk https://github.com/operator-framework/operator-sdk.git
-
-# Build operator-sdk
-pushd "${GOPATH}/src/github.com/operator-framework/operator-sdk"
-git checkout master
-make install
-popd
-
 # Install baremetal-operator
 sync_repo_and_patch github.com/metal3-io/baremetal-operator https://github.com/metal3-io/baremetal-operator.git


### PR DESCRIPTION
Building master operator-sdk requires go 1.12.  It's easier to just
download a release build to avoid a go version issue on some
platforms.

Closes #674