### PR TITLE
Add OPENSHIFT_RELEASE_TYPE variable

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -211,7 +211,8 @@ export KNI_INSTALL_FROM_GIT=${KNI_INSTALL_FROM_GIT:-}
 # if we provide OPENSHIFT_RELEASE_IMAGE, do not curl. This is needed for offline installs
 if [ -z "${OPENSHIFT_RELEASE_IMAGE:-}" ]; then
   OPENSHIFT_RELEASE_STREAM=${OPENSHIFT_RELEASE_STREAM:-4.6}
-  LATEST_CI_IMAGE=$(curl -L https://openshift-release.svc.ci.openshift.org/api/v1/releasestream/${OPENSHIFT_RELEASE_STREAM}.0-0.ci/latest | grep -o 'registry.svc.ci.openshift.org[^"]\+')
+  OPENSHIFT_RELEASE_TYPE=${OPENSHIFT_RELEASE_TYPE:-ci}
+  LATEST_CI_IMAGE=$(curl -L https://openshift-release.svc.ci.openshift.org/api/v1/releasestream/${OPENSHIFT_RELEASE_STREAM}.0-0.${OPENSHIFT_RELEASE_TYPE}/latest | grep -o 'registry.svc.ci.openshift.org[^"]\+')
 fi
 export OPENSHIFT_RELEASE_IMAGE="${OPENSHIFT_RELEASE_IMAGE:-$LATEST_CI_IMAGE}"
 export OPENSHIFT_INSTALL_PATH="$GOPATH/src/github.com/openshift/installer"

--- a/config_example.sh
+++ b/config_example.sh
@@ -9,6 +9,10 @@ set -x
 # image name is not specified
 #export OPENSHIFT_RELEASE_STREAM=4.6
 
+# Select a different release type from which to pull the latest image,
+# e.g ci or nightly
+#export OPENSHIFT_RELEASE_TYPE=ci
+
 # Use <NAME>_LOCAL_IMAGE to build or use copy of container images locally e.g.
 #export IRONIC_INSPECTOR_LOCAL_IMAGE=https://github.com/metal3-io/ironic-inspector
 #export IRONIC_LOCAL_IMAGE=quay.io/username/ironic


### PR DESCRIPTION
We've been seeing different behavior between the ci and
nightly builds, so this makes it easier to switch between
them to compare, e.g to deploy latest nightly

export OPENSHIFT_RELEASE_TYPE=nightly