### PR TITLE
Fix virtualbmc service on RHEL-8

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -100,6 +100,7 @@ if [ "${RHEL8}" = "True" ] ; then
     git pull -r
     sudo pip3 install .
     curl 'https://review.rdoproject.org/r/gitweb?p=openstack/virtualbmc-distgit.git;a=blob_plain;f=virtualbmc.service;hb=HEAD' > virtualbmc.service
+    sed -i 's|/usr/bin/vbmcd|/usr/local/bin/vbmcd|' virtualbmc.service
     sudo mv virtualbmc.service /etc/systemd/system/.
     sudo systemctl daemon-reload
     popd ; popd


### PR DESCRIPTION
We're installing virtualbmc into `/usr/loca`' and the systemd unit assumes it is in `/usr`. So the service is always in `failed` state.

virtualbmc is very cunning so when you run `vbmc add`, it goes ahead and forks the daemon:

```
 DEBUG VirtualBMC [-] Server at 50891 connection error: Server response timed out
 DEBUG VirtualBMC [-] Attempting to start `vbmcd` behind the scenes. Consider configuring your system to manage `vbmcd` via systemd. Automatic `vbmcd` start up will be removed in the future releases!
```

Things break badly only much later because cleanup with `systemctl stop` doesn't do what we expect.

Surely Ansible's systemd module would notice the service failing to start? Apparently not! https://github.com/ansible/ansible/issues/24450