### PR TITLE
Further single-stack IPv6 vs dual-stack updates

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -33,7 +33,7 @@ if [ ! -z "${VM_NODES_FILE}" ]; then
   exit 1
 fi
 
-if [[ "${IP_STACK}" == "v6" ]]; then
+if [[ "${IP_STACK}" != "v4" ]]; then
   # TODO - move this to metal3-dev-env.
   # This is to address the following error:
   #   "msg": "internal error: Check the host setup: enabling IPv6 forwarding with RA routes without accept_ra set to 2 is likely to cause routes loss. Interfaces to look at: eno2"

--- a/05_create_install_config.sh
+++ b/05_create_install_config.sh
@@ -12,7 +12,7 @@ verify_pull_secret
 
 # NOTE: This is equivalent to the external API DNS record pointing the API to the API VIP
 if [ "$MANAGE_BR_BRIDGE" == "y" ] ; then
-    if [[ -n "${EXTERNAL_SUBNET_V6}" ]]; then
+    if [[ -z "${EXTERNAL_SUBNET_V4}" ]]; then
         API_VIP=$(dig -t AAAA +noall +answer "api.${CLUSTER_DOMAIN}" @$(network_ip ${BAREMETAL_NETWORK_NAME}) | awk '{print $NF}')
         INGRESS_VIP=$(python -c "from ansible.plugins.filter import ipaddr; print(ipaddr.nthhost('"$EXTERNAL_SUBNET_V6"', 4))")
     else
@@ -24,7 +24,7 @@ if [ "$MANAGE_BR_BRIDGE" == "y" ] ; then
     echo "listen-address=::1" | sudo tee -a /etc/NetworkManager/dnsmasq.d/openshift-${CLUSTER_NAME}.conf
     sudo systemctl reload NetworkManager
 else
-    if [[ -n "${EXTERNAL_SUBNET_V6}" ]]; then
+    if [[ -z "${EXTERNAL_SUBNET_V4}" ]]; then
         API_VIP=$(dig -t AAAA +noall +answer "api.${CLUSTER_DOMAIN}"  | awk '{print $NF}')
     else
         API_VIP=$(dig +noall +answer "api.${CLUSTER_DOMAIN}"  | awk '{print $NF}')

--- a/common.sh
+++ b/common.sh
@@ -161,10 +161,10 @@ else
   exit 1
 fi
 
-if [[ "${IP_STACK}" = "v4" ]]; then
-  export DNS_VIP=${DNS_VIP:-$(python -c "import ipaddress; print(ipaddress.ip_network(u\"$EXTERNAL_SUBNET_V4\")[2])")}
-else
+if [[ "${IP_STACK}" = "v6" ]]; then
   export DNS_VIP=${DNS_VIP:-$(python -c "import ipaddress; print(ipaddress.ip_network(u\"$EXTERNAL_SUBNET_V6\")[2])")}
+else
+  export DNS_VIP=${DNS_VIP:-$(python -c "import ipaddress; print(ipaddress.ip_network(u\"$EXTERNAL_SUBNET_V4\")[2])")}
 fi
 
 # The DNS name for the registry that this cluster should use.
@@ -183,10 +183,10 @@ export PROVISIONING_HOST_USER=${PROVISIONING_HOST_USER:-$USER}
 # ipcalc on CentOS 7 doesn't support the 'minaddr' option, so use python
 # instead to get the first address in the network:
 export PROVISIONING_HOST_IP=${PROVISIONING_HOST_IP:-$(python -c "import ipaddress; print(next(ipaddress.ip_network(u\"$PROVISIONING_NETWORK\").hosts()))")}
-if [[ "${IP_STACK}" = "v4" ]]; then
-  export PROVISIONING_HOST_EXTERNAL_IP=${PROVISIONING_HOST_EXTERNAL_IP:-$(python -c "import ipaddress; print(next(ipaddress.ip_network(u\"$EXTERNAL_SUBNET_V4\").hosts()))")}
-else
+if [[ "${IP_STACK}" = "v6" ]]; then
   export PROVISIONING_HOST_EXTERNAL_IP=${PROVISIONING_HOST_EXTERNAL_IP:-$(python -c "import ipaddress; print(next(ipaddress.ip_network(u\"$EXTERNAL_SUBNET_V6\").hosts()))")}
+else
+  export PROVISIONING_HOST_EXTERNAL_IP=${PROVISIONING_HOST_EXTERNAL_IP:-$(python -c "import ipaddress; print(next(ipaddress.ip_network(u\"$EXTERNAL_SUBNET_V4\").hosts()))")}
 fi
 export MIRROR_IP=${MIRROR_IP:-$PROVISIONING_HOST_IP}
 

--- a/run_ci.sh
+++ b/run_ci.sh
@@ -14,7 +14,7 @@ function getlogs(){
 
     # And the VM journals and staticpod container logs
     BM_SUB=""
-    if [[ -n "${EXTERNAL_SUBNET_V6}" ]]; then
+    if [[ -z "${EXTERNAL_SUBNET_V4}" ]]; then
         BM_SUB=$(echo "${EXTERNAL_SUBNET_V6}" | cut -d"/" -f1 | sed "s/0$//")
     else
         BM_SUB=$(echo "${EXTERNAL_SUBNET_V4}" | cut -d"/" -f1 | sed "s/0$//")

--- a/show_bootstrap_log.sh
+++ b/show_bootstrap_log.sh
@@ -2,9 +2,15 @@
 
 source common.sh
 
+if [[ "${IP_STACK}" == "v6" ]]; then
+    pref_ip=ipv6
+else
+    pref_ip=ipv4
+fi
+
 BOOTSTRAP_VM_IP=$(sudo virsh net-dhcp-leases ${BAREMETAL_NETWORK_NAME} \
                       | grep -v master \
-                      | grep "ip${IP_STACK}" \
+                      | grep "${pref_ip}" \
                       | tail -n1 \
                       | awk '{print $5}' \
                       | sed -e 's/\(.*\)\/.*/\1/')


### PR DESCRIPTION
Followup to #1062. There are a bunch of other places that assumed that if an IPv6 subnet is defined, then we prefer IPv6. Also, two places used `${IP_STACK}` in a way that didn't take the possibility of `"v4v6"` into account.

I'm not sure if [this code](https://github.com/openshift-metal3/dev-scripts/blob/b1e7c89fb5412b4da001c25fce5a5a394bebb635/02_configure_host.sh#L159) is single-stack IPv6-specific or if it works with dual-stack?

Not tested because I don't know how to test it...

/assign @russellb 