### PR TITLE
Added a timeout on the wait for build in build_installer.sh

### DIFF
--- a/release/build_installer.sh
+++ b/release/build_installer.sh
@@ -67,7 +67,7 @@ spec:
 EOF
 
 BUILD_POD=$(oc --config "${RELEASE_KUBECONFIG}" get build "openshift-installer-${INSTALLER_VERSION}" -o json | jq -r '.metadata.annotations["openshift.io/build.pod-name"]')
-oc --config "${RELEASE_KUBECONFIG}" wait --for condition=Ready pod "${BUILD_POD}"
+oc --config "${RELEASE_KUBECONFIG}" wait --for condition=Ready pod "${BUILD_POD}" --timeout=240s
 oc --config "${RELEASE_KUBECONFIG}" logs -f "${BUILD_POD}"
 
 BUILD_PHASE=$(oc --config release-kubeconfig get build "openshift-installer-${INSTALLER_VERSION}" -o json | jq -r .status.phase)


### PR DESCRIPTION
The default configuration (with no timeout) means that the script
to build a custom release can exit before completion due to the
default timeout being hit. This may not be an issue on a fast
environment where the build can come up quickly, but on a slightly
slower environment a timeout is wise to have.