### PR TITLE
Move to v1 install-config version

### DIFF
--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -71,7 +71,7 @@ function generate_ocp_install_config() {
     # deploys the baremetal-operator
 
     cat > "${outdir}/install-config.yaml" << EOF
-apiVersion: v1beta4
+apiVersion: v1
 baseDomain: ${BASE_DOMAIN}
 networking:
   machineCIDR: ${EXTERNAL_SUBNET}


### PR DESCRIPTION
As of openshift/installer#1589 the install-config format has been
locked in as the v1 version.