### PR TITLE
multi-cluster: pass cluster name as VM prefix

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -47,6 +47,7 @@ fi
 
 ANSIBLE_FORCE_COLOR=true ansible-playbook \
     -e @vm_setup_vars.yml \
+    -e "cluster_name=${CLUSTER_NAME}" \
     -e "provisioning_network_name=${PROVISIONING_NETWORK_NAME}" \
     -e "baremetal_network_name=${BAREMETAL_NETWORK_NAME}" \
     -e "working_dir=$WORKING_DIR" \

--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -12,6 +12,7 @@ fi
 
 ANSIBLE_FORCE_COLOR=true ansible-playbook \
     -e @vm_setup_vars.yml \
+    -e "cluster_name=${CLUSTER_NAME}" \
     -e "provisioning_network_name=${PROVISIONING_NETWORK_NAME}" \
     -e "baremetal_network_name=${BAREMETAL_NETWORK_NAME}" \
     -e "working_dir=$WORKING_DIR" \

--- a/vm_setup_vars.yml
+++ b/vm_setup_vars.yml
@@ -3,7 +3,7 @@
 
 # Currently this is required because of hard-coded node-name expectations in the
 # openshift-installer terraform templates
-ironic_prefix: "openshift_"
+ironic_prefix: "{{ cluster_name }}_"
 
 # We enable more memory and masters in dev-scripts compared to the minimal setup
 # in metal3-dev-env


### PR DESCRIPTION
Use the cluster name as the prefix for VMs so they all have unique
names and we can tell which go with which cluster.