### PR TITLE
Rename bmo-ironic-configmap to metal3-config.

### DIFF
--- a/08_deploy_bmo.sh
+++ b/08_deploy_bmo.sh
@@ -20,10 +20,10 @@ cp -r $BMOPATH/deploy ocp/.
 sed -i 's/namespace: .*/namespace: openshift-machine-api/g' ocp/deploy/role_binding.yaml
 
 cp $SCRIPTDIR/operator_ironic.yaml ocp/deploy
-cp $SCRIPTDIR/ironic_bmo_configmap.yaml ocp/deploy
-sed -i "s#__RHCOS_IMAGE_URL__#${RHCOS_IMAGE_URL}#" ocp/deploy/ironic_bmo_configmap.yaml
-sed -i "s#provisioning_interface: \"ens3\"#provisioning_interface: \"${CLUSTER_PRO_IF}\"#" ocp/deploy/ironic_bmo_configmap.yaml
-sed -i "s#cache_url: \"http://192.168.111.1/images\"#cache_url: \"http://${BAREMETAL_IP}/images\"#" ocp/deploy/ironic_bmo_configmap.yaml
+cp $SCRIPTDIR/metal3-config.yaml ocp/deploy
+sed -i "s#__RHCOS_IMAGE_URL__#${RHCOS_IMAGE_URL}#" ocp/deploy/metal3-config.yaml
+sed -i "s#provisioning_interface: \"ens3\"#provisioning_interface: \"${CLUSTER_PRO_IF}\"#" ocp/deploy/metal3-config.yaml
+sed -i "s#cache_url: \"http://192.168.111.1/images\"#cache_url: \"http://${BAREMETAL_IP}/images\"#" ocp/deploy/metal3-config.yaml
 
 # Kill the dnsmasq container on the host since it is performing DHCP and doesn't
 # allow our pod in openshift to take over.  We don't want to take down all of ironic
@@ -38,7 +38,7 @@ oc --config ocp/auth/kubeconfig apply -f ocp/deploy/role.yaml --namespace=opensh
 oc --config ocp/auth/kubeconfig apply -f ocp/deploy/role_binding.yaml
 oc --config ocp/auth/kubeconfig apply -f ocp/deploy/crds/metal3_v1alpha1_baremetalhost_crd.yaml
 
-oc --config ocp/auth/kubeconfig apply -f ocp/deploy/ironic_bmo_configmap.yaml --namespace=openshift-machine-api
+oc --config ocp/auth/kubeconfig apply -f ocp/deploy/metal3-config.yaml --namespace=openshift-machine-api
 # I'm leaving this as is for debugging but we could easily generate a random password here.
 oc --config ocp/auth/kubeconfig delete secret mariadb-password --namespace=openshift-machine-api || true
 oc --config ocp/auth/kubeconfig create secret generic mariadb-password --from-literal password=password --namespace=openshift-machine-api

--- a/metal3-config.yaml
+++ b/metal3-config.yaml
@@ -1,7 +1,7 @@
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: ironic-bmo-configmap
+  name: metal3-config
 data:
   http_port: "6180"
   provisioning_interface: "ens3"

--- a/operator_ironic.yaml
+++ b/operator_ironic.yaml
@@ -29,7 +29,7 @@ spec:
             - name: CACHEURL
               valueFrom:
                 configMapKeyRef:
-                  name: ironic-bmo-configmap
+                  name: metal3-config
                   key: cache_url
         - name: rhcos-downloader
           image: quay.io/openshift-metal3/rhcos-downloader:master
@@ -45,12 +45,12 @@ spec:
             - name: RHCOS_IMAGE_URL
               valueFrom:
                 configMapKeyRef:
-                  name: ironic-bmo-configmap
+                  name: metal3-config
                   key: rhcos_image_url
             - name: CACHEURL
               valueFrom:
                 configMapKeyRef:
-                  name: ironic-bmo-configmap
+                  name: metal3-config
                   key: cache_url
         - name: static-ip-set
           image: quay.io/metal3-io/static-ip-manager:latest
@@ -63,12 +63,12 @@ spec:
             - name: PROVISIONING_IP
               valueFrom:
                 configMapKeyRef:
-                  name: ironic-bmo-configmap
+                  name: metal3-config
                   key: provisioning_ip
             - name: PROVISIONING_INTERFACE
               valueFrom:
                 configMapKeyRef:
