### PR TITLE
add variable to control use of remote libvirturi in install-config

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -83,8 +83,12 @@ export LOCAL_REGISTRY_DNS_NAME=${LOCAL_REGISTRY_DNS_NAME:-"virthost.${CLUSTER_NA
 
 # Provisioning network information
 export CLUSTER_PRO_IF=${CLUSTER_PRO_IF:-enp1s0}
-
 export PROVISIONING_NETMASK=${PROVISIONING_NETMASK:-$(ipcalc --netmask $PROVISIONING_NETWORK | cut -d= -f2)}
+
+# Hypervisor details
+export REMOTE_LIBVIRT=${REMOTE_LIBVIRT:-0}
+export PROVISIONING_HOST_USER=${PROVISIONING_HOST_USER:-$USER}
+
 # ipcalc on CentOS 7 doesn't support the 'minaddr' option, so use python
 # instead to get the first address in the network:
 export PROVISIONING_HOST_IP=${PROVISIONING_HOST_IP:-$(python -c "import ipaddress; print(next(ipaddress.ip_network(u\"$PROVISIONING_NETWORK\").hosts()))")}

--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -85,6 +85,14 @@ EOF
   fi
 }
 
+function libvirturi() {
+    if [[ "$REMOTE_LIBVIRT" -ne 0 ]]; then
+cat <<EOF
+    libvirtURI: qemu+ssh://${PROVISIONING_HOST_USER}@$(wrap_if_ipv6 ${PROVISIONING_HOST_IP})/system
+EOF
+    fi
+}
+
 function generate_ocp_install_config() {
     local outdir
 
@@ -128,6 +136,7 @@ controlPlane:
     baremetal: {}
 platform:
   baremetal:
+$(libvirturi)
 $(network_configuration)
     externalBridge: ${BAREMETAL_NETWORK_NAME}
     provisioningBridge: ${PROVISIONING_NETWORK_NAME}


### PR DESCRIPTION
We only want to use the remote libvirt feature when configuring a
cluster for hive, so use a flag to toggle that behavior.