### PR TITLE
Add support to test against alternative branches

### DIFF
--- a/run_ci.sh
+++ b/run_ci.sh
@@ -114,7 +114,7 @@ sudo mount -o bind /opt/data/installer-cache /home/notstack/.cache/openshift-ins
 if [ -n "$REPO" -a -n "$BRANCH" ]  ; then
     pushd ~
     if [ ! -d ${BASE_REPO#*/} ] ; then
-        git clone https://github.com/$BASE_REPO
+        git clone https://github.com/$BASE_REPO -b ${BASE_BRANCH:-master}
         cd ${BASE_REPO#*/}
         git pull --no-edit  https://github.com/$REPO $BRANCH
         git log --oneline -10 --graph


### PR DESCRIPTION
Use BASE_BRANCH to represent the branch a PR is
opened against. We've change the scripts that
trigger run_ci.sh to pass this down the line.

Fixes: #822