### PR TITLE
Improve README and add xinetd config example

### DIFF
--- a/openshift_xinetd_example.conf
+++ b/openshift_xinetd_example.conf
@@ -1,0 +1,50 @@
+# Reference: https://linux.die.net/man/5/xinetd.conf
+# The `IPv4` flag means that the `bind` value is in IPv4 format. `redirect` values can still be in IPv6 format.
+
+service openshift-api
+{
+    flags           = IPv4
+    bind            = <IPv4_Host_IP>
+    disable         = no
+    type            = UNLISTED
+    socket_type     = stream
+    protocol        = tcp
+    user            = root
+    wait            = no
+    redirect        = <IPv6_API_Address> 6443
+    port            = 6443
+    only_from       = 0.0.0.0/0
+    per_source      = UNLIMITED
+}
+
+service openshift-ingress-ssl
+{
+    flags           = IPv4
+    bind            = <IPv4_Host_IP>
+    disable         = no
+    type            = UNLISTED
+    socket_type     = stream
+    protocol        = tcp
+    user            = root
+    wait            = no
+    redirect        = <IPv6_Ingress_Address> 443
+    port            = 443
+    only_from       = 0.0.0.0/0
+    per_source      = UNLIMITED
+}
+
+service openshift-ingress
+{
+    flags           = IPv4
+    bind            = <IPv4_Host_IP>
+    disable         = no
+    type            = UNLISTED
+    socket_type     = stream
+    protocol        = tcp
+    user            = root
+    wait            = no
+    redirect        = <IPv6_Ingress_Address> 80
+    port            = 8080
+    only_from       = 0.0.0.0/0
+    per_source      = UNLIMITED
+}


### PR DESCRIPTION
Added the `xinetd` option to the README and created a config example file to be used as template