### PR TITLE
support better per-cluster naming

### DIFF
--- a/03_build_installer.sh
+++ b/03_build_installer.sh
@@ -10,11 +10,11 @@ source ocp_install_env.sh
 # Extract an updated client tools from the release image
 extract_oc "${OPENSHIFT_RELEASE_IMAGE}"
 
-mkdir -p ocp/
+mkdir -p $OCP_DIR
 
 if [ -z "$KNI_INSTALL_FROM_GIT" ]; then
   # Extract openshift-install from the release image
-  extract_installer "${OPENSHIFT_RELEASE_IMAGE}" ocp/
+  extract_installer "${OPENSHIFT_RELEASE_IMAGE}" $OCP_DIR
 else
   # Clone and build the installer from source
   clone_installer

--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -123,6 +123,7 @@ fi
 
 # cached images to the bootstrap VM
 sudo podman run -d --net host --privileged --name httpd --pod ironic-pod \
+     --env PROVISIONING_INTERFACE=${PROVISIONING_NETWORK_NAME} \
      -v $IRONIC_DATA_DIR:/shared --entrypoint /bin/runhttpd ${IRONIC_IMAGE}
 
 sudo podman run -d --net host --privileged --name ipa-downloader --pod ironic-pod \

--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -84,7 +84,7 @@ if [ ! -z "${MIRROR_IMAGES}" ]; then
 fi
 rm -f $DOCKERFILE
 
-for name in ironic ironic-api ironic-conductor ironic-inspector dnsmasq httpd mariadb ipa-downloader vbmc sushy-tools; do
+for name in ironic ironic-api ironic-conductor ironic-inspector dnsmasq httpd-${PROVISIONING_NETWORK_NAME} mariadb ipa-downloader vbmc sushy-tools; do
     sudo podman ps | grep -w "$name$" && sudo podman kill $name
     sudo podman ps --all | grep -w "$name$" && sudo podman rm $name -f
 done
@@ -122,7 +122,7 @@ if [ ! -f "${CACHED_MACHINE_OS_BOOTSTRAP_IMAGE}" ]; then
 fi
 
 # cached images to the bootstrap VM
-sudo podman run -d --net host --privileged --name httpd --pod ironic-pod \
+sudo podman run -d --net host --privileged --name httpd-${PROVISIONING_NETWORK_NAME} --pod ironic-pod \
      --env PROVISIONING_INTERFACE=${PROVISIONING_NETWORK_NAME} \
      -v $IRONIC_DATA_DIR:/shared --entrypoint /bin/runhttpd ${IRONIC_IMAGE}
 

--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -73,7 +73,7 @@ if [ ! -z "${MIRROR_IMAGES}" ]; then
         --command=openshift-baremetal-install --to "${EXTRACT_DIR}" \
         "${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/local-release-image:${TAG}"
 
-      mv -f "${EXTRACT_DIR}/openshift-baremetal-install" ocp/
+      mv -f "${EXTRACT_DIR}/openshift-baremetal-install" ${OCP_DIR}
     fi
 
     rm -rf "${EXTRACT_DIR}"

--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -145,8 +145,8 @@ fi
 sudo podman wait -i 1000 ipa-downloader
 
 # Wait for images to be downloaded/ready
-while ! curl --fail http://localhost/images/${MACHINE_OS_IMAGE_NAME}.sha256sum ; do sleep 1 ; done
-while ! curl --fail http://localhost/images/${MACHINE_OS_BOOTSTRAP_IMAGE_NAME}.sha256sum ; do sleep 1 ; done
-while ! curl --fail --head http://localhost/images/ironic-python-agent.initramfs ; do sleep 1; done
-while ! curl --fail --head http://localhost/images/ironic-python-agent.tar.headers ; do sleep 1; done
-while ! curl --fail --head http://localhost/images/ironic-python-agent.kernel ; do sleep 1; done
+while ! curl --fail http://${PROVISIONING_HOST_IP}/images/${MACHINE_OS_IMAGE_NAME}.sha256sum ; do sleep 1 ; done
+while ! curl --fail http://${PROVISIONING_HOST_IP}/images/${MACHINE_OS_BOOTSTRAP_IMAGE_NAME}.sha256sum ; do sleep 1 ; done
+while ! curl --fail --head http://${PROVISIONING_HOST_IP}/images/ironic-python-agent.initramfs ; do sleep 1; done
+while ! curl --fail --head http://${PROVISIONING_HOST_IP}/images/ironic-python-agent.tar.headers ; do sleep 1; done
+while ! curl --fail --head http://${PROVISIONING_HOST_IP}/images/ironic-python-agent.kernel ; do sleep 1; done

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ You can also see the status of the bootkube.sh script which is running via
 When the master nodes are up and the cluster is active, you can interact with the API:
 
 ```
-$ oc --config ocp/auth/kubeconfig get nodes
+$ oc --config ocp/${CLUSTER_NAME}/auth/kubeconfig get nodes
 NAME       STATUS    ROLES     AGE       VERSION
 master-0   Ready     master    20m       v1.12.4+50c2f2340a
 master-1   Ready     master    20m       v1.12.4+50c2f2340a
@@ -161,7 +161,7 @@ Run sshuttle:
 sshuttle -r <user>@<virthost> 192.168.111.0/24
 ```
 
