### PR TITLE
Add dual stack IPv4+IPv6 support

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -15,8 +15,10 @@ if [ -z "${METAL3_DEV_ENV}" ]; then
 fi
 
 pushd ${METAL3_DEV_ENV}
-# FIXME: Pin to aafbb89df8df88bc3ecbfe59592149c929432515
-git reset aafbb89df8df88bc3ecbfe59592149c929432515 --hard
+# Pin to a specific metal3-dev-env commit to ensure we catch breaking
+# changes before they're used by everyone and CI.
+# TODO -- come up with a plan for continuously updating this
+git reset b19da74e06062d0c21ade7dea1c6e8d09f7f4e48 --hard
 ./centos_install_requirements.sh
 ansible-galaxy install -r vm-setup/requirements.yml
 ANSIBLE_FORCE_COLOR=true ansible-playbook \

--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -131,7 +131,7 @@ if [ "$MANAGE_INT_BRIDGE" == "y" ]; then
     # external access so we need to make sure we maintain dhcp config if its available
     if [ "$INT_IF" ]; then
         echo -e "DEVICE=$INT_IF\nTYPE=Ethernet\nONBOOT=yes\nNM_CONTROLLED=no\nBRIDGE=${BAREMETAL_NETWORK_NAME}" | sudo dd of=/etc/sysconfig/network-scripts/ifcfg-$INT_IF
-        if [[ $EXTERNAL_SUBNET =~ .*:.* ]]; then
+        if [[ -n "${EXTERNAL_SUBNET_V6}" ]]; then
              grep -q BOOTPROTO /etc/sysconfig/network-scripts/ifcfg-${BAREMETAL_NETWORK_NAME} || (echo -e "BOOTPROTO=none\nIPV6INIT=yes\nIPV6_AUTOCONF=yes\nDHCPV6C=yes\nDHCPV6C_OPTIONS='-D LL'\n" | sudo tee -a /etc/sysconfig/network-scripts/ifcfg-${BAREMETAL_NETWORK_NAME})
         else
            if sudo nmap --script broadcast-dhcp-discover -e $INT_IF | grep "IP Offered" ; then

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ DNS_VIP="1.1.1.1"
 # Set your default network type, `OpenShiftSDN` or `OVNKubernetes`, defaults to `OpenShiftSDN`
 NETWORK_TYPE="OpenShiftSDN"
 # Set to the subnet in use on the external (baremetal) network
-EXTERNAL_SUBNET="192.168.111.0/24"
+EXTERNAL_SUBNET_V4="192.168.111.0/24"
 # Provide additional master/worker ignition configuration, will be
 # merged with the installer provided config, can be used to modify
 # the default nic configuration etc

--- a/common.sh
+++ b/common.sh
@@ -63,24 +63,110 @@ export MIRROR_IMAGES=${MIRROR_IMAGES:-}
 
 export IP_STACK=${IP_STACK:-"v6"}
 
