### PR TITLE
multi-cluster: separate install config from cluster build

### DIFF
--- a/05_create_install_config.sh
+++ b/05_create_install_config.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -x
+set -e
+
+source logging.sh
+source utils.sh
+source common.sh
+source ocp_install_env.sh
+source rhcos.sh
+
+# Do some PULL_SECRET sanity checking
+if [[ "${OPENSHIFT_RELEASE_IMAGE}" == *"registry.svc.ci.openshift.org"* ]]; then
+    if [[ "${PULL_SECRET}" != *"registry.svc.ci.openshift.org"* ]]; then
+        echo "Please get a valid pull secret for registry.svc.ci.openshift.org."
+        exit 1
+    fi
+fi
+
+if [[ "${PULL_SECRET}" != *"cloud.openshift.com"* ]]; then
+    echo "Please get a valid pull secret for cloud.openshift.com."
+    exit 1
+fi
+
+# NOTE: This is equivalent to the external API DNS record pointing the API to the API VIP
+if [ "$MANAGE_BR_BRIDGE" == "y" ] ; then
+    if [[ -n "${EXTERNAL_SUBNET_V6}" ]]; then
+        API_VIP=$(dig -t AAAA +noall +answer "api.${CLUSTER_DOMAIN}" @$(network_ip ${BAREMETAL_NETWORK_NAME}) | awk '{print $NF}')
+        INGRESS_VIP=$(python -c "from ansible.plugins.filter import ipaddr; print(ipaddr.nthhost('"$EXTERNAL_SUBNET_V6"', 4))")
+    else
+        API_VIP=$(dig +noall +answer "api.${CLUSTER_DOMAIN}" @$(network_ip ${BAREMETAL_NETWORK_NAME}) | awk '{print $NF}')
+        INGRESS_VIP=$(python -c "from ansible.plugins.filter import ipaddr; print(ipaddr.nthhost('"$EXTERNAL_SUBNET_V4"', 4))")
+    fi
+    echo "address=/api.${CLUSTER_DOMAIN}/${API_VIP}" | sudo tee -a /etc/NetworkManager/dnsmasq.d/openshift-${CLUSTER_NAME}.conf
+    echo "address=/.apps.${CLUSTER_DOMAIN}/${INGRESS_VIP}" | sudo tee -a /etc/NetworkManager/dnsmasq.d/openshift-${CLUSTER_NAME}.conf
+    echo "listen-address=::1" | sudo tee -a /etc/NetworkManager/dnsmasq.d/openshift-${CLUSTER_NAME}.conf
+    sudo systemctl reload NetworkManager
+else
+    if [[ -n "${EXTERNAL_SUBNET_V6}" ]]; then
+        API_VIP=$(dig -t AAAA +noall +answer "api.${CLUSTER_DOMAIN}"  | awk '{print $NF}')
+    else
+        API_VIP=$(dig +noall +answer "api.${CLUSTER_DOMAIN}"  | awk '{print $NF}')
+    fi
+    INGRESS_VIP=$(dig +noall +answer "test.apps.${CLUSTER_DOMAIN}" | awk '{print $NF}')
+fi
+
+if [ ! -f ${OCP_DIR}/install-config.yaml ]; then
+    # Validate there are enough nodes to avoid confusing errors later..
+    NODES_LEN=$(jq '.nodes | length' ${NODES_FILE})
+    if (( $NODES_LEN < ( $NUM_MASTERS + $NUM_WORKERS ) )); then
+        echo "ERROR: ${NODES_FILE} contains ${NODES_LEN} nodes, but ${NUM_MASTERS} masters and ${NUM_WORKERS} workers requested"
+        exit 1
+    fi
+
+    # Create a nodes.json file
+    mkdir -p ${OCP_DIR}
+    jq '{nodes: .}' "${NODES_FILE}" | tee "${BAREMETALHOSTS_FILE}"
+
+    # Create install config for openshift-installer
+    generate_ocp_install_config ${OCP_DIR}
+fi

--- a/06_create_cluster.sh
+++ b/06_create_cluster.sh
@@ -8,57 +8,6 @@ source common.sh
 source ocp_install_env.sh
 source rhcos.sh
 
