### PR TITLE
Add ASSETS_EXTRA_FOLDER for additional manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ EXTERNAL_SUBNET_V4="192.168.111.0/24"
 # merged with the installer provided config, can be used to modify
 # the default nic configuration etc
 export IGNITION_EXTRA=extra.ign
+# Folder where to copy extra manifests for the cluster deployment
+export ASSETS_EXTRA_FOLDER=local_file_path
 ```
 
 ## Installation

--- a/config_example.sh
+++ b/config_example.sh
@@ -165,6 +165,14 @@ set -x
 #export WORKER_DISK=20
 #export WORKER_VCPU=4
 
+# Provide additional master/worker ignition configuration, will be
+# merged with the installer provided config, can be used to modify
+# the default nic configuration etc
+#export IGNITION_EXTRA=extra.ign
+
+# Folder where to copy extra manifests for the cluster deployment
+#export ASSETS_EXTRA_FOLDER=local_file_path
+
 # Enable FIPS mode
 #export FIPS_MODE=true
 

--- a/utils.sh
+++ b/utils.sh
@@ -70,11 +70,15 @@ function create_cluster() {
       cp assets/metal3-cbo-deployment.yaml ${assets_dir}/openshift/.
     fi
 
+    if [ ! -z "${ASSETS_EXTRA_FOLDER:-}" ]; then
+      cp -rf ${ASSETS_EXTRA_FOLDER}/*.yaml ${assets_dir}/openshift/
+    fi
+
     if [ ! -z "${IGNITION_EXTRA:-}" ]; then
       $OPENSHIFT_INSTALLER --dir "${assets_dir}" --log-level=debug create ignition-configs
       if ! jq . ${IGNITION_EXTRA}; then
         echo "Error ${IGNITION_EXTRA} not valid json"
-	exit 1
+        exit 1
       fi
       mv ${assets_dir}/master.ign ${assets_dir}/master.ign.orig
       jq -s '.[0] * .[1]' ${IGNITION_EXTRA} ${assets_dir}/master.ign.orig | tee ${assets_dir}/master.ign


### PR DESCRIPTION
There is the need to deploy clusters with customized settings,
that will need to include additional manifests at deploy time.
Add the possibility to include an ASSETS_EXTRA_FOLDER, that will
allow to put additional manifests there and will be copied to
the manifests before install.

Signed-off-by: Yolanda Robla <yroblamo@redhat.com>