### PR TITLE
Workaround error with podman when XDG_RUNTIME_DIR is set

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -6,6 +6,9 @@ eval "$(go env)"
 
 export PATH="${GOPATH}/bin:$PATH"
 
+# Workaround for https://github.com/containers/libpod/issues/3463
+unset XDG_RUNTIME_DIR
+
 # Ensure if a go program crashes we get a coredump
 #
 # To get the dump, use coredumpctl:


### PR DESCRIPTION
On EL8 and podman, you get an error like this when running as a non-root-user:

```
sudo -E podman pull --authfile combined-pullsecret--l08EkMYeFz registry.svc.ci.openshift.org/ocp/release:4.4.0-0.ci-2020-01-23-160905
Error: could not get runtime: error creating runtime static files directory /var/lib/containers/storage/libpod: mkdir /var/lib/containers/storage: permission denied
```

This is due to XDG_RUNTIME_DIR variable being set, and us copying the
user's environment with sudo -E. This is fixed in podman 1.4.4 or later,
however RHEL8 is only at 1.4.2 and it doesn't look like the fix has
been backported, at least as of 1.4.2-6.