### PR TITLE
[WIP][DNM] Save and apply release image signatures

### DIFF
--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -65,11 +65,14 @@ if [ ! -z "${MIRROR_IMAGES}" ]; then
     _tmpfiles="$_tmpfiles $EXTRACT_DIR"
     MIRROR_LOG_FILE=/tmp/tmp_image_mirror-${OPENSHIFT_RELEASE_TAG}.log
 
+    mkdir -p "$OCP_DIR/release-image-signature"
+
     oc adm release mirror \
        --insecure=true \
         -a ${COMBINED_AUTH_FILE}  \
         --from ${OPENSHIFT_RELEASE_IMAGE} \
         --to-release-image ${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/local-release-image:${OPENSHIFT_RELEASE_TAG} \
+        --release-image-signature-to-dir "$OCP_DIR/release-image-signature" \
         --to ${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/local-release-image 2>&1 | tee ${MIRROR_LOG_FILE}
     echo "export MIRRORED_RELEASE_IMAGE=$OPENSHIFT_RELEASE_IMAGE" > /tmp/mirrored_release_image
 

--- a/utils.sh
+++ b/utils.sh
@@ -49,11 +49,16 @@ function create_cluster() {
     mkdir -p ${assets_dir}/openshift
     cp -rf assets/generated/*.yaml ${assets_dir}/openshift
 
+    # Ensure release image signature config map is applied to cluster
+    if [ -d "$OCP_DIR/release-image-signature" ]; then
+      cp "$OCP_DIR/release-image-signature/*.yaml" "${assets_dir}/openshift" || true
+    fi
+
     if [ ! -z "${IGNITION_EXTRA:-}" ]; then
       $OPENSHIFT_INSTALLER --dir "${assets_dir}" --log-level=debug create ignition-configs
       if ! jq . ${IGNITION_EXTRA}; then
         echo "Error ${IGNITION_EXTRA} not valid json"
-	exit 1
+	      exit 1
       fi
       mv ${assets_dir}/master.ign ${assets_dir}/master.ign.orig
       jq -s '.[0] * .[1]' ${IGNITION_EXTRA} ${assets_dir}/master.ign.orig | tee ${assets_dir}/master.ign
@@ -357,6 +362,7 @@ EOF
 
 _tmpfiles=
 function removetmp(){
-    [ -n "$_tmpfiles" ] && rm -rf $_tmpfiles || true
+  true
+#    [ -n "$_tmpfiles" ] && rm -rf $_tmpfiles || true
 }
 trap removetmp EXIT


### PR DESCRIPTION
https://github.com/openshift/oc/pull/343 now requires you to do something about the eventual release image signatures.  OpenShift CI is now failing:

```
+(./04_setup_ironic.sh:68): main(): oc adm release mirror --insecure=true -a combined-pullsecret--gyUsq8fVYL --from registry.svc.ci.openshift.org/ci-op-hmxpdxpw/release@sha256:7d9cc5731a84efab3c59fe66a81a66ec1d3e386183b383f905d0efc71dd6f161 --to-release-image virthost.ostest.test.metalkube.org:5000/localimages/local-release-image:7d9cc5731a84efab3c59fe66a81a66ec1d3e386183b383f905d0efc71dd6f161 --to virthost.ostest.test.metalkube.org:5000/localimages/local-release-image
error: if --to-dir and --apply-release-image-signature are not specified, --release-image-signature-to-dir must be used to specify a directory to export the signature
```

Unfortunately `oc` explodes when you give the release-image-signature-to-dir on older releases, so we again need to be aware of the `oc` version to give the option or not.

This whole change is problematic to deal with:

1) `oc version --client -o json` doesn't give you an easily machine comparable version
2) Even if we parse the `releaseClientVersion`, this isn't in 4.3 or 4.4 I think. The format from `oc version` has changed several times, and relying on it has broken us before
3) CI doesn't even tell us what OCP release we're using as everything is versioned as 0.0.1...

Will continue investigating on Monday. I filed https://bugzilla.redhat.com/show_bug.cgi?id=1825565 with a suggestion of exporting the config map to $PWD if no option is specified, instead of exploding.
