### PR TITLE
Fix and clean up release image variables

### DIFF
--- a/06_create_cluster.sh
+++ b/06_create_cluster.sh
@@ -8,7 +8,7 @@ source common.sh
 source ocp_install_env.sh
 
 # Do some PULL_SECRET sanity checking
-if [[ "${OPENSHIFT_RELEASE_IMAGE_OVERRIDE}" == *"registry.svc.ci.openshift.org"* ]]; then
+if [[ "${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE}" == *"registry.svc.ci.openshift.org"* ]]; then
     if [[ "${PULL_SECRET}" != *"registry.svc.ci.openshift.org"* ]]; then
         echo "Please get a valid pull secret for registry.svc.ci.openshift.org."
         exit 1
@@ -37,7 +37,7 @@ if [ ! -d ocp ]; then
 
     if [ -z "$KNI_INSTALL_FROM_GIT" ]; then
       # Extract openshift-install from the release image
-      extract_installer "${OPENSHIFT_RELEASE_IMAGE_OVERRIDE}" ocp/
+      extract_installer "${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE}" ocp/
     else
       # Clone and build the installer from source
       clone_installer

--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -12,7 +12,7 @@ export DNS_VIP=${DNS_VIP:-"192.168.111.2"}
 #
 # See https://origin-release.svc.ci.openshift.org/ for release details
 #
-export OPENSHIFT_RELEASE_IMAGE_OVERRIDE="${OPENSHIFT_RELEASE_IMAGE_OVERRIDE:-registry.svc.ci.openshift.org/ocp/release:4.2}"
+export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE:-registry.svc.ci.openshift.org/ocp/release:4.2}"
 
 function extract_installer() {
     local release_image
@@ -27,7 +27,7 @@ function extract_installer() {
     echo "${PULL_SECRET}" > "${pullsecret_file}"
     # FIXME: Find the pullspec for baremetal-installer image and extract the image, until
     # https://github.com/openshift/oc/pull/57 is merged
-    baremetal_image=$(oc adm release info --registry-config "${pullsecret_file}" $OPENSHIFT_RELEASE_IMAGE_OVERRIDE -o json | jq -r '.references.spec.tags[] | select(.name == "baremetal-installer") | .from.name')
+    baremetal_image=$(oc adm release info --registry-config "${pullsecret_file}" $OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE -o json | jq -r '.references.spec.tags[] | select(.name == "baremetal-installer") | .from.name')
     oc image extract --registry-config "${pullsecret_file}" $baremetal_image --path usr/bin/openshift-install:${extract_dir}
 
     chmod 755 "${extract_dir}/openshift-install"

--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -49,7 +49,7 @@ function build_installer() {
   # Build installer
   pushd .
   cd $OPENSHIFT_INSTALL_PATH
-  RELEASE_IMAGE="$OPENSHIFT_RELEASE_IMAGE_OVERRIDE" TAGS="libvirt baremetal" hack/build.sh
+  TAGS="libvirt baremetal" hack/build.sh
   popd
 
   export OPENSHIFT_INSTALLER="$OPENSHIFT_INSTALL_PATH/bin/openshift-install"


### PR DESCRIPTION
- Rename OPENSHIFT_RELEASE_IMAGE_OVERRIDE to the correct OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE
- Remove reference to RELEASE_IMAGE (removed in https://github.com/openshift/installer/pull/2217)