### PR TITLE
Use a better value for $PS4

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -2,6 +2,9 @@
 
 export PATH="/usr/local/go/bin:$PATH"
 
+# Set a PS4 value which logs the script name and line #.
+export PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+
 eval "$(go env)"
 
 export PATH="${GOPATH}/bin:$PATH"


### PR DESCRIPTION
Sets a value for $PS4 which will log the script name and line number,
and function name (if applicable).

As most of the scripts already run -x, this doesn't really add any extra
verbosity and is very helpful when reviewing logs and failures.