### PR TITLE
Updates for metal3-dev-env/pull/113

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -20,6 +20,7 @@ export REPO_PATH=${WORKING_DIR}
 sync_repo_and_patch metal3-dev-env https://github.com/metal3-io/metal3-dev-env.git
 pushd ${REPO_PATH}/metal3-dev-env/
 ./centos_install_requirements.sh
+ansible-galaxy install -r vm-setup/requirements.yml
 ANSIBLE_FORCE_COLOR=true ansible-playbook \
   -e "working_dir=$WORKING_DIR" \
   -e "virthost=$HOSTNAME" \
@@ -64,7 +65,6 @@ fi
 # Install Go dependency management tool
 # Using pre-compiled binaries instead of installing from source
 eval "$(go env)"
-export PATH="${GOPATH}/bin:$PATH"
 if ! which dep 2>&1 >/dev/null ; then
     mkdir -p $GOPATH/bin
     curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh

--- a/common.sh
+++ b/common.sh
@@ -2,6 +2,7 @@
 
 eval "$(go env)"
 
+export PATH="${GOPATH}/bin:/usr/local/go/bin:$PATH"
 
 # Ensure if a go program crashes we get a coredump
 #


### PR DESCRIPTION
This PR changed the way go gets installed so we need
to install the required ansible role and update the
PATH.

Note this installs go 1.12 to /usr/local/go but the
packages version still exists elsewhere on the
system paths.

Closes: #837