### PR TITLE
Remove creation of mariadb password

### DIFF
--- a/mariadb-password.yaml
+++ b/mariadb-password.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-data:
-  password: cGFzc3dvcmQ=
-kind: Secret
-metadata:
-  name: mariadb-password
-  namespace: openshift-machine-api
-type: Opaque

--- a/utils.sh
+++ b/utils.sh
@@ -184,6 +184,4 @@ function bmo_config_map {
     sed -i "s#cache_url: \"http://192.168.111.1/images\"#cache_url: \"http://${BAREMETAL_IP}/images\"#" ocp/deploy/metal3-config.yaml
     
     cp ocp/deploy/metal3-config.yaml assets/generated/99_metal3-config.yaml
-
-    cp mariadb-password.yaml assets/generated/99_metal3-mariadb-password.yaml
 }


### PR DESCRIPTION
The mariadb password will be generated and added to the openshift-machine-api namespace by the machine-api-operator and can be removed from here.