### PR TITLE
Add possibility to pass boot_mode

### DIFF
--- a/ironic_hosts.json.example
+++ b/ironic_hosts.json.example
@@ -18,7 +18,8 @@
       }],
       "properties": {
         "local_gb": "50",
-        "cpu_arch": "x86_64"
+        "cpu_arch": "x86_64",
+        "boot_mode": "UEFI"
       }
     },
      {
@@ -38,7 +39,8 @@
       }],
       "properties": {
         "local_gb": "50",
-        "cpu_arch": "x86_64"
+        "cpu_arch": "x86_64",
+        "boot_mode": "legacy"
       }
     },
      {

--- a/utils.sh
+++ b/utils.sh
@@ -160,6 +160,10 @@ function node_map_to_install_config_hosts() {
       password=$(node_val ${idx} "driver_info.password")
       address=$(node_val ${idx} "driver_info.address")
       disable_certificate_verification=$(node_val ${idx} "driver_info.disable_certificate_verification")
+      boot_mode=$(node_val ${idx} "properties.boot_mode")
+      if [[ "$boot_mode" == "null" ]]; then
+             boot_mode="UEFI"
+      fi
 
       cat << EOF
       - name: ${name}
@@ -170,6 +174,7 @@ function node_map_to_install_config_hosts() {
           password: ${password}
           disableCertificateVerification: ${disable_certificate_verification}
         bootMACAddress: ${mac}
+        bootMode: ${boot_mode}
 EOF
 
         # FIXME(stbenjam) Worker code in installer should accept


### PR DESCRIPTION
Create a new property boot_mode in the properties
dictionary. It can accept two values (UEFI, legacy) and
will default to UEFI. This will be passed to install-config
and will be picked by the installer.

Signed-off-by: Yolanda Robla <yroblamo@redhat.com>