### PR TITLE
[release-4.3] Make dnsmasq listed on IPv6

### DIFF
--- a/06_create_cluster.sh
+++ b/06_create_cluster.sh
@@ -31,6 +31,7 @@ if [ "$MANAGE_BR_BRIDGE" == "y" ] ; then
     INGRESS_VIP=$(python -c "from ansible.plugins.filter import ipaddr; print(ipaddr.nthhost('"$EXTERNAL_SUBNET"', 4))")
     echo "address=/api.${CLUSTER_DOMAIN}/${API_VIP}" | sudo tee -a /etc/NetworkManager/dnsmasq.d/openshift.conf
     echo "address=/.apps.${CLUSTER_DOMAIN}/${INGRESS_VIP}" | sudo tee -a /etc/NetworkManager/dnsmasq.d/openshift.conf
+    echo "listen-address=::1" | sudo tee -a /etc/NetworkManager/dnsmasq.d/openshift.conf
     sudo systemctl reload NetworkManager
 else
     if [[ $EXTERNAL_SUBNET =~ .*:.* ]]; then


### PR DESCRIPTION
The default configuration listens on IPv4 only.  With this
configuration, it seems to be listening on both IPv4 and IPv6
(localhost), so this should be a safe default in all cases for
dev-scripts.