### PR TITLE
Specify v4 and v6 subnets to m3-dev-env

### DIFF
--- a/vm_setup_vars.yml
+++ b/vm_setup_vars.yml
@@ -24,6 +24,8 @@ flavors:
 
 # For OpenShift we create some additional DNS records for the API/DNS VIPs
 baremetal_network_cidr: "{{ lookup('env', 'EXTERNAL_SUBNET') | default('192.168.111.0/24', true) }}"
+baremetal_network_cidr_v4: "{{ baremetal_network_cidr|ipv4 }}"
+baremetal_network_cidr_v6: "{{ baremetal_network_cidr|ipv6 }}"
 dns_extrahosts:
   - ip: "{{ baremetal_network_cidr | nthhost(5) }}"
     hostnames:


### PR DESCRIPTION
Update dev-scripts to specify the baremetal network subnets for IPv4
and IPv6 separate to be compatible with metal3-dev-env PR
https://github.com/metal3-io/metal3-dev-env/pull/280.

This should be harmless if it merges before the metal3-dev-env PR.