### PR TITLE
Revert dual stack changes and pin metal3-dev-env

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -13,7 +13,10 @@ if [ -z "${METAL3_DEV_ENV}" ]; then
   sync_repo_and_patch metal3-dev-env https://github.com/metal3-io/metal3-dev-env.git
   METAL3_DEV_ENV="${REPO_PATH}/metal3-dev-env/"
 fi
+
 pushd ${METAL3_DEV_ENV}
+# FIXME: Pin to aafbb89df8df88bc3ecbfe59592149c929432515
+git reset aafbb89df8df88bc3ecbfe59592149c929432515 --hard
 ./centos_install_requirements.sh
 ansible-galaxy install -r vm-setup/requirements.yml
 ANSIBLE_FORCE_COLOR=true ansible-playbook \

--- a/vm_setup_vars.yml
+++ b/vm_setup_vars.yml
@@ -24,8 +24,6 @@ flavors:
 
 # For OpenShift we create some additional DNS records for the API/DNS VIPs
 baremetal_network_cidr: "{{ lookup('env', 'EXTERNAL_SUBNET') | default('192.168.111.0/24', true) }}"
-baremetal_network_cidr_v4: "{{ baremetal_network_cidr|ipv4 }}"
-baremetal_network_cidr_v6: "{{ baremetal_network_cidr|ipv6 }}"
 dns_extrahosts:
   - ip: "{{ baremetal_network_cidr | nthhost(5) }}"
     hostnames:

--- a/vm_setup_vars.yml
+++ b/vm_setup_vars.yml
@@ -44,8 +44,7 @@ networks:
   - name: "{{ baremetal_network_name }}"
     bridge: "{{ baremetal_network_name }}"
     forward_mode: "{{ 'bridge' if lookup('env', 'MANAGE_BR_BRIDGE') == 'n' else 'nat' }}"
-    address_v4: "{{ baremetal_network_cidr_v4|nthhost(1)|default('', true) }}"
-    address_v6: "{{ baremetal_network_cidr_v6|nthhost(1)|default('', true) }}"
+    address: "{{ baremetal_network_cidr|nthhost(1) }}"
     netmask: "{{ baremetal_network_cidr|ipaddr('netmask') }}"
     dhcp_range:
       - "{{ baremetal_network_cidr|nthhost(20) }}"


### PR DESCRIPTION
Unfortunately it looks like this still isn't working, so going to revert and pin to an older metal3-dev-env commit.

When it's working we can get a dev-scripts PR open to restore this and then confirm with CI things pass.