### PR TITLE
Switch back to ipmi

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -227,10 +227,6 @@ fi
 
 export OPENSHIFT_RELEASE_TAG=$(echo $OPENSHIFT_RELEASE_IMAGE | sed -E 's/[[:alnum:]\/.-]*release.*://')
 
-if [[ "$OPENSHIFT_VERSION" != "4.3" ]]; then
-  export BMC_DRIVER=${BMC_DRIVER:-redfish}
-fi
-
 # Both utils.sh and 04_setup_ironic.sh use this log file, so set the
 # name one time. Users should not override this.
 export MIRROR_LOG_FILE=${REGISTRY_DIR}/${CLUSTER_NAME}-image_mirror-${OPENSHIFT_RELEASE_TAG}.log


### PR DESCRIPTION
Setting the boot device using sushy (on virt), results
in a domain reboot. This causes it to boot into RHCOS
prematurely only to be power cycled by ironic later.