### PR TITLE
Add new setting to disable certificate verification

### DIFF
--- a/ironic_hosts.json.example
+++ b/ironic_hosts.json.example
@@ -9,7 +9,8 @@
         "password": "passw0rd",
         "address": "ipmi://1.1.1.1:1234",
         "deploy_kernel": "http://172.22.0.2/images/ironic-python-agent.kernel",
-        "deploy_ramdisk": "http://172.22.0.2/images/ironic-python-agent.initramfs"
+        "deploy_ramdisk": "http://172.22.0.2/images/ironic-python-agent.initramfs",
+        "disable_certificate_verification": false
       },
       "ports": [{
         "address": "09:e1:e4:56:44:e5",
@@ -49,7 +50,8 @@
         "password": "passw0rd",
         "address": "ipmi://1.1.1.3:1234",
         "deploy_kernel": "http://172.22.0.2/images/ironic-python-agent.kernel",
-        "deploy_ramdisk": "http://172.22.0.2/images/ironic-python-agent.initramfs"
+        "deploy_ramdisk": "http://172.22.0.2/images/ironic-python-agent.initramfs",
+        "disable_certificate_verification": true
       },
       "ports": [{
         "address": "8e:af:c4:d0:a3:b4",

--- a/utils.sh
+++ b/utils.sh
@@ -143,6 +143,7 @@ function node_map_to_install_config_hosts() {
       username=$(node_val ${idx} "driver_info.username")
       password=$(node_val ${idx} "driver_info.password")
       address=$(node_val ${idx} "driver_info.address")
+      disable_certificate_verification=$(node_val ${idx} "driver_info.disable_certificate_verification")
 
       cat << EOF
       - name: ${name}
@@ -151,6 +152,7 @@ function node_map_to_install_config_hosts() {
           address: ${address}
           username: ${username}
           password: ${password}
+          disableCertificateVerification: ${disable_certificate_verification}
         bootMACAddress: ${mac}
 EOF
 


### PR DESCRIPTION
This new flag was added to skip certificate checking
in the case of non-trusted certificate. This is useful
for development environment. So adding the option in
dev-scripts to be able to use the flag in the nodes.

Signed-off-by: Yolanda Robla <yroblamo@redhat.com>