### PR TITLE
Define flavors in vm_setup_vars.yml

### DIFF
--- a/vm_setup_vars.yml
+++ b/vm_setup_vars.yml
@@ -7,8 +7,20 @@ ironic_prefix: "openshift_"
 
 # We enable more memory and masters in dev-scripts compared to the minimal setup
 # in metal3-dev-env
-default_memory: 16384
 num_masters: 3
+num_workers: 1
+flavors:
+  master:
+    memory: 16384
+    disk: 20
+    vcpu: 4
+    extradisks: false
+
+  worker:
+    memory: 8192
+    disk: 20
+    vcpu: 4
+    extradisks: false
 
 # For OpenShift we create some additional DNS records for the API/DNS VIPs
 baremetal_network_cidr: "{{ lookup('env', 'EXTERNAL_SUBNET') | default('192.168.111.0/24', true) }}"


### PR DESCRIPTION
In https://github.com/metal3-io/metal3-dev-env/pull/129/
and https://github.com/metal3-io/metal3-dev-env/pull/102
there are proposals to switch to a single "node" flavor
for metal3-dev-env testing.

Since we require master/worker flavors I proposed the templating
in https://github.com/metal3-io/metal3-dev-env/pull/129 such
that we can override the default flavors map and that's what
is done here - we'll need to land this when metal3-dev-env/129
lands.