### PR TITLE
Miscellaneous dev-scripts clean-ups

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -55,22 +55,6 @@ if [[ -z "$OPENSHIFT_CI" ]]; then
   popd
 fi
 
-if [ ! -z "${INSTALL_OPERATOR_SDK:-}" ]; then
-    # Install operator-sdk
-    if ! which operator-sdk 2>&1 >/dev/null ; then
-        sudo wget https://github.com/operator-framework/operator-sdk/releases/download/v0.9.0/operator-sdk-v0.9.0-x86_64-linux-gnu -O /usr/local/bin/operator-sdk
-        sudo chmod 755 /usr/local/bin/operator-sdk
-    fi
-fi
-
-# Install Go dependency management tool
-# Using pre-compiled binaries instead of installing from source
-eval "$(go env)"
-if ! which dep 2>&1 >/dev/null ; then
-    mkdir -p $GOPATH/bin
-    curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-fi
-
 if [[ ! -z "${MIRROR_IMAGES}" || $(env | grep "_LOCAL_IMAGE=") ]]; then
     setup_local_registry
 fi

--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -174,6 +174,10 @@ fi
 # Wait for images to be downloaded/ready
 while ! curl --fail -g http://$(wrap_if_ipv6 ${PROVISIONING_HOST_IP})/images/${MACHINE_OS_IMAGE_NAME}.sha256sum ; do sleep 1 ; done
 while ! curl --fail -g http://$(wrap_if_ipv6 ${PROVISIONING_HOST_IP})/images/${MACHINE_OS_BOOTSTRAP_IMAGE_NAME}.sha256sum ; do sleep 1 ; done
-while ! curl --fail --head -g http://$(wrap_if_ipv6 ${PROVISIONING_HOST_IP})/images/ironic-python-agent.initramfs ; do sleep 1; done
-while ! curl --fail --head -g http://$(wrap_if_ipv6 ${PROVISIONING_HOST_IP})/images/ironic-python-agent.tar.headers ; do sleep 1; done
-while ! curl --fail --head -g http://$(wrap_if_ipv6 ${PROVISIONING_HOST_IP})/images/ironic-python-agent.kernel ; do sleep 1; done
+
+if [ -n "${IRONIC_IPA_DOWNLOADER_LOCAL_IMAGE:-}" ];
+then
+  while ! curl --fail --head -g http://$(wrap_if_ipv6 ${PROVISIONING_HOST_IP})/images/ironic-python-agent.initramfs ; do sleep 1; done
+  while ! curl --fail --head -g http://$(wrap_if_ipv6 ${PROVISIONING_HOST_IP})/images/ironic-python-agent.tar.headers ; do sleep 1; done
+  while ! curl --fail --head -g http://$(wrap_if_ipv6 ${PROVISIONING_HOST_IP})/images/ironic-python-agent.kernel ; do sleep 1; done
+fi

--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -85,6 +85,10 @@ if [ ! -z "${MIRROR_IMAGES}" ]; then
     # Build a local release image, if no *_LOCAL_IMAGE env variables are set then this is just a copy of the release image
     sudo podman image build --authfile $COMBINED_AUTH_FILE -t $OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE -f $DOCKERFILE
     sudo podman push --tls-verify=false --authfile $COMBINED_AUTH_FILE $OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE $OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE
+
+    # If we're mirroring images, let's use the local Ironic image instead
+    OPENSHIFT_RELEASE_VERSION=$(oc adm release info --registry-config="$REGISTRY_AUTH_FILE" "$OPENSHIFT_RELEASE_IMAGE" -o json | jq -r ".config.config.Labels.\"io.openshift.release\"")
+    IRONIC_LOCAL_IMAGE=${IRONIC_LOCAL_IMAGE:-"${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/local-release-image:${OPENSHIFT_RELEASE_VERSION}-ironic"}
 fi
 
 for name in ironic ironic-api ironic-conductor ironic-inspector dnsmasq httpd-${PROVISIONING_NETWORK_NAME} mariadb ipa-downloader; do
@@ -101,10 +105,9 @@ fi
 sudo podman pod create -n ironic-pod
 
 IRONIC_IMAGE=${IRONIC_LOCAL_IMAGE:-$IRONIC_IMAGE}
-IRONIC_IPA_DOWNLOADER_IMAGE=${IRONIC_IPA_DOWNLOADER_LOCAL_IMAGE:-$IRONIC_IPA_DOWNLOADER_IMAGE}
 
