### PR TITLE
Avoid multiple BOOTPROTO=dhcp in ifcfg-baremetal

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -106,7 +106,7 @@ if [ "$MANAGE_INT_BRIDGE" == "y" ]; then
     if [ "$INT_IF" ]; then
         echo -e "DEVICE=$INT_IF\nTYPE=Ethernet\nONBOOT=yes\nNM_CONTROLLED=no\nBRIDGE=baremetal" | sudo dd of=/etc/sysconfig/network-scripts/ifcfg-$INT_IF
         if sudo nmap --script broadcast-dhcp-discover -e $INT_IF | grep "IP Offered" ; then
-            echo -e "\nBOOTPROTO=dhcp\n" | sudo tee -a /etc/sysconfig/network-scripts/ifcfg-baremetal
+            echo -e "\nBOOTPROTO=dhcp\n" | sudo tee -a /etc/sysconfig/network-scripts/ifcfg-$INT_IF
             sudo systemctl restart network
         else
            sudo systemctl restart network


### PR DESCRIPTION
I've had issues running the 02 script as network service won't start:

```
Jul 23 10:11:30 kni1-bootstrap.cloud.lab.eng.bos.redhat.com network[10181]: Determining IP information for baremetal...dhclient(10102) is already running - exiting.
Jul 23 10:11:30 kni1-bootstrap.cloud.lab.eng.bos.redhat.com network[10181]: This version of ISC DHCP is based on the release available
Jul 23 10:11:30 kni1-bootstrap.cloud.lab.eng.bos.redhat.com network[10181]: on ftp.isc.org. Features have been added and other changes
Jul 23 10:11:30 kni1-bootstrap.cloud.lab.eng.bos.redhat.com network[10181]: have been made to the base software release in order to make
Jul 23 10:11:30 kni1-bootstrap.cloud.lab.eng.bos.redhat.com network[10181]: it work better with this distribution.
Jul 23 10:11:30 kni1-bootstrap.cloud.lab.eng.bos.redhat.com network[10181]: Please report issues with this software via:
Jul 23 10:11:30 kni1-bootstrap.cloud.lab.eng.bos.redhat.com network[10181]: https://bugzilla.redhat.com/
Jul 23 10:11:30 kni1-bootstrap.cloud.lab.eng.bos.redhat.com network[10181]: exiting.
Jul 23 10:11:30 kni1-bootstrap.cloud.lab.eng.bos.redhat.com network[10181]:  failed.
```
IDK why (the `dd` shall overwrite everything...) but the `/etc/sysconfig/network-scripts/ifcfg-baremetal` file had a few `BOOTPROTO=dhcp` entries (one per execution), so just in case, this will fix it.