### PR TITLE
Do not curl for release image if we provide it

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -41,7 +41,10 @@ export LOCAL_REGISTRY_ADDRESS=${LOCAL_REGISTRY_ADDRESS:-"192.168.111.1:5000"}
 #
 # See https://openshift-release.svc.ci.openshift.org for release details
 #
-LATEST_CI_IMAGE=$(curl https://openshift-release.svc.ci.openshift.org/api/v1/releasestream/4.4.0-0.ci/latest | grep -o 'registry.svc.ci.openshift.org[^"]\+')
+# if we provide OPENSHIFT_RELEASE_IMAGE, do not curl. This is needed for offline installs
+if [ -z "${OPENSHIFT_RELEASE_IMAGE}" ]; then
+  LATEST_CI_IMAGE=$(curl https://openshift-release.svc.ci.openshift.org/api/v1/releasestream/4.4.0-0.ci/latest | grep -o 'registry.svc.ci.openshift.org[^"]\+')
+fi
 export OPENSHIFT_RELEASE_IMAGE="${OPENSHIFT_RELEASE_IMAGE:-$LATEST_CI_IMAGE}"
 export OPENSHIFT_INSTALL_PATH="$GOPATH/src/github.com/openshift/installer"
 


### PR DESCRIPTION
When running on a disconnected install, the host does not
have access to curl for the image version. But we can provide
it on config file. So avoid looking for that release if
we already are providing it.

Signed-off-by: Yolanda Robla <yroblamo@redhat.com>