### PR TITLE
Dockerfile file for dev-script image used by the OpenShift CI

### DIFF
--- a/images/Dockerfile.ci
+++ b/images/Dockerfile.ci
@@ -1,5 +1,16 @@
 # This Dockerfile builds the image used by the e2e-metal-ipi test steps in the OpenShift CI.
 # For more details about the test see https://steps.svc.ci.openshift.org/job/openshift-baremetal-operator-master-e2e-metal-ipi
 
-FROM centos:7
-RUN echo "noop"
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13
+ENV HOME /output
+RUN INSTALL_PKGS="ansible python-pip" && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    pip install packet-python && \
+    yum clean all && \
+    rm -rf /var/cache/yum/* && \         
+    chmod g+rwx /output && \
+# TODO: Remove once OpenShift CI will be upgraded to 4.2 (see https://access.redhat.com/articles/4859371)
+    chmod g+w /etc/passwd && \
+    echo 'echo default:x:\$(id -u):\$(id -g):Default Application User:/output:/sbin/nologin\ >> /etc/passwd' > /output/fix_uid.sh && \
+    chmod g+rwx /output/fix_uid.sh


### PR DESCRIPTION
This image will be used by the e2e-metal-ipi workflow currently under development in https://github.com/openshift/release/pull/8420.
