### PR TITLE
WIP prototype running two clusters with shared provisioning network

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 ocp/
+ocp2/
 *.qcow2
 openshift-install.log
 logs/

--- a/13_optional_configure_host_cluster2.sh
+++ b/13_optional_configure_host_cluster2.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -xe
+
+source logging.sh
+source common.sh
+source utils.sh
+source ocp_install_env2.sh
+
+ANSIBLE_FORCE_COLOR=true ansible-playbook \
+    -e @vm_setup_vars.yml \
+    -e @openshift_2_vars.yml \
+    -e "working_dir=${WORKING_DIR}" \
+    -e "virtualbmc_base_port=$VBMC_BASE_PORT" \
+    -e "num_masters=$NUM_MASTERS2" \
+    -e "num_workers=$NUM_WORKERS2" \
+    -e "extradisks=$VM_EXTRADISKS" \
+    -e "virthost=$HOSTNAME" \
+    -e "vm_platform=$NODES_PLATFORM" \
+    -e "manage_baremetal=$MANAGE_BR_BRIDGE" \
+    -e "ironic_prefix=openshift2_" \
+    -i ${VM_SETUP_PATH}/inventory.ini \
+    -b -vvv ${VM_SETUP_PATH}/setup-playbook.yml
+
+if [ "${RHEL8}" = "True" ] ; then
+    ZONE="\nZONE=libvirt"
+fi
+
+if [ "$MANAGE_INT_BRIDGE" == "y" ]; then
+    # Create the baremetal bridge
+    if [ ! -e /etc/sysconfig/network-scripts/ifcfg-baremetal2 ] ; then
+        echo -e "DEVICE=baremetal2\nTYPE=Bridge\nONBOOT=yes\nNM_CONTROLLED=no${ZONE}" | sudo dd of=/etc/sysconfig/network-scripts/ifcfg-baremetal2
+    fi
+    sudo ifdown baremetal2 || true
+    sudo ifup baremetal2
+fi
+
+# restart the libvirt network so it applies an ip to the bridge
+if [ "$MANAGE_BR_BRIDGE" == "y" ] ; then
+    sudo virsh net-destroy baremetal2
+    sudo virsh net-start baremetal2
+fi
+
+# Add firewall rules to ensure the image caches can be reached on the host
+for PORT in 80 5000 ; do
+    if [ "${RHEL8}" = "True" ] ; then
+        sudo firewall-cmd --zone=libvirt --add-port=$PORT/tcp
+        sudo firewall-cmd --zone=libvirt --add-port=$PORT/tcp --permanent
+    else
+        if ! sudo iptables -C INPUT -i baremetal2 -p tcp -m tcp --dport $PORT -j ACCEPT > /dev/null 2>&1; then
+            sudo iptables -I INPUT -i baremetal2 -p tcp -m tcp --dport $PORT -j ACCEPT
+        fi
+    fi
+done
+
+# Allow ipmi to the virtual bmc processes that we just started
+VBMC_MAX_PORT=$((6230 + ${NUM_MASTERS} + ${NUM_MASTERS2} + ${NUM_WORKERS} + ${NUM_WORKERS2} - 1))
+if [ "${RHEL8}" = "True" ] ; then
+    sudo firewall-cmd --zone=libvirt --add-port=6230-${VBMC_MAX_PORT}/udp
+    sudo firewall-cmd --zone=libvirt --add-port=6230-${VBMC_MAX_PORT}/udp --permanent
+else
+    if ! sudo iptables -C INPUT -i baremetal2 -p udp -m udp --dport 6230:${VBMC_MAX_PORT} -j ACCEPT 2>/dev/null ; then
+        sudo iptables -I INPUT -i baremetal2 -p udp -m udp --dport 6230:${VBMC_MAX_PORT} -j ACCEPT
+    fi
+fi

