### PR TITLE
Use grep instead of jq to get LATEST_CI_IMAGE

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -36,7 +36,7 @@ source $CONFIG
 #
 # See https://openshift-release.svc.ci.openshift.org for release details
 #
-LATEST_CI_IMAGE=$(curl https://openshift-release.svc.ci.openshift.org/api/v1/releasestream/4.3.0-0.ci/latest | jq -r ".pullSpec")
+LATEST_CI_IMAGE=$(curl https://openshift-release.svc.ci.openshift.org/api/v1/releasestream/4.3.0-0.ci/latest | grep -o 'registry.svc.ci.openshift.org[^"]\+')
 export OPENSHIFT_RELEASE_IMAGE="${OPENSHIFT_RELEASE_IMAGE:-$LATEST_CI_IMAGE}"
 export OPENSHIFT_INSTALL_PATH="$GOPATH/src/github.com/openshift/installer"
 


### PR DESCRIPTION
common.sh is sourced at the top of 01_install_requirements.sh, where
jq may not be installed yet.