### PR TITLE
Always use local release with MIRROR_IMAGES

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -83,9 +83,12 @@ if [ -z "$KNI_INSTALL_FROM_GIT" ]; then
 fi
 
 if env | grep -q "_LOCAL_IMAGE=" ; then
+    export MIRROR_IMAGES=true
+fi
+
+if [ -n "$MIRROR_IMAGES" ]; then
     # We're going to be using a locally modified release image
     export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="${LOCAL_REGISTRY_ADDRESS}:${LOCAL_REGISTRY_PORT}/localimages/local-release-image:latest"
-    export MIRROR_IMAGES=true
 fi
 
 # Set variables


### PR DESCRIPTION
Previously [0] would set the release override to the ci image instead
of the local one that we need to use when mirroring. This change moves
the logic for setting it into a common location where the image
override will be set correctly regardless of what combination of env
vars is in use.

0: https://github.com/openshift-metal3/dev-scripts/blob/1536fdeaeac964ecc27e876ec3e509e09563b93d/common.sh#L82