### PR TITLE
cd into coredns directory before updating module

### DIFF
--- a/run_ci.sh
+++ b/run_ci.sh
@@ -99,6 +99,7 @@ fi
 if [ -d "/home/notstack/coredns-mdns" ] ; then
     pushd /home/notstack
     git clone https://github.com/openshift/coredns
+    cd coredns
     # Update the vendoring with our local changes
     GO111MODULE=on go mod edit -replace github.com/openshift/coredns-mdns=/home/notstack/coredns-mdns
     GO111MODULE=on go mod vendor


### PR DESCRIPTION
This was missed in the original commit of coredns-mdns ci. Without
it the go mod commands fail because there is no project for them to
work on.