### PR TITLE
Remove facet references.

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -131,10 +131,6 @@ else
     # There are some packages which are newer in the tripleo repos
     sudo yum -y update
 
-    # Setup yarn and nodejs repositories
-    sudo curl -sL https://dl.yarnpkg.com/rpm/yarn.repo -o /etc/yum.repos.d/yarn.repo
-    curl -sL https://rpm.nodesource.com/setup_10.x | sudo bash -
-
     # make sure additional requirments are installed
     sudo yum -y install \
       ansible \
@@ -143,7 +139,6 @@ else
       libvirt \
       libvirt-devel \
       libvirt-daemon-kvm \
-      nodejs \
       podman \
       python-ironicclient \
       python-ironic-inspector-client \
@@ -154,8 +149,7 @@ else
       qemu-kvm \
       redhat-lsb-core \
       virt-install \
-      unzip \
-      yarn
+      unzip
 
     # Install python packages not included as rpms
     sudo pip install \

--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -178,16 +178,6 @@ if [ "$EXT_IF" ]; then
   sudo iptables -A FORWARD --in-interface baremetal -j ACCEPT
 fi
 
-# Add access to backend Facet server from remote locations
-if ! sudo iptables -C INPUT -p tcp --dport 8080 -j ACCEPT 2>/dev/null ; then
-  sudo iptables -I INPUT -p tcp --dport 8080 -j ACCEPT
-fi
-
-# Add access to Yarn development server from remote locations
-if ! sudo iptables -C INPUT -p tcp --dport 3000 -j ACCEPT 2>/dev/null ; then
-  sudo iptables -I INPUT -p tcp --dport 3000 -j ACCEPT
-fi
-
 # Switch NetworkManager to internal DNS
 if [ "$MANAGE_BR_BRIDGE" == "y" ] ; then
   sudo mkdir -p /etc/NetworkManager/conf.d/

--- a/03_ocp_repo_sync.sh
+++ b/03_ocp_repo_sync.sh
@@ -10,14 +10,5 @@ echo "GOPATH: $GOPATH" # should print $HOME/go or something like that
 # REPO_PATH is used in sync_repo_and_patch from utils.sh
 export REPO_PATH="$GOPATH/src"
 
-# Build facet
-# FIXME(russellb) - disabled due to build failure related to metal3 rename
-#sync_repo_and_patch github.com/openshift-metalkube/facet https://github.com/openshift-metalkube/facet.git
-#go get -v github.com/rakyll/statik
-#pushd "${GOPATH}/src/github.com/openshift-metalkube/facet"
-#yarn install
-#./build.sh
-#popd
-
 # Install baremetal-operator
 sync_repo_and_patch github.com/metal3-io/baremetal-operator https://github.com/metal3-io/baremetal-operator.git

--- a/README.md
+++ b/README.md
@@ -9,10 +9,9 @@ from tripleo-quickstart here.
 
 We are using this repository as a work space while we figure out what the
 installer needs to do for bare metal provisioning. As that logic is ironed out,
-we are moving it into the [facet wrapper
-API](https://github.com/openshift-metalkube/facet/tree/master/pkg/server), or
-the [go-based
-openshift-installer](https://github.com/openshift/installer).
+we are moving it into the
+the [go-based openshift-installer](https://github.com/openshift/installer) or
+to other components of OpenShift.
 
 # Pre-requisites
 
@@ -82,13 +81,6 @@ This should result in some (stopped) VMs created by tripleo-quickstart on the
 local virthost and some other dependencies installed.
 
 - `./03_ocp_repo_sync.sh`
-
-After this step, you can run the [facet](https://github.com/openshift-metalkube/facet)
-server with:
-
-```
-$ go run "${GOPATH}/src/github.com/openshift-metalkube/facet/main.go" server
-```
 
 - `./04_setup_ironic.sh`
 

--- a/run_ci.sh
+++ b/run_ci.sh
@@ -116,7 +116,7 @@ fi
 # Project-specific actions. If these directories exist in $HOME, move
 # them to the correct $GOPATH locations. If installer, run some of
 # their CI checks.
-for PROJ in facet installer ; do
+for PROJ in installer ; do
     [ ! -d /home/notstack/$PROJ ] && continue
 
     if [ "$PROJ" == "installer" ]; then


### PR DESCRIPTION
Facet development has been dormant for quite a while.  Some of the
relevant code was commented out, but we were still installing a few
unnecessary dependencies (yarn, nodejs).

Drop the facet related references from dev-scripts for now.  It can be
re-introduced when it's being actively used and we're sure the
additions are working properly.

When development of an installer UI resumes, it may take a different
form or be in a different location, so let's revisit dev-scripts
additions when that time comes.