### PR TITLE
Fix firewall issues with NUM_EXTRA_WORKERS

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -87,7 +87,7 @@ if [ ${NUM_EXTRA_WORKERS} -ne 0 ]; then
         -e "manage_baremetal=$MANAGE_BR_BRIDGE" \
         -e "provisioning_url_host=$PROVISIONING_URL_HOST" \
         -e "nodes_file=$EXTRA_NODES_FILE" \
-        -e "virtualbmc_base_port=$(($VBMC_BASE_PORT + $NUM_MASTERS + $NUM_WORKERS))" \
+        -e "virtualbmc_base_port=$((VBMC_BASE_PORT + NUM_MASTERS + NUM_WORKERS))" \
         -e "master_hostname_format=$MASTER_HOSTNAME_FORMAT" \
         -e "worker_hostname_format=extra-$WORKER_HOSTNAME_FORMAT" \
         -i ${VM_SETUP_PATH}/inventory.ini \
@@ -250,4 +250,3 @@ if [ "$DISABLE_MULTICAST" == "true" ]; then
         sudo ebtables -A OUTPUT --pkttype-type multicast -p ip6 --ip6-dst ${dst} -j DROP
     done
 fi
-

--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -87,7 +87,7 @@ if [ ${NUM_EXTRA_WORKERS} -ne 0 ]; then
         -e "manage_baremetal=$MANAGE_BR_BRIDGE" \
         -e "provisioning_url_host=$PROVISIONING_URL_HOST" \
         -e "nodes_file=$EXTRA_NODES_FILE" \
-        -e "virtualbmc_base_port=$(( $VBMC_BASE_PORT + $NUM_MASTERS + $NUM_WORKERS + 1 ))" \
+        -e "virtualbmc_base_port=$(($VBMC_BASE_PORT + $NUM_MASTERS + $NUM_WORKERS))" \
         -e "master_hostname_format=$MASTER_HOSTNAME_FORMAT" \
         -e "worker_hostname_format=extra-$WORKER_HOSTNAME_FORMAT" \
         -i ${VM_SETUP_PATH}/inventory.ini \

--- a/common.sh
+++ b/common.sh
@@ -328,7 +328,7 @@ export IRONIC_IMAGES_DIR="${IRONIC_DATA_DIR}/html/images"
 export VBMC_IMAGE=${VBMC_IMAGE:-"quay.io/metal3-io/vbmc"}
 export SUSHY_TOOLS_IMAGE=${SUSHY_TOOLS_IMAGE:-"quay.io/metal3-io/sushy-tools"}
 export VBMC_BASE_PORT=${VBMC_BASE_PORT:-"6230"}
-export VBMC_MAX_PORT=$((${VBMC_BASE_PORT} + ${NUM_MASTERS} + ${NUM_WORKERS} - 1))
+export VBMC_MAX_PORT=$((${VBMC_BASE_PORT} + ${NUM_MASTERS} + ${NUM_WORKERS} + ${NUM_EXTRA_WORKERS} - 1))
 
 # Which docker registry image should we use?
 export DOCKER_REGISTRY_IMAGE=${DOCKER_REGISTRY_IMAGE:-"docker.io/registry:latest"}

--- a/common.sh
+++ b/common.sh
@@ -328,7 +328,7 @@ export IRONIC_IMAGES_DIR="${IRONIC_DATA_DIR}/html/images"
 export VBMC_IMAGE=${VBMC_IMAGE:-"quay.io/metal3-io/vbmc"}
 export SUSHY_TOOLS_IMAGE=${SUSHY_TOOLS_IMAGE:-"quay.io/metal3-io/sushy-tools"}
 export VBMC_BASE_PORT=${VBMC_BASE_PORT:-"6230"}
-export VBMC_MAX_PORT=$((${VBMC_BASE_PORT} + ${NUM_MASTERS} + ${NUM_WORKERS} + ${NUM_EXTRA_WORKERS} - 1))
+export VBMC_MAX_PORT=$((VBMC_BASE_PORT + NUM_MASTERS + NUM_WORKERS + NUM_EXTRA_WORKERS - 1))
 
 # Which docker registry image should we use?
 export DOCKER_REGISTRY_IMAGE=${DOCKER_REGISTRY_IMAGE:-"docker.io/registry:latest"}


### PR DESCRIPTION
There are two problems - the base port is miscalculated so we
have a discontinuous port range, and we don't consider the extra
workers in the calculation of VBMC_MAX_PORT.

This means BMH registration fails when adding the extra workers
to the cluster.