### PR TITLE
New OpenShift CI Docker image

### DIFF
--- a/images/Dockerfile.ci
+++ b/images/Dockerfile.ci
@@ -4,7 +4,7 @@
 FROM centos:7
 RUN yum -y install python3 git && \
     yum clean all && \
-    pip3 install ansible packet-python 
-RUN mkdir /root/src
+    pip3 install ansible packet-python && \
+    mkdir /root/src
 WORKDIR /root/src
 

--- a/images/Dockerfile.ci
+++ b/images/Dockerfile.ci
@@ -1,9 +1,10 @@
 # This Dockerfile builds the image used by the e2e-metal-ipi test steps in the OpenShift CI.
 # For more details about the test see https://steps.svc.ci.openshift.org/job/openshift-baremetal-operator-master-e2e-metal-ipi
 
-FROM registry.access.redhat.com/ubi8/ubi
-RUN dnf -y install python3 && \
-    dnf clean all && \
-    pip3 install ansible && \
-    pip3 install packet-python
+FROM centos:7
+RUN yum -y install python3 git && \
+    yum clean all && \
+    pip3 install ansible packet-python 
+RUN mkdir /root/src
+WORKDIR /root/src
 


### PR DESCRIPTION
Refactor Dockerfile.ci to be used with OpenShift CI pipeline:src, required for OpenShift CI integration (see https://github.com/openshift/release/pull/8420) 