### PR TITLE
Restore fix_certs cron job.

### DIFF
--- a/11_register_hosts.sh
+++ b/11_register_hosts.sh
@@ -75,10 +75,16 @@ function make_bm_workers() {
 list_masters | make_bm_masters | tee $SCRIPTDIR/ocp/master_crs.yaml
 
 list_workers | make_bm_workers | tee $SCRIPTDIR/ocp/worker_crs.yaml
-# TODO - remove this once we set worker replicas to ${NUM_WORKERS} in
-# install-config, which will be after the machine-api-operator can deploy the
-# baremetal-operator
-oc scale machineset -n openshift-machine-api ${CLUSTER_NAME}-worker-0 --replicas=${NUM_WORKERS}
+if test ${NUM_WORKERS} -gt 0 ; then
+    # TODO - remove this once we set worker replicas to ${NUM_WORKERS} in
+    # install-config, which will be after the machine-api-operator can deploy the
+    # baremetal-operator
+    oc scale machineset -n openshift-machine-api ${CLUSTER_NAME}-worker-0 --replicas=${NUM_WORKERS}
+
+    # Run the fix_certs.sh script periodically as a workaround for
+    # https://github.com/openshift-metalkube/dev-scripts/issues/260
+    sudo systemd-run --on-active=30s --on-unit-active=1m --unit=fix_certs.service $(dirname $0)/fix_certs.sh
+fi
 
 oc --config ocp/auth/kubeconfig apply -f $SCRIPTDIR/ocp/master_crs.yaml --namespace=openshift-machine-api
 


### PR DESCRIPTION
The journey of #260 continues.

This was previously removed because automatic CSR approval was working
for workers.  Automatic CSR approval has stopped working because a
piece of required information (the hostname) is no longer present on
Machine objects.

The hostname is copied to the Machine from the hardware introspection
data on the BareMetalHost.  Ironic was updated to support reporting
the hostname received via DHCP here: https://review.opendev.org/#/c/663991/
More history about adding this to the baremetal-operator is here:
https://github.com/metal3-io/baremetal-operator/issues/190

Ironic was downgraded in OCP 4.2, meaning we lost the change to report
the hostname.  We'll need this cron job until we're able to upgrade
Ironic again.

For more information about automated CSR approval, see:
https://github.com/openshift/cluster-machine-approver/blob/master/README.md

Related issue: #706