### PR TITLE
Always use RHCOS version from installer

### DIFF
--- a/03_build_installer.sh
+++ b/03_build_installer.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -x
+set -e
+
+source logging.sh
+source utils.sh
+source common.sh
+source ocp_install_env.sh
+
+# Extract an updated client tools from the release image
+extract_oc "${OPENSHIFT_RELEASE_IMAGE}"
+
+mkdir -p ocp/
+
+if [ -z "$KNI_INSTALL_FROM_GIT" ]; then
+  # Extract openshift-install from the release image
+  extract_installer "${OPENSHIFT_RELEASE_IMAGE}" ocp/
+else
+  # Clone and build the installer from source
+  clone_installer
+  build_installer
+fi

--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -4,6 +4,7 @@ set -ex
 
 source logging.sh
 source common.sh
+source rhcos.sh
 
 # Either pull or build the ironic images
 # To build the IRONIC image set

--- a/06_create_cluster.sh
+++ b/06_create_cluster.sh
@@ -6,6 +6,7 @@ source logging.sh
 source utils.sh
 source common.sh
 source ocp_install_env.sh
+source rhcos.sh
 
 # Do some PULL_SECRET sanity checking
 if [[ "${OPENSHIFT_RELEASE_IMAGE}" == *"registry.svc.ci.openshift.org"* ]]; then
@@ -32,21 +33,7 @@ else
     INGRESS_VIP=$(dig +noall +answer "test.apps.${CLUSTER_DOMAIN}" | awk '{print $NF}')
 fi
 
-if [ ! -d ocp ]; then
-    mkdir -p ocp
-
-    # Extract an updated client tools from the release image
-    extract_oc ${OPENSHIFT_RELEASE_IMAGE}
-
-    if [ -z "$KNI_INSTALL_FROM_GIT" ]; then
-      # Extract openshift-install from the release image
-      extract_installer "${OPENSHIFT_RELEASE_IMAGE}" ocp/
-    else
-      # Clone and build the installer from source
-      clone_installer
-      build_installer
-    fi
-
+if [ ! -f ocp/install-config.yaml ]; then
     # Validate there are enough nodes to avoid confusing errors later..
     NODES_LEN=$(jq '.nodes | length' ${NODES_FILE})
     if (( $NODES_LEN < ( $NUM_MASTERS + $NUM_WORKERS ) )); then

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,18 @@
 .PHONY: default all requirements configure ironic ocp_run register_hosts clean ocp_cleanup ironic_cleanup host_cleanup bell csr_hack
-default: requirements configure ironic ocp_run register_hosts csr_hack bell
+default: requirements configure build_installer ironic ocp_run register_hosts csr_hack bell
 
 all: default
 
-redeploy: ocp_cleanup ironic_cleanup ironic ocp_run register_hosts csr_hack bell
+redeploy: ocp_cleanup ironic_cleanup build_installer ironic ocp_run register_hosts csr_hack bell
 
 requirements:
 	./01_install_requirements.sh
 
 configure:
 	./02_configure_host.sh
+
+build_installer:
+	./03_build_installer.sh
 
 ironic:
 	./04_setup_ironic.sh

--- a/common.sh
+++ b/common.sh
@@ -19,6 +19,28 @@ if [ -z "${CONFIG:-}" ]; then
 fi
 source $CONFIG
 
