### PR TITLE
Add support for coredns-mdns to run_ci.sh

### DIFF
--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -38,7 +38,10 @@ for IMAGE_VAR in $(env | grep "_LOCAL_IMAGE=" | grep -o "^[^=]*") ; do
         cd $REPOPATH
         export $IMAGE_VAR=${IMAGE##*/}:latest
         export $IMAGE_VAR=$LOCAL_REGISTRY_DNS_NAME:$LOCAL_REGISTRY_PORT/localimages/${!IMAGE_VAR}
-        sudo podman build --authfile $COMBINED_AUTH_FILE -t ${!IMAGE_VAR} .
+        # Some repos need to build with a non-default Dockerfile name
+        IMAGE_DOCKERFILE_NAME=${IMAGE_VAR/_LOCAL_IMAGE}_DOCKERFILE
+        IMAGE_DOCKERFILE=${!IMAGE_DOCKERFILE_NAME:-Dockerfile}
+        sudo podman build --authfile $COMBINED_AUTH_FILE -t ${!IMAGE_VAR} -f $IMAGE_DOCKERFILE .
         cd -
         sudo podman push --tls-verify=false --authfile $COMBINED_AUTH_FILE ${!IMAGE_VAR} ${!IMAGE_VAR}
     fi

--- a/run_ci.sh
+++ b/run_ci.sh
@@ -94,6 +94,18 @@ fi
 if [ -d "/home/notstack/mdns-publisher" ] ; then
     export MDNS_PUBLISHER_LOCAL_IMAGE=https://github.com/openshift/mdns-publisher
 fi
+# coredns-mdns is unique because it is vendored into the openshift/coredns project
+# and that is where the image gets built.
+if [ -d "/home/notstack/coredns-mdns" ] ; then
+    pushd /home/notstack
+    git clone https://github.com/openshift/coredns
+    # Update the vendoring with our local changes
+    GO111MODULE=on go mod edit -replace github.com/openshift/coredns-mdns=/home/notstack/coredns-mdns
+    GO111MODULE=on go mod vendor
+    popd
+    export COREDNS_LOCAL_IMAGE=https://github.com/openshift/coredns
+    export COREDNS_DOCKERFILE=Dockerfile.openshift
+fi
 
 # Some of the setup done above needs to be done before we source common.sh
 # in order for correct defaults to be set


### PR DESCRIPTION
coredns-mdns is somewhat unique in that it doesn't become its own
image, it gets included in the coredns image as a vendored plugin.
Because of this, we need a bit more logic around building proposed
changes than just exporting the appropriate local image env var.

This change adds the ability to override the Dockerfile name for the
image build in dev-scripts (because coredns is also unusual in that
way) and adds the necessary steps to clone and update the coredns
code so it can be built with the proposed change.