### PR TITLE
Restore BOOTPROTO=dhcp to baremetal bridge interface

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -106,7 +106,7 @@ if [ "$MANAGE_INT_BRIDGE" == "y" ]; then
     if [ "$INT_IF" ]; then
         echo -e "DEVICE=$INT_IF\nTYPE=Ethernet\nONBOOT=yes\nNM_CONTROLLED=no\nBRIDGE=baremetal" | sudo dd of=/etc/sysconfig/network-scripts/ifcfg-$INT_IF
         if sudo nmap --script broadcast-dhcp-discover -e $INT_IF | grep "IP Offered" ; then
-            echo -e "\nBOOTPROTO=dhcp\n" | sudo tee -a /etc/sysconfig/network-scripts/ifcfg-$INT_IF
+            grep -q BOOTPROTO /etc/sysconfig/network-scripts/ifcfg-baremetal || (echo -e "\nBOOTPROTO=dhcp\n" | sudo tee -a /etc/sysconfig/network-scripts/ifcfg-baremetal)
             sudo systemctl restart network
         else
            sudo systemctl restart network


### PR DESCRIPTION
A change was made so that the BOOTPROTO=dhcp was added to $IF_INT
instead of the baremetal bridge, but this seems to break things. The
intention of 71d221654d7 seemed to be to only add the line if it didn't
already exist, this implements that.