### PR TITLE
Add option to use upstream images for ironic

### DIFF
--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -67,14 +67,11 @@ fi
 # Create pod
 sudo podman pod create -n ironic-pod 
 
-# We start the httpd and *downloader containers so that we can provide
 IRONIC_IMAGE=${IRONIC_LOCAL_IMAGE:-$IRONIC_IMAGE}
-IPA_DOWNLOADER_IMAGE=${IRONIC_IPA_DOWNLOADER_LOCAL_IMAGE:-$IPA_DOWNLOADER_IMAGE}
-COREOS_DOWNLOADER_IMAGE=${IRONIC_RHCOS_DOWNLOADER_LOCAL_IMAGE:-$COREOS_DOWNLOADER_IMAGE}
-VBMC_IMAGE=${VBMC_IMAGE_LOCAL_IMAGE:-$VBMC_IMAGE}
-SUSHY_TOOLS_IMAGE=${SUSHY_TOOLS_IMAGE_LOCAL_IMAGE:-$SUSHY_TOOLS_IMAGE}
+IRONIC_IPA_DOWNLOADER_IMAGE=${IRONIC_IPA_DOWNLOADER_LOCAL_IMAGE:-$IRONIC_IPA_DOWNLOADER_IMAGE}
+IRONIC_RHCOS_DOWNLOADER_IMAGE=${IRONIC_RHCOS_DOWNLOADER_LOCAL_IMAGE:-$IRONIC_RHCOS_DOWNLOADER_IMAGE}
 
-for IMAGE in ${IRONIC_IMAGE} ${IPA_DOWNLOADER_IMAGE} ${COREOS_DOWNLOADER_IMAGE} ${VBMC_IMAGE} ${SUSHY_TOOLS_IMAGE} ; do
+for IMAGE in ${IRONIC_IMAGE} ${IRONIC_IPA_DOWNLOADER_IMAGE} ${IRONIC_RHCOS_DOWNLOADER_IMAGE} ${VBMC_IMAGE} ${SUSHY_TOOLS_IMAGE} ; do
     sudo podman pull $([[ $IMAGE =~ 192.168.111.1:5000.* ]] && echo "--tls-verify=false" ) $IMAGE
 done
 
@@ -83,10 +80,10 @@ sudo podman run -d --net host --privileged --name httpd --pod ironic-pod \
      -v $IRONIC_DATA_DIR:/shared --entrypoint /bin/runhttpd ${IRONIC_IMAGE}
 
 sudo podman run -d --net host --privileged --name ipa-downloader --pod ironic-pod \
-     -v $IRONIC_DATA_DIR:/shared ${IPA_DOWNLOADER_IMAGE} /usr/local/bin/get-resource.sh
+     -v $IRONIC_DATA_DIR:/shared ${IRONIC_IPA_DOWNLOADER_IMAGE} /usr/local/bin/get-resource.sh
 
 sudo podman run -d --net host --privileged --name coreos-downloader --pod ironic-pod \
-     -v $IRONIC_DATA_DIR:/shared ${COREOS_DOWNLOADER_IMAGE} /usr/local/bin/get-resource.sh $RHCOS_IMAGE_URL
+     -v $IRONIC_DATA_DIR:/shared ${IRONIC_RHCOS_DOWNLOADER_IMAGE} /usr/local/bin/get-resource.sh $RHCOS_IMAGE_URL
 
 if [ "$NODES_PLATFORM" = "libvirt" ]; then
     sudo podman run -d --net host --privileged --name vbmc --pod ironic-pod \

--- a/common.sh
+++ b/common.sh
@@ -39,6 +39,16 @@ source $CONFIG
 export OPENSHIFT_RELEASE_IMAGE="${OPENSHIFT_RELEASE_IMAGE:-registry.svc.ci.openshift.org/ocp/release:4.2}"
 export OPENSHIFT_INSTALL_PATH="$GOPATH/src/github.com/openshift/installer"
 
