### PR TITLE
Add option to mirror openshift images

### DIFF
--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -49,6 +49,14 @@ for IMAGE_VAR in $(env | grep "_LOCAL_IMAGE=" | grep -o "^[^=]*") ; do
     echo "RUN sed -i 's%$OLDIMAGE%${!IMAGE_VAR}%g' /release-manifests/*" >> $DOCKERFILE
 done
 
+if [ ! -z "${MIRROR_IMAGES}" ]; then
+    oc adm release mirror \
+       --insecure=true \
+        -a $REGISTRY_AUTH_FILE  \
+        --from $OPENSHIFT_RELEASE_IMAGE \
+        --to $LOCAL_REGISTRY_ADDRESS/localimages/local-release-image
+fi
+
 if [ -f assets/templates/99_local-registry.yaml ] ; then
     build_installer
     sudo podman image build -t $OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE -f $DOCKERFILE

--- a/common.sh
+++ b/common.sh
@@ -37,6 +37,7 @@ fi
 source $CONFIG
 
 export LOCAL_REGISTRY_ADDRESS=${LOCAL_REGISTRY_ADDRESS:-"192.168.111.1:5000"}
+export MIRROR_IMAGES=${MIRROR_IMAGES:-}
 
 #
 # See https://openshift-release.svc.ci.openshift.org for release details

--- a/config_example.sh
+++ b/config_example.sh
@@ -11,6 +11,9 @@ set -x
 #export IRONIC_LOCAL_IMAGE=quay.io/username/ironic
 #export MACHINE_CONFIG_OPERATOR_LOCAL_IMAGE=https://github.com/openshift/machine-config-operator
 
+# Mirror latest ci images to local registry
+#export MIRROR_IMAGES=true
+
 # Switch to upstream metal3-io ironic images instead of openshift ones.
 #export UPSTREAM_IRONIC=true
 

--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -97,6 +97,7 @@ platform:
     dnsVIP: ${DNS_VIP}
     hosts:
 $(master_node_map_to_install_config $NUM_MASTERS)
+$(image_mirror_config)
 pullSecret: |
   $(echo $PULL_SECRET | jq -c .)
 sshKey: |

--- a/utils.sh
+++ b/utils.sh
@@ -185,3 +185,19 @@ function bmo_config_map {
     
     cp ocp/deploy/metal3-config.yaml assets/generated/99_metal3-config.yaml
 }
+
+function image_mirror_config {
+    if [ ! -z "${MIRROR_IMAGES}" ]; then
+        TAGGED=$(echo $OPENSHIFT_RELEASE_IMAGE | sed -e 's/release://')
+        RELEASE=$(echo $OPENSHIFT_RELEASE_IMAGE | grep -o 'registry.svc.ci.openshift.org[^":]\+')
+        cat << EOF
+imageContentSources:
+- mirrors:
+    - ${LOCAL_REGISTRY_ADDRESS}/localimages/local-release-image
+  source: ${RELEASE}
+- mirrors:
+    - ${LOCAL_REGISTRY_ADDRESS}/localimages/local-release-image
+  source: ${TAGGED}
+EOF
+    fi
+}


### PR DESCRIPTION
We add a new `MIRROR_IMAGES` option.  When non-empty, it will use `oc
adm` to mirror openshift images to our local registry.  It will also
modify `install-config.yaml` to add the new mirror.