### PR TITLE
Temporarily revert to using IPMI only

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -229,15 +229,19 @@ fi
 
 export OPENSHIFT_RELEASE_TAG=$(echo $OPENSHIFT_RELEASE_IMAGE | sed -E 's/[[:alnum:]\/.-]*release.*://')
 
+# FIXME(stbenjam): Temporarily use ipmi as sushy tools currently has the
+# wrong version in CI builds of ironic images.
+export BMC_DRIVER=${BMC_DRIVER:-ipmi}
+
 # Use "ipmi" for 4.3 as it didn't support redfish, for other versions
 # use "redfish", unless its CI where we use "mixed"
-if [[ "$OPENSHIFT_VERSION" == "4.3" ]]; then
-  export BMC_DRIVER=${BMC_DRIVER:-ipmi}
-elif [[ -z "$OPENSHIFT_CI" ]]; then
-  export BMC_DRIVER=${BMC_DRIVER:-redfish}
-else
-  export BMC_DRIVER=${BMC_DRIVER:-mixed}
-fi
+#if [[ "$OPENSHIFT_VERSION" == "4.3" ]]; then
+#  export BMC_DRIVER=${BMC_DRIVER:-ipmi}
+#elif [[ -z "$OPENSHIFT_CI" ]]; then
+#  export BMC_DRIVER=${BMC_DRIVER:-redfish}
+#else
+#  export BMC_DRIVER=${BMC_DRIVER:-mixed}
+#fi
 
 # Both utils.sh and 04_setup_ironic.sh use this log file, so set the
 # name one time. Users should not override this.


### PR DESCRIPTION
Redfish is currently erroring with this below due to wrong sushy tools library in the ironic images.

```
level=error msg="Error: could not inspect: could not inspect node, node is currently 'inspect failed', last error was 'Failed to inspect hardware. Reason: unable to start inspection: 'System' object has no attribute 'set_system_boot_options''"
level=error
level=error msg=" on ../../tmp/openshift-install-695067531/masters/main.tf line 1, in resource \"ironic_node_v1\" \"openshift-master-host\":"
level=error msg=" 1: resource \"ironic_node_v1\" \"openshift-master-host\" {"
level=error
level=error
```