### PR TITLE
Use IPv4 VIPs for dual-stack envs

### DIFF
--- a/vm_setup_vars.yml
+++ b/vm_setup_vars.yml
@@ -25,7 +25,7 @@ flavors:
 # For OpenShift we create some additional DNS records for the API/DNS VIPs
 baremetal_network_cidr_v4: "{{ lookup('env', 'EXTERNAL_SUBNET_V4') }}"
 baremetal_network_cidr_v6: "{{ lookup('env', 'EXTERNAL_SUBNET_V6') }}"
-baremetal_network_cidr: "{{ baremetal_network_cidr_v6 | default(baremetal_network_cidr_v4, true) }}"
+baremetal_network_cidr: "{{ baremetal_network_cidr_v4 | default(baremetal_network_cidr_v6, true) }}"
 dns_extrahosts:
   - ip: "{{ baremetal_network_cidr | nthhost(5) }}"
     hostnames:


### PR DESCRIPTION
When running a dual-stack OpenShift cluster, the cluster uses IPv4 as
the primary address family.  We should use IPv4 for the VIPs if we're
only going to use a single address family.

This came up because baremetal-runtimecfg uses the address family of
the API VIP to determine what address to look for on the Node to give
to kubelet to use as the node IP.  Dan Winship suggested that IPv4
would be a better default since that's the primary address family for
the cluster.

This is fine for a short term change, but what we really need to do is
fix this env so that we have both IPv4 and IPv6 VIPs at the same time,
but that's going to take more work and can't be solved only in
dev-scripts alone.