### PR TITLE
Retrieve installer sha from installer container if present

### DIFF
--- a/03_build_installer.sh
+++ b/03_build_installer.sh
@@ -15,6 +15,7 @@ mkdir -p $OCP_DIR
 if [ -z "$KNI_INSTALL_FROM_GIT" ]; then
   # Extract openshift-install from the release image
   extract_installer "${OPENSHIFT_RELEASE_IMAGE}" $OCP_DIR
+  extract_rhcos_json "${OPENSHIFT_RELEASE_IMAGE}" $OCP_DIR
 else
   # Clone and build the installer from source
   clone_installer

--- a/rhcos.sh
+++ b/rhcos.sh
@@ -2,13 +2,13 @@ if [[ -f "$OCP_DIR/rhcos.json" ]]; then
   MACHINE_OS_IMAGE_JSON=$(cat "$OCP_DIR/rhcos.json")
 else
 
-	if [[ -v JOB_NAME ]] && [[ "$JOB_NAME" =~ "openshift-installer" ]]; then
-		# Get the SHA from the PR if we're in CI
-  	OPENSHIFT_INSTALL_COMMIT=${PULL_PULL_SHA:-$(echo "$JOB_SPEC" | jq -r '.refs.pulls[0].sha')}
-	else
-  	# Get the git commit that the openshift installer was built from
-	  OPENSHIFT_INSTALL_COMMIT=$($OPENSHIFT_INSTALLER version | grep commit | cut -d' ' -f4)
-	fi
+  if [[ -v JOB_NAME ]] && [[ "$JOB_NAME" =~ "openshift-installer" ]]; then
+    # Get the SHA from the PR if we're in CI
+    OPENSHIFT_INSTALL_COMMIT=${PULL_PULL_SHA:-$(echo "$JOB_SPEC" | jq -r '.refs.pulls[0].sha')}
+  else
+    # Get the git commit that the openshift installer was built from
+    OPENSHIFT_INSTALL_COMMIT=$($OPENSHIFT_INSTALLER version | grep commit | cut -d' ' -f4)
+  fi
 
   # Get the git commit that the openshift installer was built from
   OPENSHIFT_INSTALL_COMMIT=$($OPENSHIFT_INSTALLER version | grep commit | cut -d' ' -f4)

