### PR TITLE
Stop using install-config.yaml.tmp

### DIFF
--- a/utils.sh
+++ b/utils.sh
@@ -40,7 +40,6 @@ function create_cluster() {
     # Enable terraform debug logging
     export TF_LOG=DEBUG
 
-    cp ${assets_dir}/install-config.yaml{,.tmp}
     $OPENSHIFT_INSTALLER --dir "${assets_dir}" --log-level=debug create manifests
 
     generate_assets
@@ -50,7 +49,6 @@ function create_cluster() {
     mkdir -p ${assets_dir}/openshift
     cp -rf assets/generated/*.yaml ${assets_dir}/openshift
 
-    cp ${assets_dir}/install-config.yaml{.tmp,}
     if [ ! -z "${IGNITION_EXTRA:-}" ]; then
       $OPENSHIFT_INSTALLER --dir "${assets_dir}" --log-level=debug create ignition-configs
       if ! jq . ${IGNITION_EXTRA}; then


### PR DESCRIPTION
In dev-scripts we copy install-config.yaml to a temp file, as the
installer deletes it after it's consumed. We do not need to do this;
the installer keeps a copy of the install-config in it's generated
assets. It can be recovered with `create install-config` command, if
needed.

Between `create manifests` and `create cluster`, we restore our original
file. The installer reads it twice. However, if there's *any*
discrepancy at all, then the installer thinks things are dirty and
regenerates all of the assets (see error below). And the two versions
can differ, as the installer modifies it!! For example, due to the
presence of deprecated parameters that need converting.

```
level=warning msg="Discarding the Openshift Manifests that was provided in the target directory because its dependencies are dirty and it needs to be regenerated"
```

When the installer regenerates assets, it does this *without* the user's
customized manifests as they've all been discarded, so you end up losing
the metal3-config and the NTP configurations. This is the source of the current dev-scripts failures.