### PR TITLE
ipv6: Enable dual-stack feature set

### DIFF
--- a/assets/ipv6-dual-stack-no-upgrade.yaml
+++ b/assets/ipv6-dual-stack-no-upgrade.yaml
@@ -1,0 +1,6 @@
+apiVersion: config.openshift.io/v1
+kind: FeatureGate
+metadata:
+  name: cluster
+spec:
+  featureSet: IPv6DualStackNoUpgrade

--- a/utils.sh
+++ b/utils.sh
@@ -49,6 +49,14 @@ function create_cluster() {
     mkdir -p ${assets_dir}/openshift
     cp -rf assets/generated/*.yaml ${assets_dir}/openshift
 
+    if [[ "${IP_STACK}" == "v4v6" ]]; then
+        # The IPv6DualStack feature is not on by default, because it doesn't
+        # fully work yet.  If we're running a dual-stack test environment,
+        # we will turn on the IPv6DualStackNoUpgrade feature set for testing
+        # purposes.
+        cp assets/ipv6-dual-stack-no-upgrade.yaml ${assets_dir}/openshift/.
+    fi
+
     if [ ! -z "${IGNITION_EXTRA:-}" ]; then
       $OPENSHIFT_INSTALLER --dir "${assets_dir}" --log-level=debug create ignition-configs
       if ! jq . ${IGNITION_EXTRA}; then


### PR DESCRIPTION
Dual-stack IPv6 is not yet enabled by default in OpenShift since it
doesn't fully work yet.  We have a feature set that allows you to turn
it on for testing purposes.  When dev-scripts is configured to bring
up a dual-stack test environment, this change adds a manifest to
enable dual-stack in the cluster.

Now that a lot of prerequisite work has started merging, we're ready
to push the dual-stack CI jobs further and this change will ensure
that dual-stack is enabled in those jobs.