-To access the web Console use the `kubeadmin` user, and password generated in the `ocp/auth/kubeadmin-password` file.
+To access the web Console use the `kubeadmin` user, and password generated in the `ocp/${CLUSTER_NAME}/auth/kubeadmin-password` file.
 
 
 ## Interacting with Ironic directly

--- a/common.sh
+++ b/common.sh
@@ -47,6 +47,10 @@ export PROVISIONING_NETWORK=${PROVISIONING_NETWORK:-172.22.0.0/24}
 export PROVISIONING_NETMASK=${PROVISIONING_NETMASK:-$(ipcalc --netmask $PROVISIONING_NETWORK | cut -d= -f2)}
 export CLUSTER_PRO_IF=${CLUSTER_PRO_IF:-enp1s0}
 
+export PROVISIONING_NETWORK_NAME=${PROVISIONING_NETWORK_NAME:-provisioning}
+
+export BAREMETAL_NETWORK_NAME=${BAREMETAL_NETWORK_NAME:-baremetal}
+
 export BASE_DOMAIN=${BASE_DOMAIN:-test.metalkube.org}
 export CLUSTER_NAME=${CLUSTER_NAME:-ostest}
 export CLUSTER_DOMAIN="${CLUSTER_NAME}.${BASE_DOMAIN}"
@@ -70,6 +74,7 @@ export MIRROR_IMAGES=${MIRROR_IMAGES:-}
 
 # The dev-scripts working directory
 WORKING_DIR=${WORKING_DIR:-"/opt/dev-scripts"}
+OCP_DIR=${OCP_DIR:-ocp/${CLUSTER_NAME}}
 
 # variables for local registry configuration
 export LOCAL_REGISTRY_PORT=${LOCAL_REGISTRY_PORT:-"5000"}
@@ -108,7 +113,7 @@ if [ "${UPSTREAM_IRONIC:-false}" != "false" ] ; then
 fi
 
 if [ -z "$KNI_INSTALL_FROM_GIT" ]; then
-    export OPENSHIFT_INSTALLER=${OPENSHIFT_INSTALLER:-ocp/openshift-baremetal-install}
+    export OPENSHIFT_INSTALLER=${OPENSHIFT_INSTALLER:-${OCP_DIR}/openshift-baremetal-install}
  else
     export OPENSHIFT_INSTALLER=${OPENSHIFT_INSTALLER:-$OPENSHIFT_INSTALL_PATH/bin/openshift-install}
 
@@ -151,9 +156,9 @@ ROOT_DISK_NAME=${ROOT_DISK_NAME-"/dev/sda"}
 
 FILESYSTEM=${FILESYSTEM:="/"}
 
-NODES_FILE=${NODES_FILE:-"${WORKING_DIR}/ironic_nodes.json"}
+export NODES_FILE=${NODES_FILE:-"${WORKING_DIR}/${CLUSTER_NAME}/ironic_nodes.json"}
 NODES_PLATFORM=${NODES_PLATFORM:-"libvirt"}
-BAREMETALHOSTS_FILE=${BAREMETALHOSTS_FILE:-"ocp/baremetalhosts.json"}
+BAREMETALHOSTS_FILE=${BAREMETALHOSTS_FILE:-"${OCP_DIR}/baremetalhosts.json"}
 
 # Optionally set this to a path to use a local dev copy of
 # metal3-dev-env, otherwise it's cloned to $WORKING_DIR
@@ -177,6 +182,8 @@ export IRONIC_IMAGES_DIR="${IRONIC_DATA_DIR}/html/images"
 # VBMC and Redfish images
 export VBMC_IMAGE=${VBMC_IMAGE:-"quay.io/metal3-io/vbmc"}
 export SUSHY_TOOLS_IMAGE=${SUSHY_TOOLS_IMAGE:-"quay.io/metal3-io/sushy-tools"}
