### PR TITLE
Re-add tripleo repo cleanup

### DIFF
--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -23,7 +23,7 @@ ANSIBLE_FORCE_COLOR=true ansible-playbook \
     -i ${VM_SETUP_PATH}/inventory.ini \
     -b -vvv ${VM_SETUP_PATH}/teardown-playbook.yml
 
-sudo rm -rf /etc/NetworkManager/dnsmasq.d/openshift-${CLUSTER_NAME}.conf
+sudo rm -rf /etc/NetworkManager/dnsmasq.d/openshift-${CLUSTER_NAME}.conf /etc/yum.repos.d/delorean*
 # There was a bug in this file, it may need to be recreated.
 # delete the interface as it can cause issues when not rebooting
 if [ "$MANAGE_PRO_BRIDGE" == "y" ]; then


### PR DESCRIPTION
This accidentally got dropped in [0]. It's still needed to prevent
dependency issues on re-deploy.

0: https://github.com/openshift-metal3/dev-scripts/commit/f64ebda3671a6d6e7620898181e0648b40b5a9f3