### PR TITLE
Restore 4.3 compatability, remove configmap in 4.4

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -34,7 +34,7 @@ fi
 
 # Install oc client - unless we're in openshift CI
 if [[ -z "$OPENSHIFT_CI" ]]; then
-  oc_version=${OPENSHIFT_VERSION:-$(echo $OPENSHIFT_RELEASE_IMAGE | sed "s/.*:\([[:digit:]]\.[[:digit:]]\).*/\1/")}
+  oc_version=${OPENSHIFT_VERSION}
   oc_tools_dir=$HOME/oc-${oc_version}
   oc_tools_local_file=openshift-client-${oc_version}.tar.gz
   if which oc 2>&1 >/dev/null ; then

--- a/common.sh
+++ b/common.sh
@@ -87,6 +87,12 @@ fi
 export OPENSHIFT_RELEASE_IMAGE="${OPENSHIFT_RELEASE_IMAGE:-$LATEST_CI_IMAGE}"
 export OPENSHIFT_INSTALL_PATH="$GOPATH/src/github.com/openshift/installer"
 
+# CI images don't have version numbers
+export OPENSHIFT_CI=${OPENSHIFT_CI:-""}
+if [[ -z "$OPENSHIFT_CI" ]]; then
+  export OPENSHIFT_VERSION=${OPENSHIFT_VERSION:-$(echo $OPENSHIFT_RELEASE_IMAGE | sed "s/.*:\([[:digit:]]\.[[:digit:]]\).*/\1/")}
+fi
+
 # Switch Container Images to upstream, Installer defaults these to the openshift version
 if [ "${UPSTREAM_IRONIC:-false}" != "false" ] ; then
     export IRONIC_LOCAL_IMAGE=${IRONIC_LOCAL_IMAGE:-"quay.io/metal3-io/ironic:master"}

--- a/metal3-config.yaml.template
+++ b/metal3-config.yaml.template
@@ -4,4 +4,13 @@ metadata:
   name: metal3-config
   namespace: openshift-machine-api
 data:
+  http_port: "6180"
+  provisioning_interface: {{.ProvisioningInterface}}
+  provisioning_ip: {{.ProvisioningIP}}
+  dhcp_range: {{.ProvisioningDHCPRange}}
+  deploy_kernel_url: "http://{{.ClusterProvisioningURLHost}}:6180/images/ironic-python-agent.kernel"
+  deploy_ramdisk_url: "http://{{.ClusterProvisioningURLHost}}:6180/images/ironic-python-agent.initramfs"
+  ironic_endpoint: "http://{{.ClusterProvisioningURLHost}}:6385/v1/"
+  ironic_inspector_endpoint: "http://{{.ClusterProvisioningURLHost}}:5050/v1/"
+  cache_url: "http://192.168.111.1/images"
   rhcos_image_url: "{{.MachineOSImageURL}}"

--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -54,6 +54,16 @@ function build_installer() {
   popd
 }
 
+# FIXME(stbenjam): This is not available in 4.3 (yet)
+function networking_configuration() {
+  if [[ "$OPENSHIFT_VERSION" != "4.3" ]]; then
+cat <<EOF
+    provisioningNetworkCIDR: $PROVISIONING_NETWORK
+    provisioningNetworkInterface: $CLUSTER_PRO_IF
+EOF
+  fi
+}
+
 function generate_ocp_install_config() {
     local outdir
 
@@ -97,10 +107,9 @@ controlPlane:
     baremetal: {}
 platform:
   baremetal:
-    provisioningNetworkInterface: $CLUSTER_PRO_IF
+$(network_configuration)
     bootstrapOSImage: http://${MIRROR_IP}/images/${MACHINE_OS_BOOTSTRAP_IMAGE_NAME}?sha256=${MACHINE_OS_BOOTSTRAP_IMAGE_UNCOMPRESSED_SHA256}
     clusterOSImage: http://${MIRROR_IP}/images/${MACHINE_OS_IMAGE_NAME}?sha256=${MACHINE_OS_IMAGE_SHA256}
-    provisioningNetworkCIDR: $PROVISIONING_NETWORK
     dnsVIP: ${DNS_VIP}
     hosts:
 $(node_map_to_install_config_hosts $NUM_MASTERS 0 master)

--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -55,7 +55,7 @@ function build_installer() {
 }
 
 # FIXME(stbenjam): This is not available in 4.3 (yet)
-function networking_configuration() {
+function network_configuration() {
   if [[ "$OPENSHIFT_VERSION" != "4.3" ]]; then
 cat <<EOF
     provisioningNetworkCIDR: $PROVISIONING_NETWORK

--- a/run_ci.sh
+++ b/run_ci.sh
@@ -150,7 +150,7 @@ fi
 
 # Run dev-scripts
 set -o pipefail
-timeout -s 9 105m make |& ts "%b %d %H:%M:%S | " |& sed -e 's/.*auths.*/*** PULL_SECRET ***/g'
+timeout -s 9 120m make |& ts "%b %d %H:%M:%S | " |& sed -e 's/.*auths.*/*** PULL_SECRET ***/g'
 
 # Deployment is complete, but now wait to ensure the worker node comes up.
 export KUBECONFIG=ocp/auth/kubeconfig

--- a/utils.sh
+++ b/utils.sh
@@ -199,11 +199,16 @@ function generate_templates {
     # metal3-config.yaml
     mkdir -p ocp/deploy
 	  go get github.com/apparentlymart/go-cidr/cidr github.com/openshift/installer/pkg/ipnet
-    go run metal3-templater.go metal3-config.yaml.template $PROVISIONING_NETWORK $MACHINE_OS_IMAGE_URL > ocp/deploy/metal3-config.yaml
-    cp ocp/deploy/metal3-config.yaml assets/generated/99_metal3-config.yaml
+
+    if [[ "$OPENSHIFT_VERSION" == "4.3" ]]; then
+      go run metal3-templater.go metal3-config.yaml.template "$CLUSTER_PRO_IF" "$PROVISIONING_NETWORK" "$MACHINE_OS_IMAGE_URL" > ocp/deploy/metal3-config.yaml
+      cp ocp/deploy/metal3-config.yaml assets/generated/99_metal3-config.yaml
+    else
+      echo "OpenShift Version is > 4.3; skipping config map"
+    fi
 
     # clouds.yaml
-    go run metal3-templater.go clouds.yaml.template $PROVISIONING_NETWORK $MACHINE_OS_IMAGE_URL > clouds.yaml
+    go run metal3-templater.go clouds.yaml.template "$CLUSTER_PRO_IF" "$PROVISIONING_NETWORK" "$MACHINE_OS_IMAGE_URL" > clouds.yaml
 }
 
 function image_mirror_config {


### PR DESCRIPTION
In 4.4, we will no longer require any configmap at all. In 4.3 however,
we still need to provide the full configmap, as well as exclude the
install-config parameters that haven't been backported yet