+export VBMC_BASE_PORT=${VBMC_BASE_PORT:-"6230"}
+export VBMC_MAX_PORT=$((${VBMC_BASE_PORT} + ${NUM_MASTERS} + ${NUM_WORKERS} - 1))
 
 export KUBECONFIG="${SCRIPTDIR}/ocp/auth/kubeconfig"
 
@@ -246,6 +253,8 @@ if [ ! -d "$WORKING_DIR" ]; then
   sudo chown "${USER}:${USER}" "$WORKING_DIR"
   chmod 755 "$WORKING_DIR"
 fi
+
+mkdir -p "$WORKING_DIR/$CLUSTER_NAME"
 
 if [ ! -d "$IRONIC_IMAGES_DIR" ]; then
   echo "Creating Ironic Images Dir"

--- a/common.sh
+++ b/common.sh
@@ -47,12 +47,15 @@ export PROVISIONING_NETWORK=${PROVISIONING_NETWORK:-172.22.0.0/24}
 export PROVISIONING_NETMASK=${PROVISIONING_NETMASK:-$(ipcalc --netmask $PROVISIONING_NETWORK | cut -d= -f2)}
 export CLUSTER_PRO_IF=${CLUSTER_PRO_IF:-enp1s0}
 
-export PROVISIONING_NETWORK_NAME=${PROVISIONING_NETWORK_NAME:-provisioning}
+export CLUSTER_NAME=${CLUSTER_NAME:-ostest}
 
-export BAREMETAL_NETWORK_NAME=${BAREMETAL_NETWORK_NAME:-baremetal}
+# Network interface names can only be 15 characters long, so
+# abbreviate provisioning and baremetal and add them as suffixes to
+# the cluster name.
+export PROVISIONING_NETWORK_NAME=${PROVISIONING_NETWORK_NAME:-${CLUSTER_NAME}pr}
+export BAREMETAL_NETWORK_NAME=${BAREMETAL_NETWORK_NAME:-${CLUSTER_NAME}bm}
 
 export BASE_DOMAIN=${BASE_DOMAIN:-test.metalkube.org}
-export CLUSTER_NAME=${CLUSTER_NAME:-ostest}
 export CLUSTER_DOMAIN="${CLUSTER_NAME}.${BASE_DOMAIN}"
 export SSH_PUB_KEY="${SSH_PUB_KEY:-$(cat $HOME/.ssh/id_rsa.pub)}"
 export NETWORK_TYPE=${NETWORK_TYPE:-"OpenShiftSDN"}

--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -12,6 +12,8 @@ fi
 
 ANSIBLE_FORCE_COLOR=true ansible-playbook \
     -e @vm_setup_vars.yml \
+    -e "provisioning_network_name=${PROVISIONING_NETWORK_NAME}" \
+    -e "baremetal_network_name=${BAREMETAL_NETWORK_NAME}" \
     -e "working_dir=$WORKING_DIR" \
     -e "num_masters=$NUM_MASTERS" \
     -e "num_workers=$NUM_WORKERS" \
@@ -21,20 +23,20 @@ ANSIBLE_FORCE_COLOR=true ansible-playbook \
     -i ${VM_SETUP_PATH}/inventory.ini \
     -b -vvv ${VM_SETUP_PATH}/teardown-playbook.yml
 
-sudo rm -rf /etc/NetworkManager/dnsmasq.d/openshift.conf /etc/NetworkManager/conf.d/dnsmasq.conf /etc/yum.repos.d/delorean*
+sudo rm -rf /etc/NetworkManager/dnsmasq.d/openshift-${CLUSTER_NAME}.conf
 # There was a bug in this file, it may need to be recreated.
 # delete the interface as it can cause issues when not rebooting
 if [ "$MANAGE_PRO_BRIDGE" == "y" ]; then
-    sudo ifdown provisioning || true
-    sudo ip link delete provisioning || true
-    sudo rm -f /etc/sysconfig/network-scripts/ifcfg-provisioning
+    sudo ifdown ${PROVISIONING_NETWORK_NAME} || true
+    sudo ip link delete ${PROVISIONING_NETWORK_NAME} || true
+    sudo rm -f /etc/sysconfig/network-scripts/ifcfg-${PROVISIONING_NETWORK_NAME}
 fi
 # Leaving this around causes issues when the host is rebooted
 # delete the interface as it can cause issues when not rebooting
 if [ "$MANAGE_BR_BRIDGE" == "y" ]; then
