### PR TITLE
multi-cluster: add script to install hive with required configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,4 +301,3 @@ The following adds an additional file `/etc/test` as an example:
 ```
 export IGNITION_EXTRA="ignition/file_example.ign"
 ``` 
-

--- a/common.sh
+++ b/common.sh
@@ -122,6 +122,9 @@ fi
 export OPENSHIFT_RELEASE_IMAGE="${OPENSHIFT_RELEASE_IMAGE:-$LATEST_CI_IMAGE}"
 export OPENSHIFT_INSTALL_PATH="$GOPATH/src/github.com/openshift/installer"
 
+# Override the image to use for installing hive
+export HIVE_DEPLOY_IMAGE="${HIVE_DEPLOY_IMAGE:-registry.svc.ci.openshift.org/openshift/hive-v4.0:hive}"
+
 # CI images don't have version numbers
 export OPENSHIFT_CI=${OPENSHIFT_CI:-""}
 if [[ -z "$OPENSHIFT_CI" ]]; then

--- a/config_example.sh
+++ b/config_example.sh
@@ -130,3 +130,10 @@ set -x
 #export WORKER_MEMORY=8192
 #export WORKER_DISK=20
 #export WORKER_VCPU=4
+
+##
+## Multi-cluster/Hive variables
+##
+
+# Image reference for installing hive. See hive_install.sh.
+#export HIVE_DEPLOY_IMAGE="registry.svc.ci.openshift.org/openshift/hive-v4.0:hive"

--- a/hive_install.sh
+++ b/hive_install.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -ex
+
+source logging.sh
+source common.sh
+source utils.sh
+
+# The variable used by "make deploy" below is set here so we can
+# change it if we need to mirror the image.
+export DEPLOY_IMAGE="${HIVE_DEPLOY_IMAGE}"
+
+if [ ! -z "${MIRROR_IMAGES}" ]; then
+    # Mirror hive itself
+    DEPLOY_IMAGE="${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/hive:latest"
+    oc image mirror \
+       -a ${REGISTRY_CREDS} \
+       ${HIVE_DEPLOY_IMAGE} \
+       ${DEPLOY_IMAGE}
+fi
+
+# Check out hive and install it. This has to be done in the GOPATH
+# location because the installation uses 'go run' which needs to
+# compile the command it is using.
+if [[ ! -d $GOPATH/src/github.com/openshift/hive ]]; then
+    sync_repo_and_patch go/src/github.com/openshift/hive https://github.com/openshift/hive.git
+fi
+pushd $HOME/go/src/github.com/openshift/hive
+
+make deploy
+
+# Installing launches an operator, which can take a little while to be
+# all the way up. We need to modify it's config resource, so we watch
+# for it to be created before continuing.
+while ! oc get hiveconfig hive -n hive 2>/dev/null 1>&2; do
+    echo "Waiting for hiveconfig to be ready..."
+    sleep 10
+done
+
+# Disable log collection because it requires persistent storage, which
+# a dev-scripts cluster does not have by default.
+oc patch hiveconfig hive -n hive --type=merge \
+   --patch="
+spec:
+  failedProvisionConfig:
+    skipGatherLogs: true
+"
+
+oc get hiveconfig hive -n hive -o yaml


### PR DESCRIPTION
Include a variable for managing which hive image to use.  This makes it
easier to deploy a private build consistently.