### PR TITLE
Remove outdated dependencies

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -310,7 +310,6 @@ export WORKER_HOSTNAME_FORMAT=${WORKER_HOSTNAME_FORMAT:-"worker-%d"}
 
 # Ironic vars (Image can be use <NAME>_LOCAL_IMAGE to override)
 export IRONIC_IMAGE="quay.io/metal3-io/ironic:master"
-export IRONIC_IPA_DOWNLOADER_IMAGE="quay.io/metal3-io/ironic-ipa-downloader:master"
 export IRONIC_DATA_DIR="${WORKING_DIR}/ironic"
 export IRONIC_IMAGES_DIR="${IRONIC_DATA_DIR}/html/images"
 


### PR DESCRIPTION
This removes operator-sdk installation, we've moved on to 0.17 in
BMO. Is there any reason to keep installing such an old version in
dev-scripts?

I also don't know of any reason to continue to install dep. I noticed installation failed in https://github.com/openshift-metal3/dev-scripts/pull/1025.  The less we try to pull from GitHub the better, it's been so flaky lately.
