### PR TITLE
Don't hardcode oc_version

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -32,7 +32,7 @@ if sudo systemctl is-active docker-distribution.service; then
 fi
 
 # Install oc client
-oc_version=4.4
+oc_version=${OPENSHIFT_VERSION}
 oc_tools_dir=$HOME/oc-${oc_version}
 oc_tools_local_file=openshift-client-${oc_version}.tar.gz
 if which oc 2>&1 >/dev/null ; then

--- a/common.sh
+++ b/common.sh
@@ -55,6 +55,7 @@ if [ -z "${OPENSHIFT_RELEASE_IMAGE}" ]; then
   LATEST_CI_IMAGE=$(curl https://openshift-release.svc.ci.openshift.org/api/v1/releasestream/4.4.0-0.ci/latest | grep -o 'registry.svc.ci.openshift.org[^"]\+')
 fi
 export OPENSHIFT_RELEASE_IMAGE="${OPENSHIFT_RELEASE_IMAGE:-$LATEST_CI_IMAGE}"
+export OPENSHIFT_VERSION=$(echo $OPENSHIFT_RELEASE_IMAGE | sed "s/.*:\([[:digit:]].[[:digit:]]\).*/\1/")
 export OPENSHIFT_INSTALL_PATH="$GOPATH/src/github.com/openshift/installer"
 
 # Switch Container Images to upstream, Installer defaults these to the openshift version


### PR DESCRIPTION
Otherwise we re-download oc every deploy when testing with 4.3 builds