### PR TITLE
[wip]: allow to use a preexisting openshift-install binary

### DIFF
--- a/06_create_cluster.sh
+++ b/06_create_cluster.sh
@@ -41,6 +41,9 @@ if [ ! -d ocp ]; then
     if [ -z "$KNI_INSTALL_FROM_GIT" ]; then
       # Extract openshift-install from the release image
       extract_installer "${OPENSHIFT_RELEASE_IMAGE}" ocp/
+    elif [ -f openshift-install ] ; then
+      # If the binary is in the directory, use this one
+      cp openshift-install ocp
     else
       # Clone and build the installer from source
       clone_installer


### PR DESCRIPTION
- allow to use openshift-install binary if found at root dir. this allows quickly confirming an issue is related to the installer code by relaunching an install with a known to work version