--- a/14_optional_create_cluster2.sh
+++ b/14_optional_create_cluster2.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -x
+set -e
+
+source logging.sh
+source utils.sh
+source common.sh
+source ocp_install_env2.sh
+source rhcos.sh
+
+# Do some PULL_SECRET sanity checking
+if [[ "${OPENSHIFT_RELEASE_IMAGE}" == *"registry.svc.ci.openshift.org"* ]]; then
+    if [[ "${PULL_SECRET}" != *"registry.svc.ci.openshift.org"* ]]; then
+        echo "Please get a valid pull secret for registry.svc.ci.openshift.org."
+        exit 1
+    fi
+fi
+
+if [[ "${PULL_SECRET}" != *"cloud.openshift.com"* ]]; then
+    echo "Please get a valid pull secret for cloud.openshift.com."
+    exit 1
+fi
+
+# NOTE: This is equivalent to the external API DNS record pointing the API to the API VIP
+if [ "$MANAGE_BR_BRIDGE" == "y" ] ; then
+    API_VIP=$(dig +noall +answer "api.${CLUSTER_DOMAIN}" @$(network_ip baremetal2) | awk '{print $NF}')
+    INGRESS_VIP=$(python -c "from ansible.plugins.filter import ipaddr; print(ipaddr.nthhost('"$EXTERNAL_SUBNET"', 4))")
+    echo "address=/api.${CLUSTER_DOMAIN}/${API_VIP}" | sudo tee -a /etc/NetworkManager/dnsmasq.d/openshift.conf
+    echo "address=/.apps.${CLUSTER_DOMAIN}/${INGRESS_VIP}" | sudo tee -a /etc/NetworkManager/dnsmasq.d/openshift.conf
+    sudo systemctl reload NetworkManager
+else
+    API_VIP=$(dig +noall +answer "api.${CLUSTER_DOMAIN}"  | awk '{print $NF}')
+    INGRESS_VIP=$(dig +noall +answer "test.apps.${CLUSTER_DOMAIN}" | awk '{print $NF}')
+fi
+
+if [ ! -f ocp2/install-config.yaml ]; then
+    # Validate there are enough nodes to avoid confusing errors later..
+    NODES_LEN=$(jq '.nodes | length' ${NODES_FILE})
+    if (( $NODES_LEN < ( $NUM_MASTERS2 + $NUM_WORKERS2 ) )); then
+        echo "ERROR: ${NODES_FILE} contains ${NODES_LEN} nodes, but ${NUM_MASTERS2} masters and ${NUM_WORKERS2} workers requested"
+        exit 1
+    fi
+
+    # Create a master_nodes.json file
+    mkdir -p ocp2/
+    jq '.nodes[0:3] | {nodes: .}' "${NODES_FILE}" | tee "${MASTER_NODES_FILE}"
+
+    # Create install config for openshift-installer
+    generate_ocp_install_config ocp2
+fi
+
+# Call openshift-installer to deploy the bootstrap node and masters
+create_cluster ocp2
+
+echo "Cluster up, you can interact with it via oc --config ${KUBECONFIG} <command>"

--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -21,6 +21,30 @@ ANSIBLE_FORCE_COLOR=true ansible-playbook \
     -i ${VM_SETUP_PATH}/inventory.ini \
     -b -vvv ${VM_SETUP_PATH}/teardown-playbook.yml
 
+if sudo virsh list --all | grep -q openshift2; then
+  source ocp_install_env2.sh
+  ANSIBLE_FORCE_COLOR=true ansible-playbook \
+    -e @vm_setup_vars.yml \
+    -e @openshift_2_vars.yml \
+    -e "working_dir=${WORKING_DIR}" \
+    -e "virtualbmc_base_port=$VBMC_BASE_PORT" \
+    -e "num_masters=$NUM_MASTERS2" \
+    -e "num_workers=$NUM_WORKERS2" \
+    -e "extradisks=$VM_EXTRADISKS" \
+    -e "virthost=$HOSTNAME" \
+    -e "vm_platform=$NODES_PLATFORM" \
+    -e "manage_baremetal=$MANAGE_BR_BRIDGE" \
+    -e "ironic_prefix=openshift2_" \
+    -i ${VM_SETUP_PATH}/inventory.ini \
+    -b -vvv ${VM_SETUP_PATH}/teardown-playbook.yml
+
+  if [ "$MANAGE_BR_BRIDGE" == "y" ]; then
+    sudo ifdown baremetal2 || true
+    sudo ip link delete baremetal2 || true
+    sudo rm -f /etc/sysconfig/network-scripts/ifcfg-baremetal2
+  fi
+fi
+
 sudo rm -rf /etc/NetworkManager/dnsmasq.d/openshift.conf /etc/NetworkManager/conf.d/dnsmasq.conf
 # There was a bug in this file, it may need to be recreated.
 # delete the interface as it can cause issues when not rebooting

--- a/ocp_cleanup.sh
+++ b/ocp_cleanup.sh
@@ -14,6 +14,12 @@ if [ -d ocp ]; then
     rm -rf ocp
 fi
 
+if [ -d ocp2 ]; then
+    ocp2/openshift-install --dir ocp2 --log-level=debug destroy bootstrap
+    ocp2/openshift-install --dir ocp2 --log-level=debug destroy cluster
+    rm -rf ocp2
+fi
+
 sudo rm -rf /etc/NetworkManager/dnsmasq.d/openshift.conf
 
 # Cleanup ssh keys for baremetal network

