### PR TITLE
Update documentation to reflect the deployment to delete

### DIFF
--- a/docs/custom-mao-and-capbm.md
+++ b/docs/custom-mao-and-capbm.md
@@ -41,7 +41,7 @@ the baremetal-operator.
 ### 1) Stop the cluster-api controllers
 
 ```sh
-oc delete deployment -n openshift-machine-api clusterapi-manager-controllers
+oc delete deployment -n openshift-machine-api machine-api-controllers
 ```
 
 ### 2) Prepare the MAO to run locally


### PR DESCRIPTION
The referenced one does not exist, it needs to be
machine-api-controllers instead

Signed-off-by: Yolanda Robla <yroblamo@redhat.com>