### PR TITLE
move the mirror log file to working dir with cluster-specific name

### DIFF
--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -61,9 +61,8 @@ if [ ! -z "${MIRROR_IMAGES}" ]; then
     # pull from one registry and push to local one
     # hence credentials are different
 
-    EXTRACT_DIR=$(mktemp -d "mirror-installer--XXXXXXXXXX")
+    EXTRACT_DIR=$(mktemp --tmpdir -d "mirror-installer--XXXXXXXXXX")
     _tmpfiles="$_tmpfiles $EXTRACT_DIR"
-    MIRROR_LOG_FILE=/tmp/tmp_image_mirror-${OPENSHIFT_RELEASE_TAG}.log
 
     oc adm release mirror \
        --insecure=true \

--- a/common.sh
+++ b/common.sh
@@ -231,6 +231,10 @@ if [[ "$OPENSHIFT_VERSION" != "4.3" ]]; then
   export BMC_DRIVER=${BMC_DRIVER:-redfish}
 fi
 
+# Both utils.sh and 04_setup_ironic.sh use this log file, so set the
+# name one time. Users should not override this.
+export MIRROR_LOG_FILE=${REGISTRY_DIR}/${CLUSTER_NAME}-image_mirror-${OPENSHIFT_RELEASE_TAG}.log
+
 # Switch Container Images to upstream, Installer defaults these to the openshift version
 if [ "${UPSTREAM_IRONIC:-false}" != "false" ] ; then
     export IRONIC_LOCAL_IMAGE=${IRONIC_LOCAL_IMAGE:-"quay.io/metal3-io/ironic:master"}

--- a/utils.sh
+++ b/utils.sh
@@ -244,7 +244,6 @@ function image_mirror_config {
         TAGGED=$(echo $MIRRORED_RELEASE_IMAGE | sed -e 's/release://')
         RELEASE=$(echo $MIRRORED_RELEASE_IMAGE | grep -o 'registry.svc.ci.openshift.org[^":\@]\+')
         INDENTED_CERT=$( cat $REGISTRY_DIR/certs/$REGISTRY_CRT | awk '{ print " ", $0 }' )
-        MIRROR_LOG_FILE=/tmp/tmp_image_mirror-${OPENSHIFT_RELEASE_TAG}.log
         if [ ! -s ${MIRROR_LOG_FILE} ]; then
             cat << EOF
 imageContentSources:


### PR DESCRIPTION
We want the file to have the cluster name in it so we get different
mirror instructions for each cluster. We want the file to be in a
place that we clean up when we clean the registry so we don't
use stale info.