### PR TITLE
Update rhcos to 42.80.20190827.1

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -47,7 +47,7 @@ export NUM_MASTERS=${NUM_MASTERS:-"3"}
 export NUM_WORKERS=${NUM_WORKERS:-"1"}
 export VM_EXTRADISKS=${VM_EXTRADISKS:-"false"}
 
-export RHCOS_INSTALLER_IMAGE_URL="https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.2/42.80.20190725.1/rhcos-42.80.20190725.1-openstack.qcow2"
+export RHCOS_INSTALLER_IMAGE_URL="https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.2/42.80.20190827.1/rhcos-42.80.20190827.1-openstack.qcow2"
 export RHCOS_IMAGE_URL=${RHCOS_IMAGE_URL:-${RHCOS_INSTALLER_IMAGE_URL}}
 export RHCOS_IMAGE_FILENAME_LATEST="rhcos-ootpa-latest.qcow2"
 


### PR DESCRIPTION
We'll need this when https://github.com/openshift/installer/pull/2264 lands.  

Eventually we can avoid this if and when https://github.com/openshift/installer/pull/2092 lands, otherwise there's not a convenient way to get the data out of the installer.