### PR TITLE
Remove broken KUBECONFIG env var

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -208,8 +208,6 @@ export SUSHY_TOOLS_IMAGE=${SUSHY_TOOLS_IMAGE:-"quay.io/metal3-io/sushy-tools"}
 export VBMC_BASE_PORT=${VBMC_BASE_PORT:-"6230"}
 export VBMC_MAX_PORT=$((${VBMC_BASE_PORT} + ${NUM_MASTERS} + ${NUM_WORKERS} - 1))
 
-export KUBECONFIG="${SCRIPTDIR}/ocp/auth/kubeconfig"
-
 # Use a cloudy ssh that doesn't do Host Key checking
 export SSH="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5"
 


### PR DESCRIPTION
common.sh still points `KUBECONFIG` at `ocp/auth` instead of
`ocp/$CLUSTER_NAME/auth` but it moved in commit f64ebda

It looks like we don't actually need `KUBECONFIG` set anywhere these
days.