### PR TITLE
Add nodes_file when running metal3-dev-env setup

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -44,6 +44,7 @@ ANSIBLE_FORCE_COLOR=true ansible-playbook \
     -e "vm_platform=$NODES_PLATFORM" \
     -e "manage_baremetal=$MANAGE_BR_BRIDGE" \
     -e "provisioning_url_host=$PROVISIONING_URL_HOST" \
+    -e "nodes_file=$NODES_FILE" \
     -i ${VM_SETUP_PATH}/inventory.ini \
     -b -vvv ${VM_SETUP_PATH}/setup-playbook.yml
 


### PR DESCRIPTION
This is needed since https://github.com/metal3-io/metal3-dev-env/pull/231
otherwise the ansible playbook fails due to the undefined variable.