+EXTERNAL_SUBNET=${EXTERNAL_SUBNET:-""}
+EXTERNAL_SUBNET_V4=${EXTERNAL_SUBNET_V4:-""}
+EXTERNAL_SUBNET_V6=${EXTERNAL_SUBNET_V6:-""}
+if [[ -n "${EXTERNAL_SUBNET}" ]] && [[ -z "${EXTERNAL_SUBNET_V4}" ]] && [[ -z "${EXTERNAL_SUBNET_V6}" ]]; then
+    # Backwards compatibility.  If the old var was specified, and neither of the new
+    # vars are set, automatically adapt it to the right new var.
+    if [[ "${EXTERNAL_SUBNET}" =~ .*:.* ]]; then
+        export EXTERNAL_SUBNET_V6="${EXTERNAL_SUBNET}"
+    else
+        export EXTERNAL_SUBNET_V4="${EXTERNAL_SUBNET}"
+    fi
+elif [[ -n "${EXTERNAL_SUBNET}" ]]; then
+    echo "EXTERNAL_SUBNET has been removed in favor of EXTERNAL_SUBNET_V4 and EXTERNAL_NETWORK_V6."
+    echo "Please update your configuration to drop the use of EXTERNAL_SUBNET."
+    exit 1
+fi
+
+SERVICE_SUBNET=${SERVICE_SUBNET:-""}
+SERVICE_SUBNET_V4=${SERVICE_SUBNET_V4:-""}
+SERVICE_SUBNET_V6=${SERVICE_SUBNET_V6:-""}
+if [[ -n "${SERVICE_SUBNET}" ]] && [[ -z "${SERVICE_SUBNET_V4}" ]] && [[ -z "${SERVICE_SUBNET_V6}" ]]; then
+    # Backwards compatibility.  If the old var was specified, and neither of the new
+    # vars are set, automatically adapt it to the right new var.
+    if [[ "${SERVICE_SUBNET}" =~ .*:.* ]]; then
+        export SERVICE_SUBNET_V6="${SERVICE_SUBNET}"
+    else
+        export SERVICE_SUBNET_V4="${SERVICE_SUBNET}"
+    fi
+elif [[ -n "${SERVICE_SUBNET}" ]]; then
+    echo "SERVICE_SUBNET has been removed in favor of SERVICE_SUBNET_V4 and SERVICE_SUBNET_V6."
+    echo "Please update your configuration to drop the use of SERVICE_SUBNET."
+    exit 1
+fi
+
+CLUSTER_SUBNET=${CLUSTER_SUBNET:-""}
+CLUSTER_SUBNET_V4=${CLUSTER_SUBNET_V4:-""}
+CLUSTER_SUBNET_V6=${CLUSTER_SUBNET_V6:-""}
+CLUSTER_HOST_PREFIX=${CLUSTER_HOST_PREFIX:-""}
+CLUSTER_HOST_PREFIX_V4=${CLUSTER_HOST_PREFIX_V4:-""}
+CLUSTER_HOST_PREFIX_V6=${CLUSTER_HOST_PREFIX_V6:-""}
+if [[ -n "${CLUSTER_SUBNET}" ]] && [[ -z "${CLUSTER_SUBNET_V4}" ]] && [[ -z "${CLUSTER_SUBNET_V6}" ]]; then
+    # Backwards compatibility.  If the old var was specified, and neither of the new
+    # vars are set, automatically adapt it to the right new var.
+    if [[ "${CLUSTER_SUBNET}" =~ .*:.* ]]; then
+        export CLUSTER_SUBNET_V6="${CLUSTER_SUBNET}"
+        export CLUSTER_HOST_PREFIX_V6="${CLUSTER_HOST_PREFIX_V6:-${CLUSTER_HOST_PREFIX}}"
+    else
+        export CLUSTER_SUBNET_V4="${CLUSTER_SUBNET}"
+        export CLUSTER_HOST_PREFIX_V4="${CLUSTER_HOST_PREFIX_V4:-${CLUSTER_HOST_PREFIX}}"
+    fi
+elif [[ -n "${CLUSTER_SUBNET}" ]]; then
+    echo "CLUSTER_SUBNET has been removed in favor of CLUSTER_SUBNET_V4 and CLUSTER_SUBNET_V6."
+    echo "Please update your configuration to drop the use of CLUSTER_SUBNET."
+    exit 1
+fi
+
+
 if [[ "$IP_STACK" = "v4" ]]
 then
   export PROVISIONING_NETWORK=${PROVISIONING_NETWORK:-"172.22.0.0/24"}
-  export EXTERNAL_SUBNET=${EXTERNAL_SUBNET:-"192.168.111.0/24"}
-  export CLUSTER_SUBNET=${CLUSTER_SUBNET:-"10.128.0.0/14"}
-  export CLUSTER_HOST_PREFIX=${CLUSTER_HOST_PREFIX:-"23"}
-  export SERVICE_SUBNET=${SERVICE_SUBNET:-"172.30.0.0/16"}
+  export EXTERNAL_SUBNET_V4=${EXTERNAL_SUBNET_V4:-"192.168.111.0/24"}
+  export EXTERNAL_SUBNET_V6=""
+  export CLUSTER_SUBNET_V4=${CLUSTER_SUBNET_V4:-"10.128.0.0/14"}
+  export CLUSTER_SUBNET_V6=""
+  export CLUSTER_HOST_PREFIX_V4=${CLUSTER_HOST_PREFIX_V4:-"23"}
+  export CLUSTER_HOST_PREFIX_V6=""
+  export SERVICE_SUBNET_V4=${SERVICE_SUBNET_V4:-"172.30.0.0/16"}
+  export SERVICE_SUBNET_V6=""
   export NETWORK_TYPE=${NETWORK_TYPE:-"OpenShiftSDN"}
