### PR TITLE
add more cleanup scripts and Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: default all requirements configure ironic ocp_run clean ocp_cleanup ironic_cleanup host_cleanup bell
+.PHONY: default all requirements configure ironic ocp_run clean ocp_cleanup ironic_cleanup host_cleanup cache_cleanup registry_cleanup workingdir_cleanup podman_cleanup bell
 default: requirements configure build_installer ironic ocp_run bell
 
 all: default
@@ -30,6 +30,20 @@ ironic_cleanup:
 
 host_cleanup:
 	./host_cleanup.sh
+
+realclean: clean cache_cleanup registry_cleanup workingdir_cleanup podman_cleanup
+
+cache_cleanup:
+	./cache_cleanup.sh
+
+registry_cleanup:
+	./registry_cleanup.sh
+
+workingdir_cleanup:
+	./workingdir_cleanup.sh
+
+podman_cleanup:
+	./podman_cleanup.sh
 
 bell:
 	@echo "Done!" $$'\a'

--- a/cache_cleanup.sh
+++ b/cache_cleanup.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -x
+
+source logging.sh
+source common.sh
+
+rm -rf $HOME/.cache/openshift-installer

--- a/podman_cleanup.sh
+++ b/podman_cleanup.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -x
+
+source logging.sh
+source common.sh
+
+sudo podman image prune --all

--- a/registry_cleanup.sh
+++ b/registry_cleanup.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -x
+
+source logging.sh
+source common.sh
+
+sudo podman kill registry
+sudo podman rm registry
+
+sudo rm -rf $WORKING_DIR/registry

--- a/workingdir_cleanup.sh
+++ b/workingdir_cleanup.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -x
+
+source logging.sh
+source common.sh
+
+sudo rm -rf $WORKING_DIR


### PR DESCRIPTION
Use `make realclean` to run all of the new cleaning steps, in addition
to the old ones.

cache_cleanup.sh removes user cache files related to the installer.

registry_cleanup.sh removes the local registry service and its files.

workingdir_cleanup.sh removes the entire working directory.