### PR TITLE
Switch the default for CLUSTER_PRO_IF

### DIFF
--- a/utils.sh
+++ b/utils.sh
@@ -177,7 +177,7 @@ function sync_repo_and_patch {
 
 function bmo_config_map {
     # Set default value for provisioning interface
-    CLUSTER_PRO_IF=${CLUSTER_PRO_IF:-ens3}
+    CLUSTER_PRO_IF=${CLUSTER_PRO_IF:-enp1s0}
     
     # Get Baremetal ip
     BAREMETAL_IP=$(ip -o -f inet addr show baremetal | awk '{print $4}' | tail -1 | cut -d/ -f1)


### PR DESCRIPTION
Switching from machine type i440fx to q35 results
in the naming of network devices being changed.
See metal3-dev-env