### PR TITLE
08_deploy_bmo: Don't assume CLUSTER_PRO_IF == PRO_IF.

### DIFF
--- a/08_deploy_bmo.sh
+++ b/08_deploy_bmo.sh
@@ -7,7 +7,7 @@ source common.sh
 eval "$(go env)"
 
 # Set default value for provisioning interface
-CLUSTER_PRO_IF=${PRO_IF:-ens3}
+CLUSTER_PRO_IF=${CLUSTER_PRO_IF:-ens3}
 
 # Get Baremetal ip
 BAREMETAL_IP=$(ip -o -f inet addr show baremetal | awk '{print $4}' | tail -1 | cut -d/ -f1)


### PR DESCRIPTION
A new variable was added, CLUSTER_PRO_IF, which specifies which network
interface on the deployed hosts maps to the provisioning network.  The
script assumed that the value of PRO_IF is an appropriate default.

However, PRO_IF is the interface for the provisioning network on the
provisioning host.  We should not assume that network interfaces will
be the same between the provisioning host and the deployed hosts, so
separate these two options.
