### PR TITLE
ensure extra hosts are created in the right namespace

### DIFF
--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -217,6 +217,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: ${name}-bmc-secret
+  namespace: openshift-machine-api
 type: Opaque
 data:
   username: $encoded_username
@@ -227,6 +228,7 @@ apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
 metadata:
   name: $name
+  namespace: openshift-machine-api
 spec:
   online: true
   bootMACAddress: $mac


### PR DESCRIPTION
Explicitly list the namespace for the secrets and hosts so it doesn't
matter what project context is set when oc is used to add them to the
cluster.