### PR TITLE
Handle installer move to go 1.13

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -23,6 +23,7 @@ ansible-galaxy install -r vm-setup/requirements.yml
 ANSIBLE_FORCE_COLOR=true ansible-playbook \
   -e "working_dir=$WORKING_DIR" \
   -e "virthost=$HOSTNAME" \
+  -e "go_version=1.13.8" \
   -i vm-setup/inventory.ini \
   -b -vvv vm-setup/install-package-playbook.yml
 popd


### PR DESCRIPTION
This changes go version to 1.13 so we can build installer from source.

https://github.com/openshift/installer/pull/2745 has landed requiring us to use 1.13.