-else
+elif [[ "$IP_STACK" = "v6" ]]; then
   export PROVISIONING_NETWORK=${PROVISIONING_NETWORK:-"fd00:1101::0/64"}
-  export EXTERNAL_SUBNET=${EXTERNAL_SUBNET:-"fd2e:6f44:5dd8:c956::/120"}
-  export CLUSTER_SUBNET=${CLUSTER_SUBNET:-"fd01::/48"}
-  export CLUSTER_HOST_PREFIX=${CLUSTER_HOST_PREFIX:-"64"}
-  export SERVICE_SUBNET=${SERVICE_SUBNET:-"fd02::/112"}
+  export EXTERNAL_SUBNET_V4=""
+  export EXTERNAL_SUBNET_V6=${EXTERNAL_SUBNET_V6:-"fd2e:6f44:5dd8:c956::/120"}
+  export CLUSTER_SUBNET_V4=""
+  export CLUSTER_SUBNET_V6=${CLUSTER_SUBNET_V6:-"fd01::/48"}
+  export CLUSTER_HOST_PREFIX_V4=""
+  export CLUSTER_HOST_PREFIX_V6=${CLUSTER_HOST_PREFIX_V6:-"64"}
+  export SERVICE_SUBNET_V4=""
+  export SERVICE_SUBNET_V6=${SERVICE_SUBNET_V6:-"fd02::/112"}
   export NETWORK_TYPE=${NETWORK_TYPE:-"OVNKubernetes"}
   export MIRROR_IMAGES=true
+elif [[ "$IP_STACK" = "v4v6" ]]; then
+  export PROVISIONING_NETWORK=${PROVISIONING_NETWORK:-"fd00:1101::0/64"}
+  export EXTERNAL_SUBNET_V4=${EXTERNAL_SUBNET_V4:-"192.168.111.0/24"}
+  export EXTERNAL_SUBNET_V6=${EXTERNAL_SUBNET_V6:-"fd2e:6f44:5dd8:c956::/120"}
+  export CLUSTER_SUBNET_V4=${CLUSTER_SUBNET_V4:-"10.128.0.0/14"}
+  export CLUSTER_SUBNET_V6=${CLUSTER_SUBNET_V6:-"fd01::/48"}
+  export CLUSTER_HOST_PREFIX_V4=${CLUSTER_HOST_PREFIX_V4:-"23"}
+  export CLUSTER_HOST_PREFIX_V6=${CLUSTER_HOST_PREFIX_V6:-"64"}
+  export SERVICE_SUBNET_V4=${SERVICE_SUBNET_V4:-"172.30.0.0/16"}
+  export SERVICE_SUBNET_V6=${SERVICE_SUBNET_V6:-"fd02::/112"}
+  export NETWORK_TYPE=${NETWORK_TYPE:-"OVNKubernetes"}
+  export MIRROR_IMAGES=true
+else
+  echo "Unexpected setting for IP_STACK: '${IP_STACK}'"
+  exit 1
 fi
