### PR TITLE
Pass NODES_FILE into teardown

### DIFF
--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -20,6 +20,7 @@ ANSIBLE_FORCE_COLOR=true ansible-playbook \
     -e "extradisks=$VM_EXTRADISKS" \
     -e "virthost=$HOSTNAME" \
     -e "manage_baremetal=$MANAGE_BR_BRIDGE" \
+    -e "nodes_file=$NODES_FILE" \
     -i ${VM_SETUP_PATH}/inventory.ini \
     -b -vvv ${VM_SETUP_PATH}/teardown-playbook.yml
 


### PR DESCRIPTION
So that it can be cleaned up.

Fixes: https://github.com/openshift-metal3/dev-scripts/issues/932
