### PR TITLE
Create _clouds_yaml dir for ironic-client container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ logs/
 config_*.sh
 !config_example.sh
 clouds.yaml
+_clouds_yaml
 
 release/release_config_*.sh
 !release/release_config_example.sh

--- a/utils.sh
+++ b/utils.sh
@@ -216,7 +216,7 @@ function generate_templates {
 
     # metal3-config.yaml
     mkdir -p ${OCP_DIR}/deploy
-	  go get github.com/apparentlymart/go-cidr/cidr github.com/openshift/installer/pkg/ipnet
+    go get github.com/apparentlymart/go-cidr/cidr github.com/openshift/installer/pkg/ipnet
 
     if [[ "$OPENSHIFT_VERSION" == "4.3" ]]; then
       go run metal3-templater.go metal3-config.yaml.template "$CLUSTER_PRO_IF" "$PROVISIONING_NETWORK" "$MACHINE_OS_IMAGE_URL" > ${OCP_DIR}/deploy/metal3-config.yaml
@@ -227,6 +227,10 @@ function generate_templates {
 
     # clouds.yaml
     go run metal3-templater.go clouds.yaml.template "$CLUSTER_PRO_IF" "$PROVISIONING_NETWORK" "$MACHINE_OS_IMAGE_URL" > clouds.yaml
+    # For compatibility with metal3-dev-env openstackclient.sh
+    # which mounts a config dir into the ironic-client container
+    mkdir -p _clouds_yaml
+    cp clouds.yaml _clouds_yaml
 }
 
 function image_mirror_config {


### PR DESCRIPTION
Since https://github.com/metal3-io/metal3-dev-env/pull/215
openstackclient isn't installed natively by default, instead
it's run via a wrapper script which binds a directory into
the a container running the metal3-io/ironic-client image

When https://github.com/metal3-io/metal3-dev-env/pull/256
lands the wrapper script will look for a _clouds_yaml dir
in $PWD, so creating this dir will enable the containerized
client to work with dev-scripts.

We leave the existing clouds.yaml for compatibility with any
existing environments which may already have a locally installed
client.

Fixes: #971