### PR TITLE
Fix mirroring openshift CI images

### DIFF
--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -59,15 +59,13 @@ if [ ! -z "${MIRROR_IMAGES}" ]; then
     # hence credentials are different
 
     EXTRACT_DIR=$(mktemp -d "mirror-installer--XXXXXXXXXX")
-
-    TAG=$( echo $OPENSHIFT_RELEASE_IMAGE | sed -e 's/[[:alnum:]/.-]*release://' )
-    MIRROR_LOG_FILE=/tmp/tmp_image_mirror-${TAG}.log
+    MIRROR_LOG_FILE=/tmp/tmp_image_mirror-${OPENSHIFT_RELEASE_TAG}.log
 
     oc adm release mirror \
        --insecure=true \
         -a ${COMBINED_AUTH_FILE}  \
         --from ${OPENSHIFT_RELEASE_IMAGE} \
-        --to-release-image ${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/local-release-image:${TAG} \
+        --to-release-image ${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/local-release-image:${OPENSHIFT_RELEASE_TAG} \
         --to ${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/local-release-image 2>&1 | tee ${MIRROR_LOG_FILE}
 
     #To ensure that you use the correct images for the version of OpenShift Container Platform that you selected,
@@ -75,7 +73,7 @@ if [ ! -z "${MIRROR_IMAGES}" ]; then
     if [ -z "$KNI_INSTALL_FROM_GIT" ]; then
       oc adm release extract --registry-config "${COMBINED_AUTH_FILE}" \
         --command=openshift-baremetal-install --to "${EXTRACT_DIR}" \
-        "${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/local-release-image:${TAG}"
+        "${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/local-release-image:${OPENSHIFT_RELEASE_TAG}"
 
       mv -f "${EXTRACT_DIR}/openshift-baremetal-install" ${OCP_DIR}
     fi

--- a/common.sh
+++ b/common.sh
@@ -122,6 +122,8 @@ if [[ -z "$OPENSHIFT_CI" ]]; then
   export OPENSHIFT_VERSION=${OPENSHIFT_VERSION:-$(echo $OPENSHIFT_RELEASE_IMAGE | sed "s/.*:\([[:digit:]]\.[[:digit:]]\).*/\1/")}
 fi
 
+export OPENSHIFT_RELEASE_TAG=$(echo $OPENSHIFT_RELEASE_IMAGE | sed -E 's/[[:alnum:]\/.-]*release.*://')
+
 # Switch Container Images to upstream, Installer defaults these to the openshift version
 if [ "${UPSTREAM_IRONIC:-false}" != "false" ] ; then
     export IRONIC_LOCAL_IMAGE=${IRONIC_LOCAL_IMAGE:-"quay.io/metal3-io/ironic:master"}

--- a/utils.sh
+++ b/utils.sh
@@ -235,11 +235,10 @@ function generate_templates {
 
 function image_mirror_config {
     if [ ! -z "${MIRROR_IMAGES}" ]; then
-        TAG=$( echo $OPENSHIFT_RELEASE_IMAGE | sed -e 's/[[:alnum:]/.-]*release://' )
         TAGGED=$(echo $OPENSHIFT_RELEASE_IMAGE | sed -e 's/release://')
-        RELEASE=$(echo $OPENSHIFT_RELEASE_IMAGE | grep -o 'registry.svc.ci.openshift.org[^":]\+')
+        RELEASE=$(echo $OPENSHIFT_RELEASE_IMAGE | grep -o 'registry.svc.ci.openshift.org[^":\@]\+')
         INDENTED_CERT=$( cat $REGISTRY_DIR/certs/$REGISTRY_CRT | awk '{ print " ", $0 }' )
-        MIRROR_LOG_FILE=/tmp/tmp_image_mirror-${TAG}.log
+        MIRROR_LOG_FILE=/tmp/tmp_image_mirror-${OPENSHIFT_RELEASE_TAG}.log
         if [ ! -s ${MIRROR_LOG_FILE} ]; then
             cat << EOF
 imageContentSources:


### PR DESCRIPTION
A CI release image pullspec looks like this:

  registry.svc.ci.openshift.org/ci-op-cl986sps/release@sha256:a680697fcb21ae298d2ee4d25ca16f641c674bf3d5db6d670fe8a8bd03db5b89

Any raw pullspec that has a hash in it does not work with image
mirroring. This fixes it by properly handling this case.