### PR TITLE
Always export RHEL8 var

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -207,6 +207,7 @@ if [[ ${VER} -ne 7 ]] && [[ ${VER} -ne 8 ]]; then
   exit 1
 fi
 
+export RHEL8=""
 if grep -q "Red Hat Enterprise Linux release 8" /etc/redhat-release 2>/dev/null ; then
     export RHEL8="True"
 fi


### PR DESCRIPTION
The RHEL8 var comparison is used later to check
for the right OS, but the var is just defined if
we are on the RHEL8 case. Be sure to always export
this var as false before, so we have it correctly
defined and do not fail the comparison later.

Signed-off-by: Yolanda Robla <yroblamo@redhat.com>