### PR TITLE
Define default for KNI_INSTALL_FROM_GIT

### DIFF
--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -ex
+set -euxo pipefail
 
 source logging.sh
 source common.sh

--- a/common.sh
+++ b/common.sh
@@ -47,6 +47,9 @@ export REGISTRY_PASS=${REGISTRY_PASS:-ocp-pass}
 export REGISTRY_DIR=${REGISTRY_DIR:-$WORKING_DIR/registry}
 export REGISTRY_CREDS=${REGISTRY_CREDS:-$HOME/private-mirror.json}
 
+# Set this variable to build the installer from source
+export KNI_INSTALL_FROM_GIT=${KNI_INSTALL_FROM_GIT:-}
+
 #
 # See https://openshift-release.svc.ci.openshift.org for release details
 #


### PR DESCRIPTION
This is undefined as exposed by setting
set -euxo pipefail in the 04 script.

Setting that is also desirable because
currently we ignore any failure in the
oc adm release mirror because the results
are piped to tee.