### PR TITLE
fix bootstrap vm volume cleanup

### DIFF
--- a/ocp_cleanup.sh
+++ b/ocp_cleanup.sh
@@ -38,7 +38,8 @@ for vm in $(sudo virsh list --all --name | grep "^${CLUSTER_NAME}.*bootstrap"); 
   sudo virsh undefine $vm --remove-all-storage
 done
 # The .ign volume isn't deleted via --remove-all-storage
-for v in $(sudo virsh vol-list --pool default | grep "^${CLUSTER_NAME}.*bootstrap" | awk '{print $1}'); do
+VOLS="$(sudo virsh vol-list --pool default | awk '{print $1}' | grep "^${CLUSTER_NAME}.*bootstrap")"
+for v in $VOLS; do
   sudo virsh vol-delete $v --pool default
 done
 


### PR DESCRIPTION
The volume list output starts with a blank space so the grep pattern
looking for the cluster name at the start of the line was not
matching. Fix this by switching the awk to extract the volume name to
the before the grep to filter the volumes.