### PR TITLE
Don't always install operator-sdk

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -50,10 +50,12 @@ if [[ -z "$OPENSHIFT_CI" ]]; then
   fi
 fi
 
-# Install operator-sdk
-if ! which operator-sdk 2>&1 >/dev/null ; then
-    sudo wget https://github.com/operator-framework/operator-sdk/releases/download/v0.9.0/operator-sdk-v0.9.0-x86_64-linux-gnu -O /usr/local/bin/operator-sdk
-    sudo chmod 755 /usr/local/bin/operator-sdk
+if [ ! -z "${INSTALL_OPERATOR_SDK:-}" ]; then
+    # Install operator-sdk
+    if ! which operator-sdk 2>&1 >/dev/null ; then
+        sudo wget https://github.com/operator-framework/operator-sdk/releases/download/v0.9.0/operator-sdk-v0.9.0-x86_64-linux-gnu -O /usr/local/bin/operator-sdk
+        sudo chmod 755 /usr/local/bin/operator-sdk
+    fi
 fi
 
 # Install Go dependency management tool

--- a/config_example.sh
+++ b/config_example.sh
@@ -102,3 +102,6 @@ set -x
 
 # configure location of mirror's creds
 #export REGISTRY_CREDS=${REGISTRY_CREDS:-$USER/private-mirror.json}
+
+# Install operator-sdk for local testing of baremetal-operator
+#export INSTALL_OPERATOR_SDK=1

--- a/metal3-dev/run.sh
+++ b/metal3-dev/run.sh
@@ -1,5 +1,10 @@
 #!/bin/bash -xe
 
+if ! which operator-sdk 2>&1 >/dev/null ; then
+    echo "Did not find operator-sdk, set INSTALL_OPERATOR_SDK=1 in config_$USER.sh"
+    exit 1
+fi
+
 bmo_path=$GOPATH/src/github.com/metal3-io/baremetal-operator
 if [ ! -d $bmo_path ]; then
     echo "Did not find $bmo_path"


### PR DESCRIPTION
This is only required when running the BMO locally so
lets only install it when needed - this saves us several
minutes in every CI run :)