### PR TITLE
be more careful with cleaning up ssh known_hosts

### DIFF
--- a/ocp_cleanup.sh
+++ b/ocp_cleanup.sh
@@ -18,11 +18,17 @@ sudo rm -rf /etc/NetworkManager/dnsmasq.d/openshift-${CLUSTER_NAME}.conf
 # Cleanup ssh keys for baremetal network
 if [ -f $HOME/.ssh/known_hosts ]; then
     EXT_SUB_V4=$(echo "${EXTERNAL_SUBNET_V4}" | cut -d"/" -f1 | sed "s/0$//")
-    sed -i "/^${EXT_SUB_V4}/d" $HOME/.ssh/known_hosts
+    if [ -n "${EXT_SUB_V4}" ]; then
+        sed -i "/^${EXT_SUB_V4}/d" $HOME/.ssh/known_hosts
+    fi
     EXT_SUB_V6=$(echo "${EXTERNAL_SUBNET_V6}" | cut -d"/" -f1 | sed "s/0$//")
-    sed -i "/^${EXT_SUB_V^}/d" $HOME/.ssh/known_hosts
+    if [ -n "${EXT_SUB_V6}" ]; then
+        sed -i "/^${EXT_SUB_V6}/d" $HOME/.ssh/known_hosts
+    fi
     PRO_SUB=$(echo "${PROVISIONING_NETWORK}" | cut -d"/" -f1 | sed "s/0$//")
-    sed -i "/^${PRO_SUB}/d" $HOME/.ssh/known_hosts
+    if [ -n "${PRO_SUB}" ]; then
+        sed -i "/^${PRO_SUB}/d" $HOME/.ssh/known_hosts
+    fi
     sed -i "/^api.${CLUSTER_DOMAIN}/d" $HOME/.ssh/known_hosts
 fi
 


### PR DESCRIPTION
The sed calls for removing entries from the ssh known_hosts config
assume that there are v4 and v6 addresses to be removed. If one isn't
found the pattern causes all of the entries from ~/.ssh/known_hosts to
be removed. Protect those sed calls with checks for non-empty
variables.

Also fix a typo in the reference to EXT_SUB_V6 in the invocation for
IPv6.