### PR TITLE
use the openshift version of baremetal-operator image

### DIFF
--- a/operator_ironic.yaml
+++ b/operator_ironic.yaml
@@ -72,7 +72,7 @@ spec:
                   key: provisioning_interface
       containers:
         - name: baremetal-operator
-          image: quay.io/metal3-io/baremetal-operator:master
+          image: quay.io/openshift-metal3/baremetal-operator:master
           ports:
             - containerPort: 60000
               name: metrics


### PR DESCRIPTION
We build an image for the baremetal-operator out of the openshift fork
of the repo. We should start using that to test, as a way to force
ourselves to pull fixes from the upstream version of the operator into
the openshift fork.