-    sudo ifdown baremetal || true
-    sudo ip link delete baremetal || true
-    sudo rm -f /etc/sysconfig/network-scripts/ifcfg-baremetal
+    sudo ifdown ${BAREMETAL_NETWORK_NAME} || true
+    sudo ip link delete ${BAREMETAL_NETWORK_NAME} || true
+    sudo rm -f /etc/sysconfig/network-scripts/ifcfg-${BAREMETAL_NETWORK_NAME}
 fi
 # Kill any lingering proxy
 sudo pkill -f oc.*proxy

--- a/ironic_cleanup.sh
+++ b/ironic_cleanup.sh
@@ -5,7 +5,7 @@ source logging.sh
 source common.sh
 
 # Kill and remove the running ironic containers
-for name in ironic ironic-api ironic-conductor ironic-inspector dnsmasq httpd mariadb vbmc sushy-tools; do
+for name in ironic ironic-api ironic-conductor ironic-inspector dnsmasq httpd-${PROVISIONING_NETWORK_NAME} mariadb vbmc sushy-tools; do
     sudo podman ps | grep -w "$name$" && sudo podman kill $name
     sudo podman ps --all | grep -w "$name$" && sudo podman rm $name -f
 done

--- a/ocp_cleanup.sh
+++ b/ocp_cleanup.sh
@@ -7,13 +7,13 @@ source ocp_install_env.sh
 
 sudo systemctl stop fix_certs.timer
 
-if [ -d ocp ]; then
-    ocp/openshift-install --dir ocp --log-level=debug destroy bootstrap
-    ocp/openshift-install --dir ocp --log-level=debug destroy cluster
-    rm -rf ocp
+if [ -d ${OCP_DIR} ]; then
+    ${OCP_DIR}/openshift-install --dir ${OCP_DIR} --log-level=debug destroy bootstrap
+    ${OCP_DIR}/openshift-install --dir ${OCP_DIR} --log-level=debug destroy cluster
+    rm -rf ${OCP_DIR}
 fi
 
-sudo rm -rf /etc/NetworkManager/dnsmasq.d/openshift.conf
+sudo rm -rf /etc/NetworkManager/dnsmasq.d/openshift-${CLUSTER_NAME}.conf
 
 # Cleanup ssh keys for baremetal network
 if [ -f $HOME/.ssh/known_hosts ]; then

--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -108,6 +108,8 @@ controlPlane:
 platform:
   baremetal:
 $(network_configuration)
+    externalBridge: ${BAREMETAL_NETWORK_NAME}
+    provisioningBridge: ${PROVISIONING_NETWORK_NAME}
     bootstrapOSImage: http://$(wrap_if_ipv6 $MIRROR_IP)/images/${MACHINE_OS_BOOTSTRAP_IMAGE_NAME}?sha256=${MACHINE_OS_BOOTSTRAP_IMAGE_UNCOMPRESSED_SHA256}
     clusterOSImage: http://$(wrap_if_ipv6 $MIRROR_IP)/images/${MACHINE_OS_IMAGE_NAME}?sha256=${MACHINE_OS_IMAGE_SHA256}
     dnsVIP: ${DNS_VIP}

--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -112,6 +112,8 @@ $(network_configuration)
     provisioningBridge: ${PROVISIONING_NETWORK_NAME}
     bootstrapOSImage: http://$(wrap_if_ipv6 $MIRROR_IP)/images/${MACHINE_OS_BOOTSTRAP_IMAGE_NAME}?sha256=${MACHINE_OS_BOOTSTRAP_IMAGE_UNCOMPRESSED_SHA256}
     clusterOSImage: http://$(wrap_if_ipv6 $MIRROR_IP)/images/${MACHINE_OS_IMAGE_NAME}?sha256=${MACHINE_OS_IMAGE_SHA256}
+    apiVIP: ${API_VIP}
+    ingressVIP: ${INGRESS_VIP}
     dnsVIP: ${DNS_VIP}
     hosts:
 $(node_map_to_install_config_hosts $NUM_MASTERS 0 master)