--- a/rhcos.sh
+++ b/rhcos.sh
@@ -1,5 +1,17 @@
-# Get the git commit that the openshift installer was built from
-OPENSHIFT_INSTALL_COMMIT=$($OPENSHIFT_INSTALLER version | grep commit | cut -d' ' -f4)
+# If we're in OpenShift CI, get the sha for our PR. The one openshift-install version
+# reports isn't correct due to how CI rebases the PR before building.
+#
+# FIXME(stbenjam): If a PR branch is not current with master, there is a
+# potential for rhcos.json to be out of date. The potential solutions to
+# this are not ideal, we'll either have to checkout the repo ourselves and
+# check or make a bunch of API calls to see if the PR modified
+# rhcos.json, otherwise just always get master.
+if [[ "$JOB_NAME" =~ "openshift-installer" ]]; then
+  OPENSHIFT_INSTALL_COMMIT=${PULL_PULL_SHA:-$(echo "$JOB_SPEC" | jq -r '.refs.pulls[0].sha')}
+else
+  # Get the git commit that the openshift installer was built from
+  OPENSHIFT_INSTALL_COMMIT=$($OPENSHIFT_INSTALLER version | grep commit | cut -d' ' -f4)
+fi
 
 # Get the rhcos.json for that commit
 OPENSHIFT_INSTALLER_MACHINE_OS=${OPENSHIFT_INSTALLER_MACHINE_OS:-https://raw.githubusercontent.com/openshift/installer/$OPENSHIFT_INSTALL_COMMIT/data/data/rhcos.json}

--- a/rhcos.sh
+++ b/rhcos.sh
@@ -1,23 +1,24 @@
-# If we're in OpenShift CI, get the sha for our PR. The one openshift-install version
-# reports isn't correct due to how CI rebases the PR before building.
-#
-# FIXME(stbenjam): If a PR branch is not current with master, there is a
-# potential for rhcos.json to be out of date. The potential solutions to
-# this are not ideal, we'll either have to checkout the repo ourselves and
-# check or make a bunch of API calls to see if the PR modified
-# rhcos.json, otherwise just always get master.
-if [[ "$JOB_NAME" =~ "openshift-installer" ]]; then
-  OPENSHIFT_INSTALL_COMMIT=${PULL_PULL_SHA:-$(echo "$JOB_SPEC" | jq -r '.refs.pulls[0].sha')}
+if [[ -f "$OCP_DIR/rhcos.json" ]]; then
+  MACHINE_OS_IMAGE_JSON=$(cat "$OCP_DIR/rhcos.json")
 else
+
+	if [[ "$JOB_NAME" =~ "openshift-installer" ]]; then
+		# Get the SHA from the PR if we're in CI
+  	OPENSHIFT_INSTALL_COMMIT=${PULL_PULL_SHA:-$(echo "$JOB_SPEC" | jq -r '.refs.pulls[0].sha')}
+	else
+  	# Get the git commit that the openshift installer was built from
+	  OPENSHIFT_INSTALL_COMMIT=$($OPENSHIFT_INSTALLER version | grep commit | cut -d' ' -f4)
+	fi
+
   # Get the git commit that the openshift installer was built from
   OPENSHIFT_INSTALL_COMMIT=$($OPENSHIFT_INSTALLER version | grep commit | cut -d' ' -f4)
+
+  # Get the rhcos.json for that commit
+  OPENSHIFT_INSTALLER_MACHINE_OS=${OPENSHIFT_INSTALLER_MACHINE_OS:-https://raw.githubusercontent.com/openshift/installer/$OPENSHIFT_INSTALL_COMMIT/data/data/rhcos.json}
+
+  # Get the rhcos.json for that commit, and find the baseURI and openstack image path
+  MACHINE_OS_IMAGE_JSON=$(curl "${OPENSHIFT_INSTALLER_MACHINE_OS}")
 fi
-
-# Get the rhcos.json for that commit
-OPENSHIFT_INSTALLER_MACHINE_OS=${OPENSHIFT_INSTALLER_MACHINE_OS:-https://raw.githubusercontent.com/openshift/installer/$OPENSHIFT_INSTALL_COMMIT/data/data/rhcos.json}
-
-# Get the rhcos.json for that commit, and find the baseURI and openstack image path
-MACHINE_OS_IMAGE_JSON=$(curl "${OPENSHIFT_INSTALLER_MACHINE_OS}")
 
 export MACHINE_OS_INSTALLER_IMAGE_URL=$(echo "${MACHINE_OS_IMAGE_JSON}" | jq -r '.baseURI + .images.openstack.path')
 export MACHINE_OS_INSTALLER_IMAGE_SHA256=$(echo "${MACHINE_OS_IMAGE_JSON}" | jq -r '.images.openstack.sha256')

--- a/rhcos.sh
+++ b/rhcos.sh
@@ -2,7 +2,7 @@ if [[ -f "$OCP_DIR/rhcos.json" ]]; then
   MACHINE_OS_IMAGE_JSON=$(cat "$OCP_DIR/rhcos.json")
 else
 
-	if [[ "$JOB_NAME" =~ "openshift-installer" ]]; then
+	if [[ -v JOB_NAME ]] && [[ "$JOB_NAME" =~ "openshift-installer" ]]; then
 		# Get the SHA from the PR if we're in CI
   	OPENSHIFT_INSTALL_COMMIT=${PULL_PULL_SHA:-$(echo "$JOB_SPEC" | jq -r '.refs.pulls[0].sha')}
 	else


### PR DESCRIPTION
If we're in OpenShift CI in an installer PR, then the installer is
built by rebasing on the target branch (i.e. master). The SHA that
`openshift-install version` reports doesn't exist on GitHub. It's only
in the environment that CI used to build the installer.

This gets the rhcos.json that's now in the baremetal-installer container. This avoids the CI problem, and avoids making any GitHub URL calls in 4.5 or later.