### PR TITLE
Remove authfile prior to initial podman login

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -169,6 +169,9 @@ if [ "$MANAGE_BR_BRIDGE" == "y" ] ; then
   fi
 fi
 
+# Remove any previous file, or podman login panics when reading the
+# blank authfile with a "assignment to entry in nil map" error
+rm -f ${REGISTRY_CREDS}
 if [[ ! -z "${MIRROR_IMAGES}" || $(env | grep "_LOCAL_IMAGE=") ]]; then
     # create authfile for local registry
     sudo podman login --authfile ${REGISTRY_CREDS} \


### PR DESCRIPTION
This fails with an error like:

panic: assignment to entry in nil map

When REGISTRY_CREDS contains {} - it seems that
podman login reads this file and panics due to the empty
content, but having a non-existent file works fine.