--- a/run_ci.sh
+++ b/run_ci.sh
@@ -8,7 +8,7 @@ function getlogs(){
     # Grab the host journal
     sudo journalctl > $LOGDIR/bootstrap-host-system.journal
 
-    for c in httpd machine-os-downloader ipa-downloader ; do
+    for c in httpd-${PROVISIONING_NETWORK_NAME} machine-os-downloader ipa-downloader ; do
         sudo podman logs $c > $LOGDIR/$c.log || true
     done
 

--- a/run_ci.sh
+++ b/run_ci.sh
@@ -22,7 +22,7 @@ function getlogs(){
     done
 
     # openshift info
-    export KUBECONFIG=ocp/auth/kubeconfig
+    export KUBECONFIG=ocp/$CLUSTER_NAME/auth/kubeconfig
     oc --request-timeout=5s get clusterversion/version > $LOGDIR/cluster_version.log || true
     oc --request-timeout=5s get clusteroperators > $LOGDIR/cluster_operators.log || true
     oc --request-timeout=5s get pods --all-namespaces | grep -v Running | grep -v Completed  > $LOGDIR/failing_pods.log || true
@@ -153,7 +153,7 @@ set -o pipefail
 timeout -s 9 120m make |& ts "%b %d %H:%M:%S | " |& sed -e 's/.*auths.*/*** PULL_SECRET ***/g'
 
 # Deployment is complete, but now wait to ensure the worker node comes up.
-export KUBECONFIG=ocp/auth/kubeconfig
+export KUBECONFIG=ocp/$CLUSTER_NAME/auth/kubeconfig
 
 wait_for_worker() {
     worker=$1

--- a/show_bootstrap_log.sh
+++ b/show_bootstrap_log.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
-BOOTSTRAP_VM_IP=$(sudo virsh net-dhcp-leases baremetal | grep -v master | grep ipv4 | tail -n1 | sed -e 's/.*\(192.*\)\/.*/\1/')
+source common.sh
+
+BOOTSTRAP_VM_IP=$(sudo virsh net-dhcp-leases ${BAREMETAL_NETWORK_NAME} | grep -v master | grep ipv4 | tail -n1 | sed -e 's/.*\(192.*\)\/.*/\1/')
 echo "Attempting to follow $1 on ${BOOTSTRAP_VM_IP} ..."
 ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no core@${BOOTSTRAP_VM_IP} journalctl -b -f -u $1

--- a/utils.sh
+++ b/utils.sh
@@ -215,12 +215,12 @@ function generate_templates {
     MACHINE_OS_IMAGE_URL="http:///$(wrap_if_ipv6 $MIRROR_IP)/images/${MACHINE_OS_IMAGE_NAME}?sha256=${MACHINE_OS_BOOTSTRAP_IMAGE_SHA256}"
 
     # metal3-config.yaml
-    mkdir -p ocp/deploy
+    mkdir -p ${OCP_DIR}/deploy
 	  go get github.com/apparentlymart/go-cidr/cidr github.com/openshift/installer/pkg/ipnet
 
     if [[ "$OPENSHIFT_VERSION" == "4.3" ]]; then
-      go run metal3-templater.go metal3-config.yaml.template "$CLUSTER_PRO_IF" "$PROVISIONING_NETWORK" "$MACHINE_OS_IMAGE_URL" > ocp/deploy/metal3-config.yaml
-      cp ocp/deploy/metal3-config.yaml assets/generated/99_metal3-config.yaml
+      go run metal3-templater.go metal3-config.yaml.template "$CLUSTER_PRO_IF" "$PROVISIONING_NETWORK" "$MACHINE_OS_IMAGE_URL" > ${OCP_DIR}/deploy/metal3-config.yaml
+      cp ${OCP_DIR}/deploy/metal3-config.yaml assets/generated/99_metal3-config.yaml
     else
       echo "OpenShift Version is > 4.3; skipping config map"
     fi

--- a/vm_setup_vars.yml
+++ b/vm_setup_vars.yml
@@ -34,3 +34,25 @@ dns_extrahosts:
   - ip: "{{ baremetal_network_cidr | nthhost(1) }}"
     hostnames:
       - "virthost"
+
+networks:
+  - name: "{{ provisioning_network_name }}"
+    bridge: "{{ provisioning_network_name }}"
+    forward_mode: bridge
+  - name: "{{ baremetal_network_name }}"
+    bridge: "{{ baremetal_network_name }}"
+    forward_mode: nat
+    address: "{{ baremetal_network_cidr|nthhost(1) }}"
+    netmask: "{{ baremetal_network_cidr|ipaddr('netmask') }}"
+    dhcp_range:
+      - "{{ baremetal_network_cidr|nthhost(20) }}"
+      - "{{ baremetal_network_cidr|nthhost(60) }}"
+    nat_port_range:
+      - 1024
+      - 65535
+    domain: "{{ cluster_domain }}"
+    dns:
+      hosts: "{{dns_extrahosts | default([])}}"
+      forwarders:
+        - domain: "apps.{{ cluster_domain }}"
+          addr: "127.0.0.1"


### PR DESCRIPTION
This set of changes is the first in a series to support running
dev-scripts multiple times on the same host to create multiple
clusters. With these changes in place, the files created end up either
in cluster-specific locations or with the cluster name in the file
name. It is also possible to control the names of the provisioning and
baremetal networks using variables in the config file and control the
starting value for the VMBC ports used by the emulator.