-export DNS_VIP=${DNS_VIP:-$(python -c "import ipaddress; print(ipaddress.ip_network(u\"$EXTERNAL_SUBNET\")[2])")}
+
+if [[ "${IP_STACK}" = "v4" ]]; then
+  export DNS_VIP=${DNS_VIP:-$(python -c "import ipaddress; print(ipaddress.ip_network(u\"$EXTERNAL_SUBNET_V4\")[2])")}
+else
+  export DNS_VIP=${DNS_VIP:-$(python -c "import ipaddress; print(ipaddress.ip_network(u\"$EXTERNAL_SUBNET_V6\")[2])")}
+fi
+
 # The DNS name for the registry that this cluster should use.
 export LOCAL_REGISTRY_DNS_NAME=${LOCAL_REGISTRY_DNS_NAME:-"virthost.${CLUSTER_NAME}.${BASE_DOMAIN}"}
 # All DNS names for the registry, to be included in the certificate.
@@ -97,7 +183,11 @@ export PROVISIONING_HOST_USER=${PROVISIONING_HOST_USER:-$USER}
 # ipcalc on CentOS 7 doesn't support the 'minaddr' option, so use python
 # instead to get the first address in the network:
 export PROVISIONING_HOST_IP=${PROVISIONING_HOST_IP:-$(python -c "import ipaddress; print(next(ipaddress.ip_network(u\"$PROVISIONING_NETWORK\").hosts()))")}
-export PROVISIONING_HOST_EXTERNAL_IP=${PROVISIONING_HOST_EXTERNAL_IP:-$(python -c "import ipaddress; print(next(ipaddress.ip_network(u\"$EXTERNAL_SUBNET\").hosts()))")}
+if [[ "${IP_STACK}" = "v4" ]]; then
+  export PROVISIONING_HOST_EXTERNAL_IP=${PROVISIONING_HOST_EXTERNAL_IP:-$(python -c "import ipaddress; print(next(ipaddress.ip_network(u\"$EXTERNAL_SUBNET_V4\").hosts()))")}
+else
+  export PROVISIONING_HOST_EXTERNAL_IP=${PROVISIONING_HOST_EXTERNAL_IP:-$(python -c "import ipaddress; print(next(ipaddress.ip_network(u\"$EXTERNAL_SUBNET_V6\").hosts()))")}
+fi
 export MIRROR_IP=${MIRROR_IP:-$PROVISIONING_HOST_IP}
 
 # The dev-scripts working directory

--- a/config_example.sh
+++ b/config_example.sh
@@ -11,7 +11,8 @@ set -x
 #export MACHINE_CONFIG_OPERATOR_LOCAL_IMAGE=https://github.com/openshift/machine-config-operator
 
 # IP stack version.  The default is "v6".  You may also set "v4".
-# Dual stack is not yet supported.
+# For dual stack (IPv4 + IPv6), use "v4v6".
+# NOTE: dual stack is not expected to fully work yet.
 #export IP_STACK=v4
 
 # Mirror latest ci images to local registry. This is always true for IPv6, but can be turned off
@@ -72,16 +73,20 @@ set -x
 #export PROVISIONING_NETWORK=fd00:1101::0/64
 
 # External subnet
-#export EXTERNAL_SUBNET="11.0.0.0/24"
+#export EXTERNAL_SUBNET_V4="11.0.0.0/24"
+#export EXTERNAL_SUBNET_V6="fd2e:6f44:5dd8:c956::/120"
 
 # Cluster Subnet
-# export CLUSTER_SUBNET="10.128.0.0/14"
+#export CLUSTER_SUBNET_V4="10.128.0.0/14"
+#export CLUSTER_HOST_PREFIX_V4="23"
+#export CLUSTER_SUBNET_V6="fd01::/48
+#export CLUSTER_HOST_PREFIX_V6="64"
 
 # Cluster Host Prefix
-#export CLUSTER_HOST_PREFIX="23"
 
 # Service Subnet
-#export SERVICE_SUBNET="172.30.0.0/16"
+#export SERVICE_SUBNET_V4="172.30.0.0/16"
+#export SERVICE_SUBNET_V6="fd02::/112"
 
 # Enable testing of custom machine-api-operator-image
 #export TEST_CUSTOM_MAO=true

--- a/ocp_cleanup.sh
+++ b/ocp_cleanup.sh
@@ -17,8 +17,10 @@ sudo rm -rf /etc/NetworkManager/dnsmasq.d/openshift-${CLUSTER_NAME}.conf
 
 # Cleanup ssh keys for baremetal network
 if [ -f $HOME/.ssh/known_hosts ]; then
