### PR TITLE
WIP: extend multi-cluster support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,10 @@ install_config:
 ocp_run:
 	./06_create_cluster.sh
 
+.PHONY: hive_assets
+hive_assets: configure build_installer ironic install_config
+	./hive_generate_assets.sh
+
 gather:
 	./must_gather.sh
 

--- a/README.md
+++ b/README.md
@@ -300,4 +300,27 @@ The following adds an additional file `/etc/test` as an example:
 
 ```
 export IGNITION_EXTRA="ignition/file_example.ign"
-``` 
+```
+
+### Building multiple clusters
+
+The script `multicluster.sh` takes as argument several configuration
+scripts and builds the clusters described by them.
+
+```
+./multicluster.sh build config_kni.sh config_hive1.sh
+```
+
+It can also be used to clean up multiple clusters.
+
+```
+./multicluster.sh clean config_kni.sh config_hive1.sh
+```
+
+To ensure the clusters can operate in parallel, each configuration
+file must have unique values for:
+
+* `CLUSTER_NAME`
+* `PROVISIONING_NETWORK`
+* `EXTERNAL_SUBNET`
+* `VBMC_BASE_PORT`

--- a/common.sh
+++ b/common.sh
@@ -179,6 +179,7 @@ export PROVISIONING_NETMASK=${PROVISIONING_NETMASK:-$(ipcalc --netmask $PROVISIO
 # Hypervisor details
 export REMOTE_LIBVIRT=${REMOTE_LIBVIRT:-0}
 export PROVISIONING_HOST_USER=${PROVISIONING_HOST_USER:-$USER}
+export SSH_PRIVATE_KEY_NAME=${SSH_PRIVATE_KEY_NAME:-$HOME/.ssh/id_rsa}
 
 # ipcalc on CentOS 7 doesn't support the 'minaddr' option, so use python
 # instead to get the first address in the network:

--- a/config_example.sh
+++ b/config_example.sh
@@ -142,3 +142,15 @@ set -x
 
 # Image reference for installing hive. See hive_install.sh.
 #export HIVE_DEPLOY_IMAGE="registry.svc.ci.openshift.org/openshift/hive-v4.0:hive"
+
+# If building multiple clusters, each needs its own VBMC port range.
+#export VBMC_BASE_PORT=6230
+
+# Generate a URL to refer to libvirt via ssh. See SSH_PRIVATE_KEY.
+#export REMOTE_LIBVIRT=1
+
+# SSH key used to set up hive ClusterDeployment for multi-cluster
+# configurations. Does not need to match SSH_PUB_KEY. Must not use a
+# passphrase. The matching public key must be added to authorized_keys
+# on the hypervisor.
+#export SSH_PRIVATE_KEY_NAME="$HOME/.ssh/id_rsa"

--- a/hive_generate_assets.sh
+++ b/hive_generate_assets.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -xe
+
+source logging.sh
+source common.sh
+source utils.sh
+source rhcos.sh
+source ocp_install_env.sh
+source hive_utils.sh
+
+generate_ocp_install_config ${OCP_DIR}
+generate_hive_assets ${OCP_DIR}

--- a/hive_utils.sh
+++ b/hive_utils.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+
+function release_image() {
+    if [ ! -z "${MIRROR_IMAGES}" ]; then
+        echo "releaseImage: ${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/local-release-image"
+    else
+        echo "releaseImage: ${OPENSHIFT_RELEASE_IMAGE}"
+    fi
+}
+
+function generate_hive_assets() {
+    local outdir
+    local hypervisor_host
+
+    # The LIBVIRT_URI might have been overridden to not point to
+    # PROVISIONING_HOST_IP, so extract the IP of the host we have in
+    # the URI.
+    hypervisor_host=$(python3 -c "import urllib.parse; print(urllib.parse.urlparse(\"$LIBVIRT_URI\").hostname)")
+
+    outdir="$1"
+    cat > "${outdir}/manifests.yaml" <<EOF
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ${CLUSTER_NAME}-pull-secret
+type: kubernetes.io/dockerconfigjson
+stringData:
+  .dockerconfigjson: |-
+    $(echo $PULL_SECRET | jq -c .)
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ${CLUSTER_NAME}-ssh-private-key
+stringData:
+  ssh-privatekey: |-
+$(cat ${SSH_PRIVATE_KEY_NAME} | sed 's/^/    /g')
+
+---
+apiVersion: hive.openshift.io/v1
+kind: ClusterDeployment
+metadata:
+  name: ${CLUSTER_NAME}
+  annotations:
+    # do not retry if first deploy fails
+    hive.openshift.io/try-install-once: "true"
+spec:
+  baseDomain: ${BASE_DOMAIN}
+  clusterName: ${CLUSTER_NAME}
+  controlPlaneConfig:
+    servingCertificates: {}
+  platform:
+    baremetal:
+      libvirtSSHPrivateKeySecretRef:
+        name: ${CLUSTER_NAME}-ssh-private-key
+  provisioning:
+    installConfigSecretRef:
+      name: ${CLUSTER_NAME}-install-config
+    sshPrivateKeySecretRef:
+      name: ${CLUSTER_NAME}-ssh-private-key
+    $(release_image)
+    sshKnownHosts:
+$(ssh-keyscan -H ${hypervisor_host} 2>/dev/null | sed -e 's/^/      - "/g' -e 's/$/"/g')
+  pullSecretRef:
+    name: ${CLUSTER_NAME}-pull-secret
+
+EOF
+
+    cat > "${outdir}/create.sh" <<EOF
+#!/usr/bin/env bash
+
+set -xe
+
+bindir=\$(dirname \$0)
+
+if [[ -z "\$KUBECONFIG" ]]; then
+   echo "This script might fail because KUBECONFIG is not set."
+fi
+
+if ! (oc projects | grep -q ${CLUSTER_NAME}); then
+   oc new-project ${CLUSTER_NAME}
+fi
+
+oc delete secret ${CLUSTER_NAME}-pull-secret || true
+oc delete secret ${CLUSTER_NAME}-install-config || true
+
+oc create secret generic -n ${CLUSTER_NAME} ${CLUSTER_NAME}-install-config --from-file=install-config.yaml=\${bindir}/install-config.yaml
+
+oc delete -n ${CLUSTER_NAME} clusterdeployment ${CLUSTER_NAME} || true
+
+oc apply -n ${CLUSTER_NAME} -f \${bindir}/manifests.yaml
+
+EOF
+
+    chmod +x "${outdir}/create.sh"
+
+    local BOOTSTRAP_IP=$(python -c "from ansible.plugins.filter import ipaddr; print(ipaddr.nthhost('"$PROVISIONING_NETWORK"', 2))")
+    local CLUSTER_IP=$(python -c "from ansible.plugins.filter import ipaddr; print(ipaddr.nthhost('"$PROVISIONING_NETWORK"', 3))")
+
+    cat - >${outdir}/clouds.yaml <<EOF
+clouds:
+  metal3:
+    auth_type: none
+    baremetal_endpoint_override: http://$(wrap_if_ipv6 ${BOOTSTRAP_IP}):6385
+    baremetal_introspection_endpoint_override: http://$(wrap_if_ipv6 ${BOOTSTRAP_IP}):5050
+  metal3-bootstrap:
+    auth_type: none
+    baremetal_endpoint_override: http://$(wrap_if_ipv6 ${CLUSTER_IP}):6385
+    baremetal_introspection_endpoint_override: http://$(wrap_if_ipv6 ${CLUSTER_IP}):5050
+EOF
+}

--- a/multicluster.sh
+++ b/multicluster.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+set -xeu
+
+bindir=$(dirname $0)
+
+MODE=$1
+shift
+
+LOGPREFIX_BASE="multicluster-${MODE}-$(date +%F-%H%M%S)"
+
+# Set the log prefix for this process so logging.sh sets up the
+# outputs properly. Resetting this later has no effect, because the
+# outputs are already redirected.
+export LOGPREFIX=${LOGPREFIX_BASE}/
+
+source logging.sh
+source utils.sh
+source ocp_install_env.sh
+
+MAIN_CONFIG=$1
+shift
+
+SECONDARY_CONFIGS="$@"
+
+ALL_CONFIGS="${MAIN_CONFIG} ${SECONDARY_CONFIGS}"
+
+# Load the config and echo the named variable so this script can see
+# its value.
+function get_var_from_config() {
+    export INHERIT_CONFIG=$1
+    export VAR_TO_SHOW=$2
+    (
+        export CONFIG=$INHERIT_CONFIG;
+        source common.sh;
+        echo ${!VAR_TO_SHOW};
+    ) 2>/dev/null
+}
+
+function build() {
+
+    # Determine all of the hostnames for the registry so we can
+    # configure the certificate properly.
+    export ALL_REGISTRY_DNS_NAMES=""
+    for config in ${ALL_CONFIGS}; do
+        new_name=$(get_var_from_config $config LOCAL_REGISTRY_DNS_NAME)
+        ALL_REGISTRY_DNS_NAMES="$ALL_REGISTRY_DNS_NAMES $new_name"
+    done
+
+    # Use the first config to set up the registry so we get the right
+    # network types, etc.
+    CONFIG=${MAIN_CONFIG} make all
+
+    # The LIBVIRT_URI is used by the installer running in a pod in the
+    # first cluster, so it must use the IP visible from that
+    # cluster. Get the variables needed to build that URL.
+    PROVISIONING_HOST_USER=$(get_var_from_config ${MAIN_CONFIG} PROVISIONING_HOST_USER)
+    PROVISIONING_HOST_IP=$(get_var_from_config ${MAIN_CONFIG} PROVISIONING_HOST_IP)
+    export LIBVIRT_URI=$(build_libvirturi)
+
+    for config in ${SECONDARY_CONFIGS}; do
+        export LOGPREFIX="${LOGPREFIX_BASE}/$(basename $config .sh)-"
+        CONFIG=$config make hive_assets
+    done
+
+    ${bindir}/remove_iptables_isolation_rules.sh
+}
+
+function cleanup() {
+
+    for config in ${ALL_CONFIGS}; do
+        export LOGPREFIX="${LOGPREFIX_BASE}/"
+        CONFIG=$config make clean
+    done
+}
+
+function usage() {
+    echo "ERROR: $1"
+    echo "multicluster.sh (build|clean) configfile [configfile...]"
+    exit 1
+}
+
+case $MODE in
+     build)
+         build;;
+     clean)
+         cleanup;;
+     *)
+         usage "Unknown commnand $MODE";;
+esac
+
+echo "Done!" $'\a'

--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -85,10 +85,18 @@ EOF
   fi
 }
 
+function build_libvirturi() {
+    wrapped_provisioning_host_ip=$(wrap_if_ipv6 ${PROVISIONING_HOST_IP})
+    # LIBVIRT_URI is overridden by multicluster.sh but wrap_if_ipv6 is
+    # not defined in common.sh so we can't set a default there and the
+    # variable is only used here in this function.
+    echo ${LIBVIRT_URI:-qemu+ssh://${PROVISIONING_HOST_USER}@${wrapped_provisioning_host_ip}/system}
+}
+
 function libvirturi() {
     if [[ "$REMOTE_LIBVIRT" -ne 0 ]]; then
 cat <<EOF
-    libvirtURI: qemu+ssh://${PROVISIONING_HOST_USER}@$(wrap_if_ipv6 ${PROVISIONING_HOST_IP})/system
+    libvirtURI: $(build_libvirturi)
 EOF
     fi
 }

--- a/remove_iptables_isolation_rules.sh
+++ b/remove_iptables_isolation_rules.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -xeu
+
+source logging.sh
+
+# libvirt sets up the networks so they're isolated, but in a
+# multi-cluster environment we need them to be able to talk to
+# each other. Drop the relevant rules that block traffic to the
+# bare metal networks. This is done here, rather than in the host
+# setup script, because it is less invasive for the most common
+# single-cluster configuration.
+#
+# The command replaces the '-A' in the rule with '-D' and calling
+# iptables for each. For example, this rule:
+#
+# -A FORWARD -o hive1bm -j REJECT --reject-with icmp-port-unreachable
+#
+# becomes this command
+#
+# iptables -D FORWARD -o hive1bm -j REJECT --reject-with icmp-port-unreachable
+#
+sudo iptables-save \
+    | grep icmp-port-unreachable \
+    | grep 'bm -' \
+    | sed -e 's/-A/-D/' \
+    | sudo xargs -L 1 iptables


### PR DESCRIPTION
This is another series of patches to make multi-cluster support
better. With these patches in place it is possible to deploy multiple
clusters in series, as well as deploy some and build the infrastructure
for others without deploying. When a cluster is not deployed, the script
produces the inputs to hive for deploying it that way.

There is also a new script for installing hive into a cluster and configuring
it to work by disabling the need for persistent volumes.