### PR TITLE
Add mkdir for ocp in 06_create_cluster.sh

### DIFF
--- a/06_create_cluster.sh
+++ b/06_create_cluster.sh
@@ -42,6 +42,7 @@ if [ ! -f ocp/install-config.yaml ]; then
     fi
 
     # Create a master_nodes.json file
+    mkdir -p ocp/
     jq '.nodes[0:3] | {nodes: .}' "${NODES_FILE}" | tee "${MASTER_NODES_FILE}"
 
     # Create install config for openshift-installer


### PR DESCRIPTION
It can be helpful to iterate on ocp_cleanup.sh && 06_create_cluster.sh
for installer testing but currently this fails because the ocp dir is
removed