### PR TITLE
Fix some issues calculated the openshift version

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -37,10 +37,9 @@ oc_tools_dir=$HOME/oc-${oc_version}
 oc_tools_local_file=openshift-client-${oc_version}.tar.gz
 if which oc 2>&1 >/dev/null ; then
   oc_git_version=$(oc version -o json | jq -r '.clientVersion.gitVersion')
-  oc_actual_version=${oc_git_version#v*}
-  oc_major_minor="${oc_actual_version%\.[0-9]*}"
+  oc_actual_version=$(echo "${oc_git_version}" | sed "s/.*-\([[:digit:]]\.[[:digit:]]\)\.[[:digit:]]-.*/\1/")
 fi
-if [ ! -f ${oc_tools_dir}/${oc_tools_local_file} ] || [ "$oc_major_minor" != "$oc_version" ]; then
+if [ ! -f ${oc_tools_dir}/${oc_tools_local_file} ] || [ "$oc_actual_version" != "$oc_version" ]; then
   mkdir -p ${oc_tools_dir}
   cd ${oc_tools_dir}
   wget https://mirror.openshift.com/pub/openshift-v4/clients/oc/${oc_version}/linux/oc.tar.gz -O ${oc_tools_local_file}

--- a/common.sh
+++ b/common.sh
@@ -60,7 +60,7 @@ if [ -z "${OPENSHIFT_RELEASE_IMAGE:-}" ]; then
   LATEST_CI_IMAGE=$(curl https://openshift-release.svc.ci.openshift.org/api/v1/releasestream/4.4.0-0.ci/latest | grep -o 'registry.svc.ci.openshift.org[^"]\+')
 fi
 export OPENSHIFT_RELEASE_IMAGE="${OPENSHIFT_RELEASE_IMAGE:-$LATEST_CI_IMAGE}"
-export OPENSHIFT_VERSION=$(echo $OPENSHIFT_RELEASE_IMAGE | sed "s/.*:\([[:digit:]].[[:digit:]]\).*/\1/")
+export OPENSHIFT_VERSION=$(echo $OPENSHIFT_RELEASE_IMAGE | sed "s/.*:\([[:digit:]]\.[[:digit:]]\).*/\1/")
 export OPENSHIFT_INSTALL_PATH="$GOPATH/src/github.com/openshift/installer"
 
 # Switch Container Images to upstream, Installer defaults these to the openshift version


### PR DESCRIPTION
Modify the way we calculate the actual OC version - the previous string manipulation doesn't work so we ended up downloading the client every time.  Also make a similar change to improve the regex used to extract OPENSHIFT_VERSION from the release pullspec.