### PR TITLE
Change the order of the ironic containers

### DIFF
--- a/operator_ironic.yaml
+++ b/operator_ironic.yaml
@@ -71,45 +71,24 @@ spec:
                   name: metal3-config
                   key: provisioning_interface
       containers:
-        - name: baremetal-operator
-          image: quay.io/metal3-io/baremetal-operator:master
-          ports:
-            - containerPort: 60000
-              name: metrics
+        - name: static-ip-refresh
+          image: quay.io/metal3-io/static-ip-manager:latest
           command:
-            - /baremetal-operator
+            - /refresh-static-ip
           imagePullPolicy: Always
+          securityContext:
+            privileged: true
           env:
-            - name: WATCH_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "baremetal-operator"
-            - name: DEPLOY_KERNEL_URL
+            - name: PROVISIONING_IP
               valueFrom:
                 configMapKeyRef:
                   name: metal3-config
-                  key: deploy_kernel_url
-            - name: DEPLOY_RAMDISK_URL
+                  key: provisioning_ip
+            - name: PROVISIONING_INTERFACE
               valueFrom:
                 configMapKeyRef:
                   name: metal3-config
-                  key: deploy_ramdisk_url
-            - name: IRONIC_ENDPOINT
-              valueFrom:
-                configMapKeyRef:
-                  name: metal3-config
-                  key: ironic_endpoint
-            - name: IRONIC_INSPECTOR_ENDPOINT
-              valueFrom:
-                configMapKeyRef:
-                  name: metal3-config
-                  key: ironic_inspector_endpoint
+                  key: provisioning_interface
         - name: ironic-dnsmasq
           image: quay.io/metal3-io/ironic:master
           imagePullPolicy: Always
@@ -239,24 +218,45 @@ spec:
                 configMapKeyRef:
                   name: metal3-config
                   key: provisioning_interface
-        - name: static-ip-refresh
-          image: quay.io/metal3-io/static-ip-manager:latest
+        - name: baremetal-operator
+          image: quay.io/metal3-io/baremetal-operator:master
+          ports:
+            - containerPort: 60000
+              name: metrics
           command:
-            - /refresh-static-ip
+            - /baremetal-operator
           imagePullPolicy: Always
-          securityContext:
-            privileged: true
           env:
-            - name: PROVISIONING_IP
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: "baremetal-operator"
+            - name: DEPLOY_KERNEL_URL
               valueFrom:
                 configMapKeyRef:
                   name: metal3-config
-                  key: provisioning_ip
-            - name: PROVISIONING_INTERFACE
+                  key: deploy_kernel_url
+            - name: DEPLOY_RAMDISK_URL
               valueFrom:
                 configMapKeyRef:
                   name: metal3-config
-                  key: provisioning_interface
+                  key: deploy_ramdisk_url
+            - name: IRONIC_ENDPOINT
+              valueFrom:
+                configMapKeyRef:
+                  name: metal3-config
+                  key: ironic_endpoint
+            - name: IRONIC_INSPECTOR_ENDPOINT
+              valueFrom:
+                configMapKeyRef:
+                  name: metal3-config
+                  key: ironic_inspector_endpoint
       volumes:
         - name: ironic-data-volume
           emptyDir: {}


### PR DESCRIPTION
To ensure the IP address on the provisioning interface is set
We need static-ip-refresh to start before the others, observation
suggests the order in this file is the order they are started in.
