### PR TITLE
Install redhat-rpm-config

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -67,7 +67,8 @@ sudo yum -y install \
   patch \
   psmisc \
   vim-enhanced \
-  wget
+  wget \
+  redhat-rpm-config
 
 if [ "${RHEL8}" = "True" ] ; then
     sudo subscription-manager repos --enable=ansible-2-for-rhel-8-x86_64-rpms


### PR DESCRIPTION
There have been some reports of errors installing packages via pip
due to a missing /usr/lib/rpm/redhat/redhat-hardened-cc1

This is provided via redhat-rpm-config so lets install it to be sure
the needed file exists for pip installs.