### PR TITLE
Add MachineCIDR definition to install-config.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ BASE_DOMAIN=your.valid.domain.com
 CLUSTER_NAME=clustername
 # Set your valid DNS VIP, such as 1.1.1.1 for 'ns1.example.com'
 DNS_VIP="1.1.1.1"
+# Set to the subnet in use on the external (baremetal) network
+EXTERNAL_SUBNET="192.168.111.0/24"
 ```
 
 ## Installation

--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -6,7 +6,7 @@ export BASE_DOMAIN=${BASE_DOMAIN:-test.metalkube.org}
 export CLUSTER_NAME=${CLUSTER_NAME:-ostest}
 export CLUSTER_DOMAIN="${CLUSTER_NAME}.${BASE_DOMAIN}"
 export SSH_PUB_KEY="${SSH_PUB_KEY:-$(cat $HOME/.ssh/id_rsa.pub)}"
-export EXTERNAL_SUBNET="192.168.111.0/24"
+export EXTERNAL_SUBNET=${EXTERNAL_SUBNET:-"192.168.111.0/24"}
 export DNS_VIP=${DNS_VIP:-"192.168.111.2"}
 
 #

--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -63,6 +63,8 @@ function generate_ocp_install_config() {
     cat > "${outdir}/install-config.yaml" << EOF
 apiVersion: v1beta4
 baseDomain: ${BASE_DOMAIN}
+networking:
+  machineCIDR: ${EXTERNAL_SUBNET}
 metadata:
   name: ${CLUSTER_NAME}
 compute:


### PR DESCRIPTION
openshift/installer#2140 adds validation that the VIPs are a) in the
MachineCIDR and b) not in ClusterNetworks or ServiceNetworks.

This patch defines the MachineCIDR to EXTERNAL_SUBNET in order to
satisfy the first requirement.