### PR TITLE
Forward mode of baremetal bridge needs to be flexible

### DIFF
--- a/vm_setup_vars.yml
+++ b/vm_setup_vars.yml
@@ -41,7 +41,7 @@ networks:
     forward_mode: bridge
   - name: "{{ baremetal_network_name }}"
     bridge: "{{ baremetal_network_name }}"
-    forward_mode: nat
+    forward_mode: "{{ 'bridge' if lookup('env', 'MANAGE_BR_BRIDGE') == 'n' else 'nat' }}"
     address: "{{ baremetal_network_cidr|nthhost(1) }}"
     netmask: "{{ baremetal_network_cidr|ipaddr('netmask') }}"
     dhcp_range:


### PR DESCRIPTION
If we choose not to manage our bridges, we assume that those
are already created on the host. In that case we cannot use nat,
because it will conflict with the existing bridge. We need to
use bridge mode (shared physical device).

Signed-off-by: Yolanda Robla <yroblamo@redhat.com>