### PR TITLE
Remove assets/generated on ocp cleanup

### DIFF
--- a/ocp_cleanup.sh
+++ b/ocp_cleanup.sh
@@ -35,3 +35,7 @@ for vm in $(sudo virsh list --all --name | grep "^${CLUSTER_NAME}.*bootstrap"); 
   sudo virsh destroy $vm
   sudo virsh undefine $vm --remove-all-storage
 done
+
+if [ -d assets/generated ]; then
+  rm -rf assets/generated
+fi


### PR DESCRIPTION
Many times I've wasted time debugging something only to realize that a
generated asset was still present and overriding something in another
component. This removes the generated directory on ocp_cleanup.sh