### PR TITLE
Deprecate CentOS 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ other components of OpenShift via support for a baremetal platform type.
 
 # Pre-requisites
 
-- CentOS 7.5 or greater (installed from 7.4 or newer) or RHEL8 host
+- CentOS 8 or RHEL 8 host
 - file system that supports d_type (see Troubleshooting section for more information)
 - ideally on a bare metal host with at least 64G of RAM
 - run as a user with passwordless sudo access

--- a/common.sh
+++ b/common.sh
@@ -235,8 +235,28 @@ fi
 
 # Check CentOS version
 VER=$(awk -F= '/^VERSION_ID=/ { print $2 }' /etc/os-release | tr -d '"' | cut -f1 -d'.')
-if [[ ${VER} -ne 7 ]] && [[ ${VER} -ne 8 ]]; then
-  echo "Required CentOS 7 / RHEL 7 / RHEL 8"
+if [[ ${VER} -eq 7 ]]; then
+  if [[ "${ALLOW_CENTOS7}" -ne "yes" ]]; then
+    echo "*****************************************************"
+    echo "*****************************************************"
+    echo "*****************************************************"
+    echo "***                                               ***"
+    echo "*** CentOS 7 Support has been deprecated and will ***"
+    echo "*** be removed in the near future.                ***"
+    echo "***                                               ***"
+    echo "*** Please upgrade your dev-scripts system to     ***"
+    echo "*** CentOS 8 or RHEL 8.                           ***"
+    echo "***                                               ***"
+    echo "*** To temporarily continue allowing CentOS 7,    ***"
+    echo "*** set ALLOW_CENTOS7=yes in your config file.    ***"
+    echo "***                                               ***"
+    echo "*****************************************************"
+    echo "*****************************************************"
+    echo "*****************************************************"
+    exit 1
+  fi
+elif [[ ${VER} -ne 8 ]]; then
+  echo "Required CentOS 8 / RHEL 8"
   exit 1
 fi
 


### PR DESCRIPTION
Most people have already moved to CentOS 8 or RHEL 8 at this point.
Let's give one last very clear warning that CentOS 7 is going away,
and then a bit later we can drop all related code for CentOS 7.

Closes #888