### PR TITLE
Version local registry cert files

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -73,6 +73,7 @@ export REGISTRY_USER=${REGISTRY_USER:-ocp-user}
 export REGISTRY_PASS=${REGISTRY_PASS:-ocp-pass}
 export REGISTRY_DIR=${REGISTRY_DIR:-$WORKING_DIR/registry}
 export REGISTRY_CREDS=${REGISTRY_CREDS:-$HOME/private-mirror.json}
+export REGISTRY_CRT=registry.1.crt
 
 # Set this variable to build the installer from source
 export KNI_INSTALL_FROM_GIT=${KNI_INSTALL_FROM_GIT:-}


### PR DESCRIPTION
We only want to generate these cert files when necessary, either on
a new deployment of the registry or when the cert files change.
The previous check for existence meant the latter case wasn't handled
correctly. Even if we fixed that somehow, the md5 check later wasn't
effective either because the directory is bind mounted into the
container so we're essentially checking that the md5 of the file
matches itself.

To address these issues, I've added a version number to the cert and
key files for the registry. If/when we make further changes to the
cert configuration for the registry we just need to bump that version
to force an update of the registry. The registry restart is also
explicitly requested any time the certs are re-generated so we don't
have to try to figure out which cert is in use.

It's possible we could try to inspect the existing cert for differences
with the desired cert, but that would be more complicated and I'm not
sure it would be less error-prone than this approach.