### PR TITLE
Replace crudini usage with ansible

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -167,7 +167,7 @@ fi
 # Switch NetworkManager to internal DNS
 if [ "$MANAGE_BR_BRIDGE" == "y" ] ; then
   sudo mkdir -p /etc/NetworkManager/conf.d/
-  sudo $(which crudini) --set /etc/NetworkManager/conf.d/dnsmasq.conf main dns dnsmasq
+  ansible localhost -b -m ini_file -a "path=/etc/NetworkManager/conf.d/dnsmasq.conf section=main option=dns value=dnsmasq"
   if [ "$ADDN_DNS" ] ; then
     echo "server=$ADDN_DNS" | sudo tee /etc/NetworkManager/dnsmasq.d/upstream.conf
   fi


### PR DESCRIPTION
In https://github.com/metal3-io/metal3-dev-env/pull/215
I'm trying to remove the dependency on RDO repos, where
crudini is installed from - instead we can use an ansible
ad-hoc command to do the same thing.