### PR TITLE
Add support for virtualmedia with sushy-tools

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -17,7 +17,7 @@ if [ -z "${METAL3_DEV_ENV}" ]; then
   # TODO -- come up with a plan for continuously updating this
   # Note we only do this in the case where METAL3_DEV_ENV is
   # unset, to enable developer testing of local checkouts
-  git reset 0363856461a4ec2c9d0981843085c6491ac749ae --hard
+  git reset 15260d6313758d29397f2b14ccac084e8bf8bcdd --hard
   popd
 fi
 

--- a/config_example.sh
+++ b/config_example.sh
@@ -19,6 +19,9 @@ set -x
 # NOTE: dual stack is not expected to fully work yet.
 #export IP_STACK=v4
 
+# BMC type. Valid values are redfish, redfish-virtualmedia, or ipmi.
+#export BMC_DRIVER=redfish-virtualmedia
+
 # Mirror latest ci images to local registry. This is always true for IPv6, but can be turned off
 # for an IPv4 install.
 #export MIRROR_IMAGES=true
@@ -49,7 +52,7 @@ set -x
 # Provisioning interface within the cluster
 #export CLUSTER_PRO_IF="eno1"
 
-# Which disk to deploy 
+# Which disk to deploy
 #export ROOT_DISK="/dev/sda"
 
 # Cluster name


### PR DESCRIPTION
This allows setting BMC_DRIVER to redfish-virtualmedia. This bumps the
metal3-dev-env commit, and adds docs to config_exmaple.sh for virtual
media.