### PR TITLE
Enable the ability to block multicast traffic for testing

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -235,3 +235,19 @@ OPENSTACKCLIENT_PATH="${OPENSTACKCLIENT_PATH:-/usr/local/bin/openstack}"
 if ! command -v openstack | grep -v "${OPENSTACKCLIENT_PATH}"; then
 	  sudo ln -sf "${METAL3_DEV_ENV_PATH}/openstackclient.sh" "${OPENSTACKCLIENT_PATH}"
 fi
+
+# Block Multicast with ebtables
+if [ "$DISABLE_MULTICAST" == "true" ]; then
+    for dst in 224.0.0.251 224.0.0.18; do
+        sudo ebtables -A INPUT --pkttype-type multicast -p ip4 --ip-dst ${dst} -j DROP
+        sudo ebtables -A FORWARD --pkttype-type multicast -p ip4 --ip-dst ${dst} -j DROP
+        sudo ebtables -A OUTPUT --pkttype-type multicast -p ip4 --ip-dst ${dst} -j DROP
+    done
+
+    for dst in ff02::fb ff02::12; do
+        sudo ebtables -A INPUT --pkttype-type multicast -p ip6 --ip6-dst ${dst} -j DROP
+        sudo ebtables -A FORWARD --pkttype-type multicast -p ip6 --ip6-dst ${dst} -j DROP
+        sudo ebtables -A OUTPUT --pkttype-type multicast -p ip6 --ip6-dst ${dst} -j DROP
+    done
+fi
+

--- a/config_example.sh
+++ b/config_example.sh
@@ -149,6 +149,10 @@ set -x
 # Enable FIPS mode
 #export FIPS_MODE=true
 
+# In order to test using unicast for keepalived, one needs to disable multicast.
+# Setting this variable to true will block multicast via ebtables for both IPv4 and IPv6.
+#export DISABLE_MULTICAST=false
+
 ##
 ## Multi-cluster/Hive variables
 ##

--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -62,5 +62,9 @@ if [ "$MANAGE_BR_BRIDGE" == "y" ]; then
     sudo ip link delete ${BAREMETAL_NETWORK_NAME} || true
     sudo rm -f /etc/sysconfig/network-scripts/ifcfg-${BAREMETAL_NETWORK_NAME}
 fi
+
+# Drop all ebtables rules
+sudo ebtables --flush
+
 # Kill any lingering proxy
 sudo pkill -f oc.*proxy


### PR DESCRIPTION
In order to properly test unicast VRRP with keepalived, it is desirable to
block multicast on the provisioning host.

This patch does so with ebtables. Additional config will be required in
vm_setup_vars.yml to create external SRV records, since coredns-multicast
will no longer be working.