+#
+# See https://origin-release.svc.ci.openshift.org/ for release details
+#
+export OPENSHIFT_RELEASE_IMAGE="${OPENSHIFT_RELEASE_IMAGE:-registry.svc.ci.openshift.org/ocp/release:4.2}"
+export OPENSHIFT_INSTALL_PATH="$GOPATH/src/github.com/openshift/installer"
+
+if [ -z "$KNI_INSTALL_FROM_GIT" ]; then
+    export OPENSHIFT_INSTALLER=${OPENSHIFT_INSTALLER:-ocp/openshift-baremetal-install}
+ else
+    export OPENSHIFT_INSTALLER=${OPENSHIFT_INSTALLER:-$OPENSHIFT_INSTALL_PATH/bin/openshift-install}
+
+    # This is an URI so we can use curl for either the file on GitHub, or locally
+    export OPENSHIFT_INSTALLER_RHCOS=${OPENSHIFT_INSTALLER_RHCOS:-file:///$OPENSHIFT_INSTALL_PATH/data/data/rhcos.json}
+
+    # The installer defaults to origin/CI releases, e.g registry.svc.ci.openshift.org/origin/release:4.2
+    # Which currently don't work for us ref
+    # https://github.com/openshift/ironic-inspector-image/pull/17
+    # Until we can align OPENSHIFT_RELEASE_IMAGE with the installer default, we still need
+    # to set OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE for openshift-install source builds
+    export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="${OPENSHIFT_RELEASE_IMAGE}"
+fi
+
 # Set variables
 # Additional DNS
 ADDN_DNS=${ADDN_DNS:-}
@@ -46,10 +68,6 @@ MASTER_NODES_FILE=${MASTER_NODES_FILE:-"ocp/master_nodes.json"}
 export NUM_MASTERS=${NUM_MASTERS:-"3"}
 export NUM_WORKERS=${NUM_WORKERS:-"1"}
 export VM_EXTRADISKS=${VM_EXTRADISKS:-"false"}
-
-export RHCOS_INSTALLER_IMAGE_URL="https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.2/42.80.20190827.1/rhcos-42.80.20190827.1-openstack.qcow2"
-export RHCOS_IMAGE_URL=${RHCOS_IMAGE_URL:-${RHCOS_INSTALLER_IMAGE_URL}}
-export RHCOS_IMAGE_FILENAME_LATEST="rhcos-ootpa-latest.qcow2"
 
 # Ironic vars
 export IRONIC_IMAGE=${IRONIC_IMAGE:-"quay.io/metal3-io/ironic:master"}

--- a/rhcos.sh
+++ b/rhcos.sh
@@ -1,0 +1,11 @@
+# Get the git commit that the openshift installer was built from
+OPENSHIFT_INSTALL_COMMIT=$($OPENSHIFT_INSTALLER version | grep commit | cut -d' ' -f4)
+
+# Get the rhcos.json for that commit
+OPENSHIFT_INSTALLER_RHCOS=${OPENSHIFT_INSTALLER_RHCOS:-https://raw.githubusercontent.com/openshift/installer/$OPENSHIFT_INSTALL_COMMIT/data/data/rhcos.json}
+
+# Get the rhcos.json for that commit, and find the baseURI and openstack image path
+RHCOS_IMAGE_JSON=$(curl "${OPENSHIFT_INSTALLER_RHCOS}")
+export RHCOS_INSTALLER_IMAGE_URL=$(echo "${RHCOS_IMAGE_JSON}" | jq -r '.baseURI + .images.openstack.path')
+export RHCOS_IMAGE_URL=${RHCOS_IMAGE_URL:-${RHCOS_INSTALLER_IMAGE_URL}}
+export RHCOS_IMAGE_FILENAME_LATEST="rhcos-ootpa-latest.qcow2"

--- a/run_ci.sh
+++ b/run_ci.sh
@@ -142,9 +142,7 @@ done
 
 # Run dev-scripts
 set -o pipefail
-# TODO - Run all steps again once the baremetal-operator pod is fixed
-#timeout -s 9 85m make |& ts "%b %d %H:%M:%S | " |& sed -e 's/.*auths.*/*** PULL_SECRET ***/g'
-timeout -s 9 85m make requirements configure ironic ocp_run register_hosts |& ts "%b %d %H:%M:%S | " |& sed -e 's/.*auths.*/*** PULL_SECRET ***/g'
+timeout -s 9 85m make |& ts "%b %d %H:%M:%S | " |& sed -e 's/.*auths.*/*** PULL_SECRET ***/g'
 
 # Deployment is complete, but now wait to ensure the worker node comes up.
 export KUBECONFIG=ocp/auth/kubeconfig


### PR DESCRIPTION
Instead of hardcoding the RHCOS version in dev-scripts, by re-ordering
some things like extracting/building the installer first, we can use the
rhcos.json from the installer to find out which RHCOS version we should
be using.