### PR TITLE
Give masters 8 vCPUs

### DIFF
--- a/vm_setup_vars.yml
+++ b/vm_setup_vars.yml
@@ -13,7 +13,7 @@ flavors:
   master:
     memory: 16384
     disk: 20
-    vcpu: 4
+    vcpu: 8
     extradisks: false
 
   worker:


### PR DESCRIPTION
I'm seeing k8s-prometheus pods fail because of lack of CPU resources.
Give masters 8 vCPUs instead of 4.