### PR TITLE
Assert 'go' command is available before calling `go env`.

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
+export PATH="/usr/local/go/bin:$PATH"
+
 eval "$(go env)"
+
+export PATH="${GOPATH}/bin:$PATH"
 
 # Make dev-scripts work again temporarily
 export KNI_INSTALL_FROM_GIT=true
-
-export PATH="${GOPATH}/bin:/usr/local/go/bin:$PATH"
 
 # Ensure if a go program crashes we get a coredump
 #


### PR DESCRIPTION
If `go` command is not available in default PATH, `go env` call fails,

``` bash
    +++ go env
    common.sh: line 3: go: command not found
    ++ eval ''
```

This change adds extra check to assert `go` binary is available in
default PATH, and if not prepend it with '/usr/local/go/bin'