### PR TITLE
Remove tripleo repos when cleaning

### DIFF
--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -21,7 +21,7 @@ ANSIBLE_FORCE_COLOR=true ansible-playbook \
     -i ${VM_SETUP_PATH}/inventory.ini \
     -b -vvv ${VM_SETUP_PATH}/teardown-playbook.yml
 
-sudo rm -rf /etc/NetworkManager/dnsmasq.d/openshift.conf /etc/NetworkManager/conf.d/dnsmasq.conf
+sudo rm -rf /etc/NetworkManager/dnsmasq.d/openshift.conf /etc/NetworkManager/conf.d/dnsmasq.conf /etc/yum.repos.d/delorean*
 # There was a bug in this file, it may need to be recreated.
 # delete the interface as it can cause issues when not rebooting
 if [ "$MANAGE_PRO_BRIDGE" == "y" ]; then


### PR DESCRIPTION
These are added as part of the dev-scripts run, but they aren't
removed by make clean. This is currently causing failures due to a
dependency issue between epel and tripleo.[0] Removing them when
cleaning should fix the problem.

0: #922