### PR TITLE
Make it easier to install older releases

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -210,7 +210,8 @@ export KNI_INSTALL_FROM_GIT=${KNI_INSTALL_FROM_GIT:-}
 #
 # if we provide OPENSHIFT_RELEASE_IMAGE, do not curl. This is needed for offline installs
 if [ -z "${OPENSHIFT_RELEASE_IMAGE:-}" ]; then
-  LATEST_CI_IMAGE=$(curl -L https://openshift-release.svc.ci.openshift.org/api/v1/releasestream/4.6.0-0.ci/latest | grep -o 'registry.svc.ci.openshift.org[^"]\+')
+  OPENSHIFT_RELEASE_STREAM=${OPENSHIFT_RELEASE_STREAM:-4.6}
+  LATEST_CI_IMAGE=$(curl -L https://openshift-release.svc.ci.openshift.org/api/v1/releasestream/${OPENSHIFT_RELEASE_STREAM}.0-0.ci/latest | grep -o 'registry.svc.ci.openshift.org[^"]\+')
 fi
 export OPENSHIFT_RELEASE_IMAGE="${OPENSHIFT_RELEASE_IMAGE:-$LATEST_CI_IMAGE}"
 export OPENSHIFT_INSTALL_PATH="$GOPATH/src/github.com/openshift/installer"

--- a/config_example.sh
+++ b/config_example.sh
@@ -5,6 +5,10 @@ set +x
 export PULL_SECRET=''
 set -x
 
+# Select a different release stream from which to pull the latest image, if the
+# image name is not specified
+#export OPENSHIFT_RELEASE_STREAM=4.6
+
 # Use <NAME>_LOCAL_IMAGE to build or use copy of container images locally e.g.
 #export IRONIC_INSPECTOR_LOCAL_IMAGE=https://github.com/metal3-io/ironic-inspector
 #export IRONIC_LOCAL_IMAGE=quay.io/username/ironic


### PR DESCRIPTION
Automatically look up the latest CI image for a given release stream by
setting the OPENSHIFT_RELEASE_STREAM environment variable.