### PR TITLE
Ensure firewalld is running

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -89,6 +89,8 @@ fi
 
 if [ "${RHEL8}" = "True" ] || [ "${CENTOS8}" = "True" ] ; then
     ZONE="\nZONE=libvirt"
+
+    sudo systemctl enable --now firewalld
 fi
 
 if [ "$MANAGE_PRO_BRIDGE" == "y" ]; then


### PR DESCRIPTION
At least on CentOS 8 as deployed by packet.net, firewalld is installed
but not running by default.  This should be safe, even if it's already
enabled and running.