### PR TITLE
Specify provisioning interface in install config

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -121,6 +121,8 @@ ROOT_DISK_NAME=${ROOT_DISK_NAME-"/dev/sda"}
 export PROVISIONING_NETWORK=${PROVISIONING_NETWORK:-172.22.0.0/24}
 export PROVISIONING_NETMASK=${PROVISIONING_NETMASK:-$(ipcalc --netmask $PROVISIONING_NETWORK | cut -d= -f2)}
 
+export CLUSTER_PRO_IF=${CLUSTER_PRO_IF:-enp1s0}
+
 # ipcalc on CentOS 7 doesn't support the 'minaddr' option, so use python
 # instead to get the first address in the network:
 export PROVISIONING_HOST_IP=${PROVISIONING_HOST_IP:-$(python -c "import ipaddress; print(next(ipaddress.ip_network(u\"$PROVISIONING_NETWORK\").hosts()))")}

--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -103,6 +103,7 @@ controlPlane:
     baremetal: {}
 platform:
   baremetal:
+    provisioningNetworkInterface: $CLUSTER_PRO_IF
     bootstrapOSImage: http://${MIRROR_IP}/images/${MACHINE_OS_BOOTSTRAP_IMAGE_NAME}?sha256=${MACHINE_OS_BOOTSTRAP_IMAGE_UNCOMPRESSED_SHA256}
     clusterOSImage: http://${MIRROR_IP}/images/${MACHINE_OS_IMAGE_NAME}?sha256=${MACHINE_OS_IMAGE_SHA256}
     provisioningNetworkCIDR: $PROVISIONING_NETWORK


### PR DESCRIPTION
Since the installer and MAO changes have merged, we're now using the
configurable provisioning interface from the installer, but the default
is wrong for dev-scripts.

https://github.com/openshift-metal3/dev-scripts/pull/897 is a more complete solution, getting rid of most of the config map, but it's going to be more complicated to land. I'm trying to install workers in the install and we're hitting timeouts. I'm going need to introduce a platform-specific 60 minute timeout for baremetal...which is going to be very controversial.
