### PR TITLE
multi-cluster: make it possible to change the docker registry image

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -208,6 +208,9 @@ export SUSHY_TOOLS_IMAGE=${SUSHY_TOOLS_IMAGE:-"quay.io/metal3-io/sushy-tools"}
 export VBMC_BASE_PORT=${VBMC_BASE_PORT:-"6230"}
 export VBMC_MAX_PORT=$((${VBMC_BASE_PORT} + ${NUM_MASTERS} + ${NUM_WORKERS} - 1))
 
+# Which docker registry image should we use?
+export DOCKER_REGISTRY_IMAGE=${DOCKER_REGISTRY_IMAGE:-"docker.io/registry:latest"}
+
 export KUBECONFIG="${SCRIPTDIR}/ocp/$CLUSTER_NAME/auth/kubeconfig"
 
 # Use a cloudy ssh that doesn't do Host Key checking

--- a/utils.sh
+++ b/utils.sh
@@ -355,7 +355,7 @@ EOF
             -v ${REGISTRY_DIR}/certs:/certs:z \
             -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/${REGISTRY_CRT} \
             -e REGISTRY_HTTP_TLS_KEY=/certs/${REGISTRY_KEY} \
-            docker.io/registry:latest
+            ${DOCKER_REGISTRY_IMAGE}
     fi
 
 }


### PR DESCRIPTION
The latest image has a bug that prevents mirroring some images, so
make it possible to specify an older version.