### PR TITLE
Bump to go 1.14

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -27,7 +27,7 @@ ansible-galaxy install -r vm-setup/requirements.yml
 ANSIBLE_FORCE_COLOR=true ansible-playbook \
   -e "working_dir=$WORKING_DIR" \
   -e "virthost=$HOSTNAME" \
-  -e "go_version=1.13.8" \
+  -e "go_version=1.14.4" \
   -i vm-setup/inventory.ini \
   -b -vvv vm-setup/install-package-playbook.yml
 popd


### PR DESCRIPTION
If you want to build the installer from source, go 1.14 is the minimum
version.