### PR TITLE
Revert "Switch back to ipmi (#1041)"

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -227,6 +227,10 @@ fi
 
 export OPENSHIFT_RELEASE_TAG=$(echo $OPENSHIFT_RELEASE_IMAGE | sed -E 's/[[:alnum:]\/.-]*release.*://')
 
+if [[ "$OPENSHIFT_VERSION" != "4.3" ]]; then
+  export BMC_DRIVER=${BMC_DRIVER:-redfish}
+fi
+
 # Both utils.sh and 04_setup_ironic.sh use this log file, so set the
 # name one time. Users should not override this.
 export MIRROR_LOG_FILE=${REGISTRY_DIR}/${CLUSTER_NAME}-image_mirror-${OPENSHIFT_RELEASE_TAG}.log


### PR DESCRIPTION
This reverts commit 60ab6265ee497240b82f1cb903076867d1cdd30a.

The sushy-tools image should now be fixed

Fixed here
https://review.opendev.org/#/c/733152/
https://review.opendev.org/#/c/734837/
https://github.com/metal3-io/metal3-dev-env/pull/344
