### PR TITLE
Wait for baremetal-operator pod to become ready

### DIFF
--- a/08_deploy_bmo.sh
+++ b/08_deploy_bmo.sh
@@ -45,3 +45,5 @@ oc --config ocp/auth/kubeconfig create secret generic mariadb-password --from-li
 
 oc --config ocp/auth/kubeconfig adm --as system:admin policy add-scc-to-user privileged system:serviceaccount:openshift-machine-api:baremetal-operator
 oc --config ocp/auth/kubeconfig apply -f ocp/deploy/operator_ironic.yaml -n openshift-machine-api
+
+oc wait -n openshift-machine-api --for condition=ready pod -l name=metal3-baremetal-operator --timeout=2400s


### PR DESCRIPTION
The baremetal-operator pod can take around 20 minutes to come up. Currently make exits successfully without the baremetal-operator being ready. This change waits for the pod to become ready before registering the baremetalhosts in 11_register_hosts.sh.