+# Switch Container Images to upstream, Installer defaults these to the openshift version
+if [ "${UPSTREAM_IRONIC:-false}" != "false" ] ; then
+    export IRONIC_LOCAL_IMAGE=${IRONIC_LOCAL_IMAGE:-"quay.io/metal3-io/ironic:master"}
+    export IRONIC_INSPECTOR_LOCAL_IMAGE=${IRONIC_INSPECTOR_LOCAL_IMAGE:-"quay.io/metal3-io/ironic-inspector:master"}
+    export IRONIC_IPA_DOWNLOADER_LOCAL_IMAGE=${IRONIC_IPA_DOWNLOADER_LOCAL_IMAGE:-"quay.io/metal3-io/ironic-ipa-downloader:master"}
+    export IRONIC_RHCOS_DOWNLOADER_LOCAL_IMAGE=${IRONIC_RHCOS_DOWNLOADER_LOCAL_IMAGE:-"quay.io/openshift-metal3/rhcos-downloader:master"}
+    export IRONIC_STATIC_IP_MANAGER_LOCAL_IMAGE=${IRONIC_STATIC_IP_MANAGER_LOCAL_IMAGE:-"quay.io/metal3-io/static-ip-manager"}
+    export BAREMETAL_OPERATOR_LOCAL_IMAGE=${BAREMETAL_OPERATOR_LOCAL_IMAGE:-"quay.io/metal3-io/baremetal-operator"}
+fi
+
 if env | grep -q "_LOCAL_IMAGE=" ; then
     # We need a custome installer (allows http image pulls for local images)
     KNI_INSTALL_FROM_GIT=true
@@ -93,11 +103,10 @@ export NUM_MASTERS=${NUM_MASTERS:-"3"}
 export NUM_WORKERS=${NUM_WORKERS:-"1"}
 export VM_EXTRADISKS=${VM_EXTRADISKS:-"false"}
 
-# Ironic vars
-export IRONIC_IMAGE=${IRONIC_IMAGE:-"quay.io/metal3-io/ironic:master"}
-export IRONIC_INSPECTOR_IMAGE=${IRONIC_INSPECTOR_IMAGE:-"quay.io/metal3-io/ironic-inspector:master"}
-export IPA_DOWNLOADER_IMAGE=${IPA_DOWNLOADER_IMAGE:-"quay.io/metal3-io/ironic-ipa-downloader:master"}
-export COREOS_DOWNLOADER_IMAGE=${COREOS_DOWNLOADER_IMAGE:-"quay.io/openshift-metal3/rhcos-downloader:master"}
+# Ironic vars (Image can be use <NAME>_LOCAL_IMAGE to override)
+export IRONIC_IMAGE="quay.io/metal3-io/ironic:master"
+export IRONIC_IPA_DOWNLOADER_IMAGE="quay.io/metal3-io/ironic-ipa-downloader:master"
+export IRONIC_RHCOS_DOWNLOADER_IMAGE="quay.io/openshift-metal3/rhcos-downloader:master"
 export IRONIC_DATA_DIR="$WORKING_DIR/ironic"
 
 # VBMC and Redfish images

--- a/config_example.sh
+++ b/config_example.sh
@@ -6,9 +6,13 @@ set +x
 export PULL_SECRET=''
 set -x
 
-# Uncomment to build a copy of ironic or inspector locally
-#export IRONIC_INSPECTOR_IMAGE=https://github.com/metal3-io/ironic-inspector
-#export IRONIC_IMAGE=https://github.com/metal3-io/ironic
+# Use <NAME>_LOCAL_IMAGE to build or use copy of container images locally e.g.
+#export IRONIC_INSPECTOR_LOCAL_IMAGE=https://github.com/metal3-io/ironic-inspector
+#export IRONIC_LOCAL_IMAGE=quay.io/username/ironic
+#export MACHINE_CONFIG_OPERATOR_LOCAL_IMAGE=https://github.com/openshift/machine-config-operator
+
+# Switch to upstream metal3-io ironic images instead of openshift ones.
+#export UPSTREAM_IRONIC=true
 
 # SSH key used to ssh into deployed hosts.  This must be the contents of the
 # variable, not the filename. The contents of ~/.ssh/id_rsa.pub are used by

--- a/run_ci.sh
+++ b/run_ci.sh
@@ -133,10 +133,10 @@ fi
 
 # If directories for the containers exists then we build the images (as they are what triggered the job)
 if [ -d "/home/notstack/ironic-image" ] ; then
-    export IRONIC_IMAGE=https://github.com/metal3-io/ironic-image
+    export IRONIC_LOCAL_IMAGE=https://github.com/metal3-io/ironic-image
 fi
 if [ -d "/home/notstack/ironic-inspector-image" ] ; then
-    export IRONIC_INSPECTOR_IMAGE=https://github.com/metal3-io/ironic-inspector-image
+    export IRONIC_INSPECTOR_LOCAL_IMAGE=https://github.com/metal3-io/ironic-inspector-image
 fi
 
 


### PR DESCRIPTION
Use upstream container images for the containers that
make up the ironic/bmo pod.