-# Do some PULL_SECRET sanity checking
-if [[ "${OPENSHIFT_RELEASE_IMAGE}" == *"registry.svc.ci.openshift.org"* ]]; then
-    if [[ "${PULL_SECRET}" != *"registry.svc.ci.openshift.org"* ]]; then
-        echo "Please get a valid pull secret for registry.svc.ci.openshift.org."
-        exit 1
-    fi
-fi
-
-if [[ "${PULL_SECRET}" != *"cloud.openshift.com"* ]]; then
-    echo "Please get a valid pull secret for cloud.openshift.com."
-    exit 1
-fi
-
-# NOTE: This is equivalent to the external API DNS record pointing the API to the API VIP
-if [ "$MANAGE_BR_BRIDGE" == "y" ] ; then
-    if [[ -n "${EXTERNAL_SUBNET_V6}" ]]; then
-        API_VIP=$(dig -t AAAA +noall +answer "api.${CLUSTER_DOMAIN}" @$(network_ip ${BAREMETAL_NETWORK_NAME}) | awk '{print $NF}')
-        INGRESS_VIP=$(python -c "from ansible.plugins.filter import ipaddr; print(ipaddr.nthhost('"$EXTERNAL_SUBNET_V6"', 4))")
-    else
-        API_VIP=$(dig +noall +answer "api.${CLUSTER_DOMAIN}" @$(network_ip ${BAREMETAL_NETWORK_NAME}) | awk '{print $NF}')
-        INGRESS_VIP=$(python -c "from ansible.plugins.filter import ipaddr; print(ipaddr.nthhost('"$EXTERNAL_SUBNET_V4"', 4))")
-    fi
-    echo "address=/api.${CLUSTER_DOMAIN}/${API_VIP}" | sudo tee -a /etc/NetworkManager/dnsmasq.d/openshift-${CLUSTER_NAME}.conf
-    echo "address=/.apps.${CLUSTER_DOMAIN}/${INGRESS_VIP}" | sudo tee -a /etc/NetworkManager/dnsmasq.d/openshift-${CLUSTER_NAME}.conf
-    echo "listen-address=::1" | sudo tee -a /etc/NetworkManager/dnsmasq.d/openshift-${CLUSTER_NAME}.conf
-    sudo systemctl reload NetworkManager
-else
-    if [[ -n "${EXTERNAL_SUBNET_V6}" ]]; then
-        API_VIP=$(dig -t AAAA +noall +answer "api.${CLUSTER_DOMAIN}"  | awk '{print $NF}')
-    else
-        API_VIP=$(dig +noall +answer "api.${CLUSTER_DOMAIN}"  | awk '{print $NF}')
-    fi
-    INGRESS_VIP=$(dig +noall +answer "test.apps.${CLUSTER_DOMAIN}" | awk '{print $NF}')
-fi
-
-if [ ! -f ${OCP_DIR}/install-config.yaml ]; then
-    # Validate there are enough nodes to avoid confusing errors later..
-    NODES_LEN=$(jq '.nodes | length' ${NODES_FILE})
-    if (( $NODES_LEN < ( $NUM_MASTERS + $NUM_WORKERS ) )); then
-        echo "ERROR: ${NODES_FILE} contains ${NODES_LEN} nodes, but ${NUM_MASTERS} masters and ${NUM_WORKERS} workers requested"
-        exit 1
-    fi
-
-    # Create a nodes.json file
-    mkdir -p ${OCP_DIR}
-    jq '{nodes: .}' "${NODES_FILE}" | tee "${BAREMETALHOSTS_FILE}"
-
-    # Create install config for openshift-installer
-    generate_ocp_install_config ${OCP_DIR}
-fi
-
 # Call openshift-installer to deploy the bootstrap node and masters
 create_cluster ${OCP_DIR}
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
-.PHONY: default all requirements configure ironic ocp_run clean ocp_cleanup ironic_cleanup host_cleanup cache_cleanup registry_cleanup workingdir_cleanup podman_cleanup bell
-default: requirements configure build_installer ironic ocp_run bell
+.PHONY: default all requirements configure ironic ocp_run install_config clean ocp_cleanup ironic_cleanup host_cleanup cache_cleanup registry_cleanup workingdir_cleanup podman_cleanup bell
+default: requirements configure build_installer ironic install_config ocp_run bell
 
 all: default
 
-redeploy: ocp_cleanup ironic_cleanup build_installer ironic ocp_run bell
+redeploy: ocp_cleanup ironic_cleanup build_installer ironic install_config ocp_run bell
 
 requirements:
 	./01_install_requirements.sh
@@ -16,6 +16,9 @@ build_installer:
 
 ironic:
 	./04_setup_ironic.sh
+
+install_config:
+	./05_create_install_config.sh
 
 ocp_run:
 	./06_create_cluster.sh


### PR DESCRIPTION
When we use dev-scripts to build the infrastructure for a cluster,
we might not want it to actually run the installer. This change
separates the steps for generating the install config from the
steps for building the cluster so we can be explicit about that.