### PR TITLE
fix instructions for patching cluster-version-operator to ignore machine-api-operator

### DIFF
--- a/docs/custom-mao-and-capbm.md
+++ b/docs/custom-mao-and-capbm.md
@@ -22,7 +22,7 @@ Deployment. Without this, it will scale the MAO back up within a few minutes of
 you scaling it down.
 
 ```sh
-oc patch clusterversion version --namespace openshift-cluster-version --type merge -p '{"spec":{"overrides":[{"kind":"Deployment","name":"machine-api-operator","namespace":"openshift-machine-api","unmanaged":true}]}}'
+oc patch clusterversion version --namespace openshift-cluster-version --type merge -p '{"spec":{"overrides":[{"kind":"Deployment","group":"apps/v1","name":"machine-api-operator","namespace":"openshift-machine-api","unmanaged":true}]}}'
 ```
 
 Stop the currently running MAO by scaling it to zero replicas:

--- a/stop-mao.sh
+++ b/stop-mao.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -xe
+
+# Tell the cluster-version-operator to stop managing the machine-api-operator
+oc patch clusterversion version --namespace openshift-cluster-version --type merge -p '{"spec":{"overrides":[{"kind":"Deployment","group":"apps/v1","name":"machine-api-operator","namespace":"openshift-machine-api","unmanaged":true}]}}'
+
+# Stop any existing machine-api-operator
+oc scale deployment -n openshift-machine-api --replicas=0 machine-api-operator


### PR DESCRIPTION
The "group" is required for the cluster-version-operator overrides list.