-for IMAGE in ${IRONIC_IMAGE} ${IRONIC_IPA_DOWNLOADER_IMAGE} ${VBMC_IMAGE} ${SUSHY_TOOLS_IMAGE} ; do
-    sudo -E podman pull --authfile $COMBINED_AUTH_FILE $IMAGE
+for IMAGE in ${IRONIC_IMAGE} ${VBMC_IMAGE} ${SUSHY_TOOLS_IMAGE} ; do
+    sudo -E podman pull --authfile $COMBINED_AUTH_FILE $IMAGE || echo "WARNING: Could not pull latest $IMAGE; will try to use cached images instead"
 done
 
 CACHED_MACHINE_OS_IMAGE="${IRONIC_DATA_DIR}/html/images/${MACHINE_OS_IMAGE_NAME}"
@@ -126,8 +129,16 @@ sudo podman run -d --net host --privileged --name httpd-${PROVISIONING_NETWORK_N
      --env PROVISIONING_INTERFACE=${PROVISIONING_NETWORK_NAME} \
      -v $IRONIC_DATA_DIR:/shared --entrypoint /bin/runhttpd ${IRONIC_IMAGE}
 
-sudo podman run -d --net host --privileged --name ipa-downloader --pod ironic-pod \
-     -v $IRONIC_DATA_DIR:/shared ${IRONIC_IPA_DOWNLOADER_IMAGE} /usr/local/bin/get-resource.sh
+# IPA Downloader - for testing
+if [ -n "${IRONIC_IPA_DOWNLOADER_LOCAL_IMAGE:-}" ];
+then
+  sudo -E podman pull --authfile $COMBINED_AUTH_FILE $IRONIC_IPA_DOWNLOADER_LOCAL_IMAGE
+
+  sudo podman run -d --net host --privileged --name ipa-downloader --pod ironic-pod \
+     -v $IRONIC_DATA_DIR:/shared ${IRONIC_IPA_DOWNLOADER_LOCAL_IMAGE} /usr/local/bin/get-resource.sh
+
+  sudo podman wait -i 1000 ipa-downloader
+fi
 
 function is_running() {
     local podname="$1"
@@ -159,9 +170,6 @@ if [ "$NODES_PLATFORM" = "libvirt" ]; then
 fi
 
 
-# Wait for the downloader containers to finish, if they are updating an existing cache
-# the checks below will pass because old data exists
-sudo podman wait -i 1000 ipa-downloader
 
 # Wait for images to be downloaded/ready
 while ! curl --fail -g http://$(wrap_if_ipv6 ${PROVISIONING_HOST_IP})/images/${MACHINE_OS_IMAGE_NAME}.sha256sum ; do sleep 1 ; done

--- a/common.sh
+++ b/common.sh
@@ -310,7 +310,6 @@ export WORKER_HOSTNAME_FORMAT=${WORKER_HOSTNAME_FORMAT:-"worker-%d"}
 
 # Ironic vars (Image can be use <NAME>_LOCAL_IMAGE to override)
 export IRONIC_IMAGE="quay.io/metal3-io/ironic:master"
-export IRONIC_IPA_DOWNLOADER_IMAGE="quay.io/metal3-io/ironic-ipa-downloader:master"
 export IRONIC_DATA_DIR="${WORKING_DIR}/ironic"
 export IRONIC_IMAGES_DIR="${IRONIC_DATA_DIR}/html/images"
 


### PR DESCRIPTION
A few improvements here:

- We don't need ipa downloader anymore. IPA image is embedded in the
OpenShift release so this is unused. This shaves a few minutes off an
install. It leaves support for using upstream Ironic images with
OpenShift for testing, however.

- When mirroring images, this also uses the ironic image we've already
cached instead of pointing to the upstream ironic image on Quay.

- For sushy tools and vbmc, we don't want dev environments to get out of
date, but in case of a quay outage we are OK to fail the image pulling
and used cached copies. This obviously won't work in CI where the nodes
are fresh, but at least it makes a dev environment more resilient to
outages.

Also incorporating https://github.com/openshift-metal3/dev-scripts/pull/1035 here:

- Removes operator-sdk installation, we've moved on to 0.17 in BMO. Is there any reason to keep installing such an old version in dev-scripts?
    
- I also don't know of any reason to continue to install dep. Most everything has moved to go mod.