### PR TITLE
Match existing machines in add-machine-ips.sh

### DIFF
--- a/add-machine-ips.sh
+++ b/add-machine-ips.sh
@@ -9,7 +9,7 @@ source ocp_install_env.sh
 
 for node in $(oc --config ocp/auth/kubeconfig get nodes -o template --template='{{range .items}}{{.metadata.uid}}:{{.metadata.name}}{{"\n"}}{{end}}'); do
     node_name=$(echo $node | cut -f2 -d':')
-    machine_name=$CLUSTER_NAME-$node_name
+    machine_name=$CLUSTER_NAME-$(echo $node_name | grep -oE "(master|worker)-[0-9]+")
     if [[ "$machine_name" == *"worker"* ]]; then
         echo "Skipping worker $machine_name because it should have inspection data to link automatically"
         continue


### PR DESCRIPTION
Currently add-machine-ips.sh fails when nodes hostnames are different than master-$index. This change adjusts the script so that it matches the existing machine names.

Fixes #732 