### PR TITLE
Add override for metal3-dev-env testing

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -16,9 +16,13 @@ if selinuxenabled ; then
     sudo sed -i "s/=enforcing/=permissive/g" /etc/selinux/config
 fi
 
-export REPO_PATH=${WORKING_DIR}
-sync_repo_and_patch metal3-dev-env https://github.com/metal3-io/metal3-dev-env.git
-pushd ${REPO_PATH}/metal3-dev-env/
+
+if [ -z "${METAL3_DEV_ENV}" ]; then
+  export REPO_PATH=${WORKING_DIR}
+  sync_repo_and_patch metal3-dev-env https://github.com/metal3-io/metal3-dev-env.git
+  METAL3_DEV_ENV="${REPO_PATH}/metal3-dev-env/"
+fi
+pushd ${METAL3_DEV_ENV}
 ./centos_install_requirements.sh
 ansible-galaxy install -r vm-setup/requirements.yml
 ANSIBLE_FORCE_COLOR=true ansible-playbook \

--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -33,8 +33,6 @@ if [ ! -z "${VM_NODES_FILE}" ]; then
   exit 1
 fi
 
-VM_SETUP_PATH="${WORKING_DIR}/metal3-dev-env/vm-setup"
-
 ANSIBLE_FORCE_COLOR=true ansible-playbook \
     -e @vm_setup_vars.yml \
     -e "working_dir=$WORKING_DIR" \

--- a/common.sh
+++ b/common.sh
@@ -100,6 +100,15 @@ NODES_FILE=${NODES_FILE:-"${WORKING_DIR}/ironic_nodes.json"}
 NODES_PLATFORM=${NODES_PLATFORM:-"libvirt"}
 MASTER_NODES_FILE=${MASTER_NODES_FILE:-"ocp/master_nodes.json"}
 
+# Optionally set this to a path to use a local dev copy of
+# metal3-dev-env, otherwise it's cloned to $WORKING_DIR
+export METAL3_DEV_ENV=${METAL3_DEV_ENV:-}
+if [ -z "${METAL3_DEV_ENV}" ]; then
+  export VM_SETUP_PATH="${WORKING_DIR}/metal3-dev-env/vm-setup"
+else
+  export VM_SETUP_PATH="${METAL3_DEV_ENV}/vm-setup"
+fi
+
 export NUM_MASTERS=${NUM_MASTERS:-"3"}
 export NUM_WORKERS=${NUM_WORKERS:-"1"}
 export VM_EXTRADISKS=${VM_EXTRADISKS:-"false"}

--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -5,9 +5,10 @@ source logging.sh
 source common.sh
 source utils.sh
 
-export REPO_PATH=${WORKING_DIR}
-sync_repo_and_patch metal3-dev-env https://github.com/metal3-io/metal3-dev-env.git
-VM_SETUP_PATH="${REPO_PATH}/metal3-dev-env/vm-setup"
+if [ -z "${METAL3_DEV_ENV}" ]; then
+  export REPO_PATH=${WORKING_DIR}
+  sync_repo_and_patch metal3-dev-env https://github.com/metal3-io/metal3-dev-env.git
+fi
 
 ANSIBLE_FORCE_COLOR=true ansible-playbook \
     -e @vm_setup_vars.yml \


### PR DESCRIPTION
For development of metal3-dev-env it's convenient to have an
override that forces use of a local checkout instead of the one
cloned under WORKING_DIR, e.g:

export METAL3_DEV_ENV="/home/shardy/metal3-dev-env"