-                  name: ironic-bmo-configmap
+                  name: metal3-config
                   key: provisioning_interface
       containers:
         - name: baremetal-operator
@@ -93,22 +93,22 @@ spec:
             - name: DEPLOY_KERNEL_URL
               valueFrom:
                 configMapKeyRef:
-                  name: ironic-bmo-configmap
+                  name: metal3-config
                   key: deploy_kernel_url
             - name: DEPLOY_RAMDISK_URL
               valueFrom:
                 configMapKeyRef:
-                  name: ironic-bmo-configmap
+                  name: metal3-config
                   key: deploy_ramdisk_url
             - name: IRONIC_ENDPOINT
               valueFrom:
                 configMapKeyRef:
-                  name: ironic-bmo-configmap
+                  name: metal3-config
                   key: ironic_endpoint
             - name: IRONIC_INSPECTOR_ENDPOINT
               valueFrom:
                 configMapKeyRef:
-                  name: ironic-bmo-configmap
+                  name: metal3-config
                   key: ironic_inspector_endpoint
         - name: ironic-dnsmasq
           image: quay.io/metal3-io/ironic:master
@@ -124,17 +124,17 @@ spec:
             - name: HTTP_PORT
               valueFrom:
                 configMapKeyRef:
-                  name: ironic-bmo-configmap
+                  name: metal3-config
                   key: http_port
             - name: PROVISIONING_INTERFACE
               valueFrom:
                 configMapKeyRef:
-                  name: ironic-bmo-configmap
+                  name: metal3-config
                   key: provisioning_interface
             - name: DHCP_RANGE
               valueFrom:
                 configMapKeyRef:
-                  name: ironic-bmo-configmap
+                  name: metal3-config
                   key: dhcp_range
         - name: mariadb
           image: quay.io/metal3-io/ironic:master
@@ -166,12 +166,12 @@ spec:
             - name: HTTP_PORT
               valueFrom:
                 configMapKeyRef:
-                  name: ironic-bmo-configmap
+                  name: metal3-config
                   key: http_port
             - name: PROVISIONING_INTERFACE
               valueFrom:
                 configMapKeyRef:
-                  name: ironic-bmo-configmap
+                  name: metal3-config
                   key: provisioning_interface
         - name: ironic-conductor
           image: quay.io/metal3-io/ironic:master
@@ -192,12 +192,12 @@ spec:
             - name: HTTP_PORT
               valueFrom:
                 configMapKeyRef:
-                  name: ironic-bmo-configmap
+                  name: metal3-config
                   key: http_port
             - name: PROVISIONING_INTERFACE
               valueFrom:
                 configMapKeyRef:
-                  name: ironic-bmo-configmap
+                  name: metal3-config
                   key: provisioning_interface
         - name: ironic-api
           image: quay.io/metal3-io/ironic:master
@@ -218,12 +218,12 @@ spec:
             - name: HTTP_PORT
               valueFrom:
                 configMapKeyRef:
-                  name: ironic-bmo-configmap
+                  name: metal3-config
                   key: http_port
             - name: PROVISIONING_INTERFACE
               valueFrom:
                 configMapKeyRef:
-                  name: ironic-bmo-configmap
+                  name: metal3-config
                   key: provisioning_interface
         - name: ironic-inspector
           image: quay.io/metal3-io/ironic-inspector:master
@@ -237,7 +237,7 @@ spec:
             - name: PROVISIONING_INTERFACE
               valueFrom:
                 configMapKeyRef:
-                  name: ironic-bmo-configmap
+                  name: metal3-config
                   key: provisioning_interface
         - name: static-ip-refresh
           image: quay.io/metal3-io/static-ip-manager:latest
@@ -250,12 +250,12 @@ spec:
             - name: PROVISIONING_IP
               valueFrom:
                 configMapKeyRef:
-                  name: ironic-bmo-configmap
+                  name: metal3-config
                   key: provisioning_ip
             - name: PROVISIONING_INTERFACE
               valueFrom:
                 configMapKeyRef:
-                  name: ironic-bmo-configmap
+                  name: metal3-config
                   key: provisioning_interface
       volumes:
         - name: ironic-data-volume


### PR DESCRIPTION
metal3-config is a better name for the configmap and better
matches other configmap names.