### PR TITLE
Wire in hostname format parameters

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -48,6 +48,8 @@ ANSIBLE_FORCE_COLOR=true ansible-playbook \
     -e "provisioning_url_host=$PROVISIONING_URL_HOST" \
     -e "nodes_file=$NODES_FILE" \
     -e "virtualbmc_base_port=$VBMC_BASE_PORT" \
+    -e "master_hostname_format=$MASTER_HOSTNAME_FORMAT" \
+    -e "worker_hostname_format=$WORKER_HOSTNAME_FORMAT" \
     -i ${VM_SETUP_PATH}/inventory.ini \
     -b -vvv ${VM_SETUP_PATH}/setup-playbook.yml
 

--- a/common.sh
+++ b/common.sh
@@ -175,6 +175,8 @@ fi
 export NUM_MASTERS=${NUM_MASTERS:-"3"}
 export NUM_WORKERS=${NUM_WORKERS:-"1"}
 export VM_EXTRADISKS=${VM_EXTRADISKS:-"false"}
+export MASTER_HOSTNAME_FORMAT=${MASTER_HOSTNAME_FORMAT:-"master-%d"}
+export WORKER_HOSTNAME_FORMAT=${WORKER_HOSTNAME_FORMAT:-"worker-%d"}
 
 # Ironic vars (Image can be use <NAME>_LOCAL_IMAGE to override)
 export IRONIC_IMAGE="quay.io/metal3-io/ironic:master"

--- a/config_example.sh
+++ b/config_example.sh
@@ -108,3 +108,11 @@ set -x
 
 # Install operator-sdk for local testing of baremetal-operator
 #export INSTALL_OPERATOR_SDK=1
+
+# Set a custom hostname format for masters. This is a format string that should
+# include one %d field, which will be replaced with the number of the node.
+#export MASTER_HOSTNAME_FORMAT=master-%d
+
+# Set a custom hostname format for workers. This is a format string that should
+# include one %d field, which will be replaced with the number of the node.
+#export WORKER_HOSTNAME_FORMAT=worker-%d


### PR DESCRIPTION
Support was added in metal3-dev-env[0] for using custom hostname
formats for the Ironic nodes. This adds the necessary configuration
variables to dev-scripts to override the master and worker hostnames.
Real deployments frequently won't use master-X hostnames so it is
important that we can test those formats in a virtual environment.

0: https://github.com/metal3-io/metal3-dev-env/commit/3cf4203ffeb66a30bf5bf71efc462e7b8adbeb9f