-    EXT_SUB=$(echo "${EXTERNAL_SUBNET}" | cut -d"/" -f1 | sed "s/0$//")
-    sed -i "/^${EXT_SUB}/d" $HOME/.ssh/known_hosts
+    EXT_SUB_V4=$(echo "${EXTERNAL_SUBNET_V4}" | cut -d"/" -f1 | sed "s/0$//")
+    sed -i "/^${EXT_SUB_V4}/d" $HOME/.ssh/known_hosts
+    EXT_SUB_V6=$(echo "${EXTERNAL_SUBNET_V6}" | cut -d"/" -f1 | sed "s/0$//")
+    sed -i "/^${EXT_SUB_V^}/d" $HOME/.ssh/known_hosts
     PRO_SUB=$(echo "${PROVISIONING_NETWORK}" | cut -d"/" -f1 | sed "s/0$//")
     sed -i "/^${PRO_SUB}/d" $HOME/.ssh/known_hosts
     sed -i "/^api.${CLUSTER_DOMAIN}/d" $HOME/.ssh/known_hosts

--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -96,6 +96,8 @@ EOF
 function cluster_network() {
   if [[ "${IP_STACK}" == "v4" ]]; then
 cat <<EOF
+  machineNetwork:
+  - cidr: ${EXTERNAL_SUBNET_V4}
   clusterNetwork:
   - cidr: ${CLUSTER_SUBNET_V4}
     hostPrefix: ${CLUSTER_HOST_PREFIX_V4}
@@ -104,6 +106,8 @@ cat <<EOF
 EOF
   elif [[ "${IP_STACK}" == "v6" ]]; then
 cat <<EOF
+  machineNetwork:
+  - cidr: ${EXTERNAL_SUBNET_V6}
   clusterNetwork:
   - cidr: ${CLUSTER_SUBNET_V6}
     hostPrefix: ${CLUSTER_HOST_PREFIX_V6}
@@ -112,6 +116,9 @@ cat <<EOF
 EOF
   elif [[ "${IP_STACK}" == "v4v6" ]]; then
 cat <<EOF
+  machineNetwork:
+  - cidr: ${EXTERNAL_SUBNET_V4}
+  - cidr: ${EXTERNAL_SUBNET_V6}
   clusterNetwork:
   - cidr: ${CLUSTER_SUBNET_V4}
     hostPrefix: ${CLUSTER_HOST_PREFIX_V4}
@@ -146,16 +153,13 @@ function generate_ocp_install_config() {
         echo "NETWORK_TYPE must be OVNKubernetes when using IPv6"
         exit 1
       fi
-      MACHINE_CIDR="${EXTERNAL_SUBNET_V6}"
-    else
-      MACHINE_CIDR="${EXTERNAL_SUBNET_V4}"
     fi
+
     cat > "${outdir}/install-config.yaml" << EOF
 apiVersion: v1
 baseDomain: ${BASE_DOMAIN}
 networking:
   networkType: ${NETWORK_TYPE}
-  machineCIDR: ${MACHINE_CIDR}
 $(cluster_network)
 metadata:
   name: ${CLUSTER_NAME}

--- a/run_ci.sh
+++ b/run_ci.sh
@@ -13,7 +13,12 @@ function getlogs(){
     done
 
     # And the VM journals and staticpod container logs
-    BM_SUB=$(echo "${EXTERNAL_SUBNET}" | cut -d"/" -f1 | sed "s/0$//")
+    BM_SUB=""
+    if [[ -n "${EXTERNAL_SUBNET_V6}" ]]; then
+        BM_SUB=$(echo "${EXTERNAL_SUBNET_V6}" | cut -d"/" -f1 | sed "s/0$//")
+    else
+        BM_SUB=$(echo "${EXTERNAL_SUBNET_V4}" | cut -d"/" -f1 | sed "s/0$//")
+    fi
     for HOST in $(sudo virsh net-dhcp-leases ${BAREMETAL_NETWORK_NAME} | grep -o "${BM_SUB}.*/" | cut -d"/" -f1) ; do
         sshpass -p notworking $SSH core@$HOST sudo journalctl > $LOGDIR/$HOST-system.journal || true
         sshpass -p notworking $SSH core@$HOST sudo journalctl -u ironic.service > $LOGDIR/$HOST-ironic.journal || true

--- a/vm_setup_vars.yml
+++ b/vm_setup_vars.yml
@@ -23,9 +23,9 @@ flavors:
     extradisks: false
 
 # For OpenShift we create some additional DNS records for the API/DNS VIPs
-baremetal_network_cidr: "{{ lookup('env', 'EXTERNAL_SUBNET') | default('192.168.111.0/24', true) }}"
-baremetal_network_cidr_v4: "{{ baremetal_network_cidr|ipv4 }}"
-baremetal_network_cidr_v6: "{{ baremetal_network_cidr|ipv6 }}"
+baremetal_network_cidr_v4: "{{ lookup('env', 'EXTERNAL_SUBNET_V4') }}"
+baremetal_network_cidr_v6: "{{ lookup('env', 'EXTERNAL_SUBNET_V6') }}"
+baremetal_network_cidr: "{{ baremetal_network_cidr_v6 | default(baremetal_network_cidr_v4, true) }}"
 dns_extrahosts:
   - ip: "{{ baremetal_network_cidr | nthhost(5) }}"
     hostnames:

--- a/vm_setup_vars.yml
+++ b/vm_setup_vars.yml
@@ -24,6 +24,8 @@ flavors:
 
 # For OpenShift we create some additional DNS records for the API/DNS VIPs
 baremetal_network_cidr: "{{ lookup('env', 'EXTERNAL_SUBNET') | default('192.168.111.0/24', true) }}"
+baremetal_network_cidr_v4: "{{ baremetal_network_cidr|ipv4 }}"
+baremetal_network_cidr_v6: "{{ baremetal_network_cidr|ipv6 }}"
 dns_extrahosts:
   - ip: "{{ baremetal_network_cidr | nthhost(5) }}"
     hostnames:
@@ -42,11 +44,16 @@ networks:
   - name: "{{ baremetal_network_name }}"
     bridge: "{{ baremetal_network_name }}"
     forward_mode: "{{ 'bridge' if lookup('env', 'MANAGE_BR_BRIDGE') == 'n' else 'nat' }}"
-    address: "{{ baremetal_network_cidr|nthhost(1) }}"
-    netmask: "{{ baremetal_network_cidr|ipaddr('netmask') }}"
-    dhcp_range:
-      - "{{ baremetal_network_cidr|nthhost(20) }}"
-      - "{{ baremetal_network_cidr|nthhost(60) }}"
+    address_v4: "{{ baremetal_network_cidr_v4|nthhost(1)|default('', true) }}"
+    netmask_v4: "{{ baremetal_network_cidr_v4|ipaddr('netmask') }}"
+    address_v6: "{{ baremetal_network_cidr_v6|nthhost(1)|default('', true) }}"
+    prefix_v6: "{{ baremetal_network_cidr_v6|ipaddr('prefix') }}"
+    dhcp_range_v4:
+      - "{{ baremetal_network_cidr_v4|nthhost(20) }}"
+      - "{{ baremetal_network_cidr_v4|nthhost(60) }}"
+    dhcp_range_v6:
+      - "{{ baremetal_network_cidr_v6|nthhost(20) }}"
+      - "{{ baremetal_network_cidr_v6|nthhost(60) }}"
     nat_port_range:
       - 1024
       - 65535


### PR DESCRIPTION
This commit allows configuring a dual-stack IPv4+IPv6 environment.  It
changes a bunch of configuration to reflect that IPv4 and IPv6
settings are required at the same time, creates a dual-stack
"baremetal" network environment, and configures the OpenShift cluster
with both IPv4 and IPv6 subnets.

This isn't actually expected to result in a working OpenShift cluster
yet, but this provides a development and test environment for
dual-stack OpenShift clusters.