### PR TITLE
Calculate vbmc max port based on number of nodes

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -141,12 +141,13 @@ for PORT in 80 5000 ; do
 done
 
 # Allow ipmi to the virtual bmc processes that we just started
+VBMC_MAX_PORT=$((6230 + ${NUM_MASTERS} + ${NUM_WORKERS} - 1))
 if [ "${RHEL8}" = "True" ] ; then
-    sudo firewall-cmd --zone=libvirt --add-port=6230-6235/udp
-    sudo firewall-cmd --zone=libvirt --add-port=6230-6235/udp --permanent
+    sudo firewall-cmd --zone=libvirt --add-port=6230-${VBMC_MAX_PORT}/udp
+    sudo firewall-cmd --zone=libvirt --add-port=6230-${VBMC_MAX_PORT}/udp --permanent
 else
-    if ! sudo iptables -C INPUT -i baremetal -p udp -m udp --dport 6230:6235 -j ACCEPT 2>/dev/null ; then
-        sudo iptables -I INPUT -i baremetal -p udp -m udp --dport 6230:6235 -j ACCEPT
+    if ! sudo iptables -C INPUT -i baremetal -p udp -m udp --dport 6230:${VBMC_MAX_PORT} -j ACCEPT 2>/dev/null ; then
+        sudo iptables -I INPUT -i baremetal -p udp -m udp --dport 6230:${VBMC_MAX_PORT} -j ACCEPT
     fi
 fi
 


### PR DESCRIPTION
Currently this is hard-coded and will mean the ports are blocked
when testing with more than 6 nodes in total, ideally we'll move
this to the vm-setup roles in metal3-dev-env (which has the same
issue) but for now this is a quick fix to enable testing with
 more than 3 workers.