### PR TITLE
Export WORKING_DIR in common.sh

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -101,7 +101,7 @@ export PROVISIONING_HOST_EXTERNAL_IP=${PROVISIONING_HOST_EXTERNAL_IP:-$(python -
 export MIRROR_IP=${MIRROR_IP:-$PROVISIONING_HOST_IP}
 
 # The dev-scripts working directory
-WORKING_DIR=${WORKING_DIR:-"/opt/dev-scripts"}
+export WORKING_DIR=${WORKING_DIR:-"/opt/dev-scripts"}
 OCP_DIR=${OCP_DIR:-ocp/${CLUSTER_NAME}}
 
 # variables for local registry configuration


### PR DESCRIPTION
Not exporting it results in a default being used in
./centos_install_requirements.sh, which ends up in an
empty "/opt/metal3-dev-env/" directory being created
by dev-scripts.