### PR TITLE
add script for pausing bmo management of control plane hosts

### DIFF
--- a/metal3-dev/pause-control-plane.sh
+++ b/metal3-dev/pause-control-plane.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -x
+
+for host in $(oc get baremetalhost -n openshift-machine-api -o name | grep -e '-master-'); do
+    oc annotate --overwrite -n openshift-machine-api "$host" \
+       'baremetalhost.metal3.io/paused=""'
+done


### PR DESCRIPTION
Sometimes when working on the baremetal-operator it is useful to have
it ignore hosts so the logs do not become cluttered with the usual
regular updates. This script applies the pause annotation to the
control plane hosts so the baremetal-operator will stop regularly
checking their power state.