### PR TITLE
Remove last workaround

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -6,9 +6,6 @@ eval "$(go env)"
 
 export PATH="${GOPATH}/bin:$PATH"
 
-# Make dev-scripts work again temporarily
-export KNI_INSTALL_FROM_GIT=true
-
 # Ensure if a go program crashes we get a coredump
 #
 # To get the dump, use coredumpctl:

--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -49,7 +49,7 @@ function extract_installer() {
 function clone_installer() {
   # Clone repo, if not already present
   if [[ ! -d $OPENSHIFT_INSTALL_PATH ]]; then
-    sync_repo_and_patch go/src/github.com/openshift/installer https://github.com/openshift/installer.git https://patch-diff.githubusercontent.com/raw/openshift/installer/pull/2666.patch
+    sync_repo_and_patch go/src/github.com/openshift/installer https://github.com/openshift/installer.git
   fi
 }
 


### PR DESCRIPTION
RHCOS bump is passing and https://github.com/openshift/installer/pull/2666 to be merged in openshift/installer. We can drop the last workaround when it gets merged and lands in a CI build.