### PR TITLE
Ensure same release image is used for mirror and install

### DIFF
--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -71,6 +71,7 @@ if [ ! -z "${MIRROR_IMAGES}" ]; then
         --from ${OPENSHIFT_RELEASE_IMAGE} \
         --to-release-image ${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/local-release-image:${OPENSHIFT_RELEASE_TAG} \
         --to ${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/local-release-image 2>&1 | tee ${MIRROR_LOG_FILE}
+    echo "export MIRRORED_RELEASE_IMAGE=$OPENSHIFT_RELEASE_IMAGE" > /tmp/mirrored_release_image
 
     #To ensure that you use the correct images for the version of OpenShift Container Platform that you selected,
     #you must extract the installation program from the mirrored content:

--- a/utils.sh
+++ b/utils.sh
@@ -240,8 +240,9 @@ function generate_templates {
 
 function image_mirror_config {
     if [ ! -z "${MIRROR_IMAGES}" ]; then
-        TAGGED=$(echo $OPENSHIFT_RELEASE_IMAGE | sed -e 's/release://')
-        RELEASE=$(echo $OPENSHIFT_RELEASE_IMAGE | grep -o 'registry.svc.ci.openshift.org[^":\@]\+')
+        . /tmp/mirrored_release_image
+        TAGGED=$(echo $MIRRORED_RELEASE_IMAGE | sed -e 's/release://')
+        RELEASE=$(echo $MIRRORED_RELEASE_IMAGE | grep -o 'registry.svc.ci.openshift.org[^":\@]\+')
         INDENTED_CERT=$( cat $REGISTRY_DIR/certs/$REGISTRY_CRT | awk '{ print " ", $0 }' )
         MIRROR_LOG_FILE=/tmp/tmp_image_mirror-${OPENSHIFT_RELEASE_TAG}.log
         if [ ! -s ${MIRROR_LOG_FILE} ]; then


### PR DESCRIPTION
If a new release image is published between when the local mirror is
created and when the install-config file is created, it is possible
that the releases used may not match. This causes the local mirror
to not be used, which results in either unnecessary external traffic
or complete failure, depending on the situation.

This change writes the mirrored release image to a temp file so it
can be retrieved later when install-config is generated. This way
we know the same release image is used for both.

Closes #1001