### PR TITLE
Remove patch for ironic-machine-os-downloader rename

### DIFF
--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -50,7 +50,7 @@ function extract_installer() {
 function clone_installer() {
   # Clone repo, if not already present
   if [[ ! -d $OPENSHIFT_INSTALL_PATH ]]; then
-    sync_repo_and_patch go/src/github.com/openshift/installer https://github.com/openshift/installer.git https://patch-diff.githubusercontent.com/raw/openshift/installer/pull/2821.patch
+    sync_repo_and_patch go/src/github.com/openshift/installer https://github.com/openshift/installer.git
   fi
 }
 

--- a/run_ci.sh
+++ b/run_ci.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -ex
 
-# temporary
-export KNI_INSTALL_FROM_GIT=true
-
 # grabs files and puts them into $LOGDIR to be saved as jenkins artifacts
 function getlogs(){
     LOGDIR=/home/notstack/dev-scripts/logs


### PR DESCRIPTION
After the installer PR merges (https://github.com/openshift/installer/pull/2821), we must remove this patch.