### PR TITLE
Add sanity checks to verify the working dir

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 set -ex
 
+
 source logging.sh
 source common.sh
+source sanitychecks.sh
 source utils.sh
 source ocp_install_env.sh
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Run sshuttle:
 sshuttle -r <user>@<virthost> 192.168.111.0/24
 ```
 
-
+To access the web Console use the `kubeadmin` user, and password generated in the `ocp/auth/kubeadmin-password` file.
 
 
 ## Interacting with Ironic directly

--- a/common.sh
+++ b/common.sh
@@ -65,7 +65,11 @@ export MIRROR_IP=${MIRROR_IP:-$PROVISIONING_HOST_IP}
 # mirror images for installation in restricted network
 export MIRROR_IMAGES=${MIRROR_IMAGES:-}
 
+# The dev-scripts working directory
 WORKING_DIR=${WORKING_DIR:-"/opt/dev-scripts"}
+
+# The minimum amount of space required for a default installation, expressed in GB
+MIN_SPACE_REQUIRED=${MIN_SPACE_REQUIRED:=80}
 
 # variables for local registry configuration
 export LOCAL_REGISTRY_PORT=${LOCAL_REGISTRY_PORT:-"5000"}

--- a/sanitychecks.sh
+++ b/sanitychecks.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+function verifyWorkingDirIsWorldReadable {
+  if [ ! -d $WORKING_DIR ]; then
+    echo "WORKING_DIR ${WORKING_DIR} is not a directory"
+    exit 1
+  fi
+
+  if [ ! -r $WORKING_DIR ]; then
+    echo "Unable to access WORKING_DIR ${WORKING_DIR}"
+    exit 1
+  fi
+
+  if find "${WORKING_DIR}" -maxdepth 0 ! -perm -o=r | grep . ; then
+    echo "The WORKING_DIR ${WORKING_DIR} is not world-readable!"
+    exit 1 
+  fi
+}
+
+function verifyFreeSpace {
+  AVAIL=$(df -h --output=avail -B 1G $WORKING_DIR | tail -n 1)
+
+  if (( $AVAIL < $MIN_SPACE_REQUIRED )); then 
+    echo "Not enough free space, at least MIN_SPACE_REQUIRED=${MIN_SPACE_REQUIRED} GB required"
+    exit 1
+  fi
+}
+
+verifyFreeSpace
+verifyWorkingDirIsWorldReadable
+
+echo "Sanity checks passed"


### PR DESCRIPTION
This PR addresses issue #895.

A couple of sanity checks have been added to verify that:
1) The WORKING_DIR is world readable
2) Enough free space is available to successfully setup dev-scripts. Since this value can be difficult to estimate precisely, it can be configured via the MIN_SPACE_REQUIRED setting, by default set to 80Gb

To minimize the impact on the existing code, these checks have been placed in a separate script invoked just after commons.sh