### PR TITLE
don't hardcode provisioning ip

### DIFF
--- a/metal3-dev/run.sh
+++ b/metal3-dev/run.sh
@@ -62,10 +62,10 @@ oc apply -f $OUTDIR/deployment-dev.yaml -n openshift-machine-api
 
 # Set some variables the operator expects to have in order to work
 export OPERATOR_NAME=baremetal-operator
-export DEPLOY_KERNEL_URL=http://172.22.0.3:6180/images/ironic-python-agent.kernel
-export DEPLOY_RAMDISK_URL=http://172.22.0.3:6180/images/ironic-python-agent.initramfs
-export IRONIC_ENDPOINT=http://172.22.0.3:6385/v1/
-export IRONIC_INSPECTOR_ENDPOINT=http://172.22.0.3:5050/v1/
+
+for var in IRONIC_ENDPOINT IRONIC_INSPECTOR_ENDPOINT DEPLOY_KERNEL_URL DEPLOY_RAMDISK_URL; do
+    export "$var"=$(cat $OUTDIR/deployment-full.yaml | yq -r ".spec.template.spec.containers[0].env | map(select( .name == \""${var}"\"))[0].value")
+done
 
 # Wait for the ironic service to be available
 wait_for_json ironic "$IRONIC_ENDPOINT" 300 \


### PR DESCRIPTION
Instead of hardcoding it, we look it up from the install state file. We
also update the operator-sdk command to conform to the latest usage
pattern.