### PR TITLE
save a copy of the install config

### DIFF
--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -124,4 +124,6 @@ pullSecret: |
 sshKey: |
   ${SSH_PUB_KEY}
 EOF
+
+    cp "${outdir}/install-config.yaml" "${outdir}/install-config.yaml.save"
 }


### PR DESCRIPTION
When the installer runs, it removes the install config file, which
makes debugging a failed deployment more challenging. Make a backup
copy when we produce the real output file.