### PR TITLE
Update some docs for new cluster dir location

### DIFF
--- a/demo/launch_demo_bmo.sh
+++ b/demo/launch_demo_bmo.sh
@@ -3,8 +3,8 @@
 # Run the baremetal operator locally in "demo" mode.
 #
 # This script assumes that you have ~/.kube/config set up, which may
-# mean copying ocp/auth/kubeconfig after running the scripts to build
-# a dev environment.
+# mean copying ocp/$CLUSTER_NAME/auth/kubeconfig after running the
+# scripts to build a dev environment.
 
 set -xe
 

--- a/docs/custom-mao-and-capbm.md
+++ b/docs/custom-mao-and-capbm.md
@@ -104,7 +104,7 @@ didn’t build a custom CAPBM.
 Update the `kubeconfig` path to reflect your own environment.
 
 ```sh
-bin/machine-api-operator start --images-json=custom-images.json --kubeconfig=/home/${USER}/dev-scripts/ocp/auth/kubeconfig -v 4
+bin/machine-api-operator start --images-json=custom-images.json --kubeconfig=/home/${USER}/dev-scripts/ocp/$CLUSTER_NAME/auth/kubeconfig -v 4
 ```
 
 ## Run a custom baremetal-operator


### PR DESCRIPTION
Fix couple of places still referring to `ocp/auth` instead of
`ocp/$CLUSTER_NAME/auth` after commit f64ebda3