--- a/ocp_install_env2.sh
+++ b/ocp_install_env2.sh
@@ -1,0 +1,114 @@
+eval "$(go env)"
+
+export KUBECONFIG="${SCRIPTDIR}/ocp2/auth/kubeconfig"
+export NUM_MASTERS2=${NUM_MASTERS2:-$NUM_MASTERS}
+export NUM_WORKERS2=${NUM_WORKERS2:-$NUM_WORKERS}
+export VBMC_BASE_PORT=$((6230 + ${NUM_MASTERS} + ${NUM_WORKERS}))
+
+export BASE_DOMAIN=${BASE_DOMAIN2:-test.metalkube.org}
+export CLUSTER_NAME=${CLUSTER_NAME2:-ostest2}
+export CLUSTER_DOMAIN="${CLUSTER_NAME}.${BASE_DOMAIN}"
+export SSH_PUB_KEY="${SSH_PUB_KEY:-$(cat $HOME/.ssh/id_rsa.pub)}"
+export NETWORK_TYPE=${NETWORK_TYPE2:-"OpenShiftSDN"}
+export EXTERNAL_SUBNET=${EXTERNAL_SUBNET2:-"192.168.112.0/24"}
+export DNS_VIP=${DNS_VIP:-"192.168.112.2"}
+
+function extract_command() {
+    local release_image
+    local cmd
+    local outdir
+    local extract_dir
+
+    cmd="$1"
+    release_image="$2"
+    outdir="$3"
+
+    extract_dir=$(mktemp -d "installer--XXXXXXXXXX")
+    pullsecret_file=$(mktemp "pullsecret--XXXXXXXXXX")
+
+    echo "${PULL_SECRET}" > "${pullsecret_file}"
+    oc adm release extract --registry-config "${pullsecret_file}" --command=$cmd --to "${extract_dir}" ${release_image}
+
+    mv "${extract_dir}/${cmd}" "${outdir}"
+    rm -rf "${extract_dir}"
+    rm -rf "${pullsecret_file}"
+}
+
+# Let's always grab the `oc` from the release we're using.
+function extract_oc() {
+    extract_dir=$(mktemp -d "installer--XXXXXXXXXX")
+    extract_command oc "$1" "${extract_dir}"
+    sudo mv "${extract_dir}/oc" /usr/local/bin
+    rm -rf "${extract_dir}"
+}
+
+function extract_installer() {
+    local release_image
+    local outdir
+
+    release_image="$1"
+    outdir="$2"
+
+    extract_command openshift-baremetal-install "$1" "$2"
+}
+
+function clone_installer() {
+  # Clone repo, if not already present
+  if [[ ! -d $OPENSHIFT_INSTALL_PATH ]]; then
+    sync_repo_and_patch go/src/github.com/openshift/installer https://github.com/openshift/installer.git
+  fi
+}
+
+function build_installer() {
+  # Build installer
+  pushd .
+  cd $OPENSHIFT_INSTALL_PATH
+  TAGS="libvirt baremetal" hack/build.sh
+  popd
+}
+
+function generate_ocp_install_config() {
+    local outdir
+
+    outdir="$1"
+
+    deploy_kernel=$(master_node_val 0 "driver_info.deploy_kernel")
+    deploy_ramdisk=$(master_node_val 0 "driver_info.deploy_ramdisk")
+
+    # Always deploy with 0 workers by default.  We do not yet support
+    # automatically deploying workers at install time anyway.  We can scale up
+    # the worker MachineSet after deploying the baremetal-operator
+    #
+    # TODO - Change worker replicas to ${NUM_WORKERS2} once the machine-api-operator
+    # deploys the baremetal-operator
+
+    mkdir -p "${outdir}"
+    cat > "${outdir}/install-config.yaml" << EOF
+apiVersion: v1
+baseDomain: ${BASE_DOMAIN}
+networking:
+  networkType: ${NETWORK_TYPE}
+  machineCIDR: ${EXTERNAL_SUBNET}
+metadata:
+  name: ${CLUSTER_NAME}
+compute:
+- name: worker
+  replicas: 0
+controlPlane:
+  name: master
+  replicas: ${NUM_MASTERS2}
+  platform:
+    baremetal: {}
+platform:
+  baremetal:
+    provisioningBridge: provisioning
+    externalBridge: baremetal2
+    dnsVIP: ${DNS_VIP}
+    hosts:
+$(master_node_map_to_install_config $NUM_MASTERS2)
+pullSecret: |
+  $(echo $PULL_SECRET | jq -c .)
+sshKey: |
+  ${SSH_PUB_KEY}
+EOF
+}

--- a/openshift_2_vars.yml
+++ b/openshift_2_vars.yml
@@ -1,0 +1,21 @@
+networks:
+  - name: provisioning
+    bridge: provisioning
+    forward_mode: bridge
+  - name: baremetal2
+    bridge: baremetal2
+    forward_mode: "{% if manage_baremetal == 'y' %}nat{% else %}bridge{% endif %}"
+    address: "{{ baremetal_network_cidr|nthhost(1) }}"
+    netmask: "{{ baremetal_network_cidr|ipaddr('netmask') }}"
+    dhcp_range:
+      - "{{ baremetal_network_cidr|nthhost(20) }}"
+      - "{{ baremetal_network_cidr|nthhost(60) }}"
+    nat_port_range:
+      - 1024
+      - 65535
+    domain: "{{ cluster_domain }}"
+    dns:
+      hosts: "{{dns_extrahosts | default([])}}"
+      forwarders:
+        - domain: "apps.{{ cluster_domain }}"
+          addr: "127.0.0.1"


### PR DESCRIPTION
Until the installer supports configuring the provisioning subnet, we
may be able to deploy two clusters on the same virthost with only
different external networks, provided the metal3 pod on the first
cluster is disabled after any workers are deployed.

This is pretty hacky atm, but aims to prove if this will be possible