### PR TITLE
Fix world-readable check in sanitychecks.sh

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -68,9 +68,6 @@ export MIRROR_IMAGES=${MIRROR_IMAGES:-}
 # The dev-scripts working directory
 WORKING_DIR=${WORKING_DIR:-"/opt/dev-scripts"}
 
-# The minimum amount of space required for a default installation, expressed in GB
-MIN_SPACE_REQUIRED=${MIN_SPACE_REQUIRED:=80}
-
 # variables for local registry configuration
 export LOCAL_REGISTRY_PORT=${LOCAL_REGISTRY_PORT:-"5000"}
 export REGISTRY_USER=${REGISTRY_USER:-ocp-user}

--- a/sanitychecks.sh
+++ b/sanitychecks.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+set -euxo pipefail
+
+# The minimum amount of space required for a default installation, expressed in GB
+MIN_SPACE_REQUIRED=${MIN_SPACE_REQUIRED:=80}
+
 function verifyWorkingDirIsWorldReadable {
   if [ ! -d $WORKING_DIR ]; then
     echo "WORKING_DIR ${WORKING_DIR} is not a directory"
@@ -11,7 +16,7 @@ function verifyWorkingDirIsWorldReadable {
     exit 1
   fi
 
-  if find "${WORKING_DIR}" -maxdepth 0 ! -perm -o=r | grep . ; then
+  if ! sudo -u nobody test -r ${WORKING_DIR}; then
     echo "The WORKING_DIR ${WORKING_DIR} is not world-readable!"
     exit 1 
   fi
@@ -26,7 +31,7 @@ function verifyFreeSpace {
   fi
 }
 
-verifyFreeSpace
 verifyWorkingDirIsWorldReadable
+verifyFreeSpace
 
 echo "Sanity checks passed"


### PR DESCRIPTION
This issue was mentioned in #900 but I missed it when
merging - we need to ensure world-readable access to
the entire path, not only the $WORKING_DIR which may
be a subdirectory.

Also made the script executable and moved a variable to
enable easier local testing, and reversed the order of
the size and access test (the size test will always fail
if the directory is not readable, so we should check for
access first).