### PR TITLE
multi-cluster: do not tie the registry hostname to the cluster name

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -79,7 +79,7 @@ else
   export DNS_VIP=${DNS_VIP:-"fd2e:6f44:5dd8:c956:0:0:0:2"}
   export MIRROR_IMAGES=true
 fi
-export LOCAL_REGISTRY_DNS_NAME=${LOCAL_REGISTRY_DNS_NAME:-"virthost.${CLUSTER_NAME}.${BASE_DOMAIN}"}
+export LOCAL_REGISTRY_DNS_NAME=${LOCAL_REGISTRY_DNS_NAME:-"virthost.${BASE_DOMAIN}"}
 
 # Provisioning network information
 export CLUSTER_PRO_IF=${CLUSTER_PRO_IF:-enp1s0}


### PR DESCRIPTION
Use a hostname that isn't tied to the cluster for the registry to
allow it to be used for multiple clusters.