### PR TITLE
Add validation for number of nodes in NODES_FILE

### DIFF
--- a/06_create_cluster.sh
+++ b/06_create_cluster.sh
@@ -44,6 +44,13 @@ if [ ! -d ocp ]; then
       build_installer
     fi
 
+    # Validate there are enough nodes to avoid confusing errors later..
+    NODES_LEN=$(jq '.nodes | length' ${NODES_FILE})
+    if (( $NODES_LEN < ( $NUM_MASTERS + $NUM_WORKERS ) )); then
+        echo "ERROR: ${NODES_FILE} contains ${NODES_LEN} nodes, but ${NUM_MASTERS} masters and ${NUM_WORKERS} workers requested"
+        exit 1
+    fi
+
     # Create a master_nodes.json file
     jq '.nodes[0:3] | {nodes: .}' "${NODES_FILE}" | tee "${MASTER_NODES_FILE}"
 


### PR DESCRIPTION
Some folks have seen a confusing error like:

```
Terraform variables: Unknown BMC type 'null' for address null://null\""
```

It turns out this is because the NODES_FILE created outside
of dev-scripts contains only two nodes, so the jq slice to create
the 3 masters in the install-config returns null for the missing
node.

Adding some validation here should make it clearer, but probably we should
catch this via validation in the installer.