### PR TITLE
Drop CentOS 7 support completely

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -88,11 +88,8 @@ EOF
     virsh pool-autostart default
 fi
 
-if [ "${RHEL8}" = "True" ] || [ "${CENTOS8}" = "True" ] ; then
-    ZONE="\nZONE=libvirt"
-
-    sudo systemctl enable --now firewalld
-fi
+ZONE="\nZONE=libvirt"
+sudo systemctl enable --now firewalld
 
 if [ "$MANAGE_PRO_BRIDGE" == "y" ]; then
     # Adding an IP address in the libvirt definition for this network results in
@@ -163,7 +160,7 @@ if [[ "$(ipversion $PROVISIONING_HOST_IP)" == "6" ]]; then
 fi
 
 ANSIBLE_FORCE_COLOR=true ansible-playbook \
-    -e "{use_firewalld: $USE_FIREWALLD}" \
+    -e "{use_firewalld: True}" \
     -e "provisioning_interface=$PROVISIONING_NETWORK_NAME" \
     -e "baremetal_interface=$BAREMETAL_NETWORK_NAME" \
     -e "{provisioning_host_ports: [80, ${LOCAL_REGISTRY_PORT}, 8000]}" \
@@ -172,10 +169,8 @@ ANSIBLE_FORCE_COLOR=true ansible-playbook \
     -b -vvv ${VM_SETUP_PATH}/firewall.yml
 
 # FIXME(stbenjam): ansbile firewalld module doesn't seem to be doing the right thing
-if [ "$USE_FIREWALLD" == "True" ]; then
-  sudo firewall-cmd --zone=libvirt --change-interface=provisioning
-  sudo firewall-cmd --zone=libvirt --change-interface=baremetal
-fi
+sudo firewall-cmd --zone=libvirt --change-interface=provisioning
+sudo firewall-cmd --zone=libvirt --change-interface=baremetal
 
 # Need to route traffic from the provisioning host.
 if [ "$EXT_IF" ]; then

--- a/common.sh
+++ b/common.sh
@@ -350,28 +350,8 @@ fi
 
 # Check CentOS version
 VER=$(awk -F= '/^VERSION_ID=/ { print $2 }' /etc/os-release | tr -d '"' | cut -f1 -d'.')
-if [[ ${VER} -eq 7 ]]; then
-  if [[ "${ALLOW_CENTOS7}" -ne "yes" ]]; then
-    error "*****************************************************"
-    error "*****************************************************"
-    error "*****************************************************"
-    error "***                                               ***"
-    error "*** CentOS 7 Support has been deprecated and will ***"
-    error "*** be removed in the near future.                ***"
-    error "***                                               ***"
-    error "*** Please upgrade your dev-scripts system to     ***"
-    error "*** CentOS 8 or RHEL 8.                           ***"
-    error "***                                               ***"
-    error "*** To temporarily continue allowing CentOS 7,    ***"
-    error "*** set ALLOW_CENTOS7=yes in your config file.    ***"
-    error "***                                               ***"
-    error "*****************************************************"
-    error "*****************************************************"
-    error "*****************************************************"
-    exit 1
-  fi
-elif [[ ${VER} -ne 8 ]]; then
-  error "Required CentOS 8 / RHEL 8"
+if [[ ${VER} -ne 8 ]]; then
+  error "CentOS 8 or RHEL 8 are required."
   exit 1
 fi
 

--- a/common.sh
+++ b/common.sh
@@ -355,23 +355,6 @@ if [[ ${VER} -ne 8 ]]; then
   exit 1
 fi
 
-export RHEL8=""
-if grep -q "Red Hat Enterprise Linux release 8" /etc/redhat-release 2>/dev/null ; then
-    export RHEL8="True"
-fi
-
-export CENTOS8=""
-if grep -q "CentOS Linux release 8" /etc/redhat-release 2>/dev/null; then
-    export CENTOS8="True"
-fi
-
-if [ "${RHEL8}" = "True"  ] || [ "${CENTOS8}" = "True"  ]; then
-  export USE_FIREWALLD=${USE_FIREWALLD:-True}
-else
-  export USE_FIREWALLD=${USE_FIREWALLD:-False}
-fi
-
-
 # Check d_type support
 FSTYPE=$(df "${FILESYSTEM}" --output=fstype | tail -n 1)
 


### PR DESCRIPTION
CentOS 7 was marked deprecated in #1000.  Everyone really needs to be
on RHEL 8 or CentOS 8 at this point.  Drop CentOS 7 support completely
now that a warning has been in place for a bit.

RHEL 8 (or CentOS 8) is required because that's the environment we
would expect customers to use to run the installer.  Any issues with
CentOS 7 are not worth our focus anymore.