### PR TITLE
Move dep install to install script.

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -183,3 +183,12 @@ if ! which operator-sdk 2>&1 >/dev/null ; then
     sudo wget https://github.com/operator-framework/operator-sdk/releases/download/v0.9.0/operator-sdk-v0.9.0-x86_64-linux-gnu -O /usr/local/bin/operator-sdk
     sudo chmod 755 /usr/local/bin/operator-sdk
 fi
+
+# Install Go dependency management tool
+# Using pre-compiled binaries instead of installing from source
+eval "$(go env)"
+export PATH="${GOPATH}/bin:$PATH"
+if ! which dep 2>&1 >/dev/null ; then
+    mkdir -p $GOPATH/bin
+    curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+fi

--- a/03_ocp_repo_sync.sh
+++ b/03_ocp_repo_sync.sh
@@ -19,11 +19,5 @@ export REPO_PATH="$GOPATH/src"
 #./build.sh
 #popd
 
-# Install Go dependency management tool
-# Using pre-compiled binaries instead of installing from source
-mkdir -p $GOPATH/bin
-curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-export PATH="${GOPATH}/bin:$PATH"
-
 # Install baremetal-operator
 sync_repo_and_patch github.com/metal3-io/baremetal-operator https://github.com/metal3-io/baremetal-operator.git


### PR DESCRIPTION
The repo sync script installed dep.  Move it to the dependency
installation script instead.  Also don't bother if dep is already
installed.