### PR TITLE
support workers not included in initial deployment

### DIFF
--- a/05_create_install_config.sh
+++ b/05_create_install_config.sh
@@ -47,3 +47,9 @@ if [ ! -f ${OCP_DIR}/install-config.yaml ]; then
     # Create install config for openshift-installer
     generate_ocp_install_config ${OCP_DIR}
 fi
+
+# Generate the assets for extra worker VMs
+if [ -f "${EXTRA_NODES_FILE}" ]; then
+    jq '.nodes' "${EXTRA_NODES_FILE}" | tee "${EXTRA_BAREMETALHOSTS_FILE}"
+    generate_ocp_host_manifest ${OCP_DIR} ${EXTRA_BAREMETALHOSTS_FILE}
+fi

--- a/common.sh
+++ b/common.sh
@@ -285,8 +285,10 @@ ROOT_DISK_NAME=${ROOT_DISK_NAME-"/dev/sda"}
 FILESYSTEM=${FILESYSTEM:="/"}
 
 export NODES_FILE=${NODES_FILE:-"${WORKING_DIR}/${CLUSTER_NAME}/ironic_nodes.json"}
+export EXTRA_NODES_FILE=${EXTRA_NODES_FILE:-"${WORKING_DIR}/${CLUSTER_NAME}/extra_ironic_nodes.json"}
 NODES_PLATFORM=${NODES_PLATFORM:-"libvirt"}
 BAREMETALHOSTS_FILE=${BAREMETALHOSTS_FILE:-"${OCP_DIR}/baremetalhosts.json"}
+EXTRA_BAREMETALHOSTS_FILE=${EXTRA_BAREMETALHOSTS_FILE:-"${OCP_DIR}/extra_baremetalhosts.json"}
 
 # Optionally set this to a path to use a local dev copy of
 # metal3-dev-env, otherwise it's cloned to $WORKING_DIR
@@ -300,6 +302,7 @@ export VM_SETUP_PATH="${METAL3_DEV_ENV_PATH}/vm-setup"
 
 export NUM_MASTERS=${NUM_MASTERS:-"3"}
 export NUM_WORKERS=${NUM_WORKERS:-"2"}
+export NUM_EXTRA_WORKERS=${NUM_EXTRA_WORKERS:-"0"}
 export VM_EXTRADISKS=${VM_EXTRADISKS:-"false"}
 export MASTER_HOSTNAME_FORMAT=${MASTER_HOSTNAME_FORMAT:-"master-%d"}
 export WORKER_HOSTNAME_FORMAT=${WORKER_HOSTNAME_FORMAT:-"worker-%d"}

--- a/config_example.sh
+++ b/config_example.sh
@@ -33,6 +33,9 @@ set -x
 # Indicate number of workers to deploy
 #export NUM_WORKERS=0
 
+# Indicate number of extra VMs to create but not deploy
+#export NUM_EXTRA_WORKERS=0
+
 # Provisioning interface on the helper ndoe
 #export PRO_IF="eno1"
 

--- a/vm_setup_vars.yml
+++ b/vm_setup_vars.yml
@@ -3,7 +3,7 @@
 
 # Currently this is required because of hard-coded node-name expectations in the
 # openshift-installer terraform templates
-ironic_prefix: "{{ cluster_name }}_"
+ironic_prefix: "{{ ironic_prefix }}"
 
 # We enable more memory and masters in dev-scripts compared to the minimal setup
 # in metal3-dev-env


### PR DESCRIPTION
Add NUM_EXTRA_WORKERS variable to manage creating more workers than
are deployed initially. A manifest file for registering these
additional hosts is created in the ocp directory for the cluster.