### PR TITLE
ocp_cleanup: Remove any stale .ign volumes

### DIFF
--- a/ocp_cleanup.sh
+++ b/ocp_cleanup.sh
@@ -35,6 +35,10 @@ for vm in $(sudo virsh list --all --name | grep "^${CLUSTER_NAME}.*bootstrap"); 
   sudo virsh destroy $vm
   sudo virsh undefine $vm --remove-all-storage
 done
+# The .ign volume isn't deleted via --remove-all-storage
+for v in $(sudo virsh vol-list --pool default | grep "^${CLUSTER_NAME}.*bootstrap" | awk '{print $1}'); do
+  sudo virsh vol-delete $v --pool default
+done
 
 if [ -d assets/generated ]; then
   rm -rf assets/generated


### PR DESCRIPTION
These can get left as the --remove-all-storage doesn't remove them
(they're passed via -fw-cfg not strictly owned by the domain).