### PR TITLE
Allow for RELEASE_IMAGE URL with a "-"

### DIFF
--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -56,7 +56,7 @@ if [ ! -z "${MIRROR_IMAGES}" ]; then
 
     EXTRACT_DIR=$(mktemp -d "mirror-installer--XXXXXXXXXX")
 
-    TAG=$( echo $OPENSHIFT_RELEASE_IMAGE | sed -e 's/[[:alnum:]/.]*release://' )
+    TAG=$( echo $OPENSHIFT_RELEASE_IMAGE | sed -e 's/[[:alnum:]/.-]*release://' )
     MIRROR_LOG_FILE=/tmp/tmp_image_mirror-${TAG}.log
 
     oc adm release mirror \

--- a/utils.sh
+++ b/utils.sh
@@ -210,7 +210,7 @@ function generate_templates {
 
 function image_mirror_config {
     if [ ! -z "${MIRROR_IMAGES}" ]; then
-        TAG=$( echo $OPENSHIFT_RELEASE_IMAGE | sed -e 's/[[:alnum:]/.]*release://' )
+        TAG=$( echo $OPENSHIFT_RELEASE_IMAGE | sed -e 's/[[:alnum:]/.-]*release://' )
         TAGGED=$(echo $OPENSHIFT_RELEASE_IMAGE | sed -e 's/release://')
         RELEASE=$(echo $OPENSHIFT_RELEASE_IMAGE | grep -o 'registry.svc.ci.openshift.org[^":]\+')
         INDENTED_CERT=$( cat $REGISTRY_DIR/certs/registry.crt | awk '{ print " ", $0 }' )


### PR DESCRIPTION
In openshift CI the URL takes the form
registry.svc.ci.openshift.org/ci-op-45stc91l/release:latest

we need to allow for the "-"'s in ci-op-45stc91l