### PR TITLE
Run ifup on provisioning bridge after bouncing interface

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -86,6 +86,9 @@ if [ "$MANAGE_PRO_BRIDGE" == "y" ]; then
         echo -e "DEVICE=$PRO_IF\nTYPE=Ethernet\nONBOOT=yes\nNM_CONTROLLED=no\nBRIDGE=provisioning" | sudo dd of=/etc/sysconfig/network-scripts/ifcfg-$PRO_IF
         sudo ifdown $PRO_IF || true
         sudo ifup $PRO_IF
+        # Need to ifup the provisioning bridge again because ifdown $PRO_IF
+        # will bring down the bridge as well.
+        sudo ifup provisioning
     fi
 fi
 


### PR DESCRIPTION
On RHEL 8, when ifdown is run on a bridge's only (or last up) interface,
then the bridge is deleted. However, when ifup is run on the bridge's
interface, it is not correspondingly run on the bridge itself.

See:
https://github.com/fedora-sysv/initscripts/blob/rhel8-branch/network-scripts/ifdown-eth#L144

Since the provisioning interface is bounced with ifup/ifdown after
bringing the bridge up, then the bridge itself ends up not existing.
This patch adds an additional call to ifup the provisioning bridge after
bouncing the interface.

Signed-off-by: James Slagle <james.slagle@gmail.com>