### PR TITLE
Switch to "mixed" mode for VM management

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -17,7 +17,7 @@ if [ -z "${METAL3_DEV_ENV}" ]; then
   # TODO -- come up with a plan for continuously updating this
   # Note we only do this in the case where METAL3_DEV_ENV is
   # unset, to enable developer testing of local checkouts
-  git reset 15260d6313758d29397f2b14ccac084e8bf8bcdd --hard
+  git reset d31a9c11651c4baaeb82c3db4a30b613713f3dba --hard
   popd
 fi
 

--- a/common.sh
+++ b/common.sh
@@ -228,6 +228,16 @@ fi
 
 export OPENSHIFT_RELEASE_TAG=$(echo $OPENSHIFT_RELEASE_IMAGE | sed -E 's/[[:alnum:]\/.-]*release.*://')
 
+# Use "ipmi" for 4.3 as it didn't support redfish, for other versions
+# use "redfish", unless its CI where we use "mixed"
+if [[ "$OPENSHIFT_VERSION" == "4.3" ]]; then
+  export BMC_DRIVER=${BMC_DRIVER:-ipmi}
+elif [[ -z "$OPENSHIFT_CI" ]]; then
+  export BMC_DRIVER=${BMC_DRIVER:-redfish}
+else
+  export BMC_DRIVER=${BMC_DRIVER:-mixed}
+fi
+
 # Both utils.sh and 04_setup_ironic.sh use this log file, so set the
 # name one time. Users should not override this.
 export MIRROR_LOG_FILE=${REGISTRY_DIR}/${CLUSTER_NAME}-image_mirror-${OPENSHIFT_RELEASE_TAG}.log


### PR DESCRIPTION
Creates some VMs with ipmi and others with redfish, so
dev-scripts will test both paths.