### PR TITLE
Changes to use Ironic Stein

### DIFF
--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -24,7 +24,7 @@ for IMAGE_VAR in IRONIC_IMAGE IRONIC_INSPECTOR_IMAGE IPA_DOWNLOADER_IMAGE COREOS
     fi
 done
 
-for name in ironic ironic-api ironic-conductor ironic-exporter ironic-inspector dnsmasq httpd mariadb ipa-downloader coreos-downloader; do
+for name in ironic ironic-api ironic-conductor ironic-inspector dnsmasq httpd mariadb ipa-downloader coreos-downloader; do
     sudo podman ps | grep -w "$name$" && sudo podman kill $name
     sudo podman ps --all | grep -w "$name$" && sudo podman rm $name -f
 done
@@ -60,10 +60,6 @@ sudo podman run -d --net host --privileged --name ironic-conductor --pod ironic-
 sudo podman run -d --net host --privileged --name ironic-api --pod ironic-pod \
      --env MARIADB_PASSWORD=$mariadb_password \
      --entrypoint /bin/runironic-api \
-     -v $IRONIC_DATA_DIR:/shared ${IRONIC_IMAGE}
-
-sudo podman run -d --net host --privileged --name ironic-exporter --pod ironic-pod \
-     --entrypoint /bin/runironic-exporter \
      -v $IRONIC_DATA_DIR:/shared ${IRONIC_IMAGE}
 
 sudo podman run -d --net host --privileged --name ipa-downloader --pod ironic-pod \

--- a/ironic_cleanup.sh
+++ b/ironic_cleanup.sh
@@ -5,7 +5,7 @@ source logging.sh
 source common.sh
 
 # Kill and remove the running ironic containers
-for name in ironic ironic-api ironic-conductor ironic-exporter ironic-inspector dnsmasq httpd mariadb; do
+for name in ironic ironic-api ironic-conductor ironic-inspector dnsmasq httpd mariadb; do
     sudo podman ps | grep -w "$name$" && sudo podman kill $name
     sudo podman ps --all | grep -w "$name$" && sudo podman rm $name -f
 done

--- a/operator_ironic.yaml
+++ b/operator_ironic.yaml
@@ -225,32 +225,6 @@ spec:
                 configMapKeyRef:
                   name: ironic-bmo-configmap
                   key: provisioning_interface
-        - name: ironic-exporter
-          image: quay.io/metal3-io/ironic:master
-          imagePullPolicy: Always
-          securityContext:
-            privileged: true
-          command:
-            - /bin/runironic-exporter
-          volumeMounts:
-            - mountPath: /shared
-              name: ironic-data-volume
-          env:
-            - name: MARIADB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: mariadb-password
-                  key: password
-            - name: HTTP_PORT
-              valueFrom:
-                configMapKeyRef:
-                  name: ironic-bmo-configmap
-                  key: http_port
-            - name: PROVISIONING_INTERFACE
-              valueFrom:
-                configMapKeyRef:
-                  name: ironic-bmo-configmap
-                  key: provisioning_interface
         - name: ironic-inspector
           image: quay.io/metal3-io/ironic-inspector:master
           imagePullPolicy: Always

--- a/run_ci.sh
+++ b/run_ci.sh
@@ -11,7 +11,6 @@ function getlogs(){
     # The logs shared by the ironic containers
     sudo cp -r /opt/dev-scripts/ironic/log $LOGDIR/container-logs
 
-    sudo podman logs ironic-exporter > $LOGDIR/ironic-exporter.log
     sudo podman logs coreos-downloader > $LOGDIR/coreos-downloader.log
     sudo podman logs ipa-downloader > $LOGDIR/ipa-downloader.log
 


### PR DESCRIPTION
This patch contains changes needed to be able to use Ironic Stein.

It has dependencies from other patches in other related repos
and they should all be merged at the same time, following the order below,
to guarantee a correct behavior.

Full patch set:
https://github.com/openshift-metal3/dev-scripts/pull/680
https://github.com/metal3-io/ironic-image/pull/79
https://github.com/metal3-io/ironic-inspector-image/pull/30
https://github.com/metal3-io/ironic-ipa-downloader/pull/3
