### PR TITLE
Restore redfish/ipmi mixed mode as default for BMC's

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -229,19 +229,15 @@ fi
 
 export OPENSHIFT_RELEASE_TAG=$(echo $OPENSHIFT_RELEASE_IMAGE | sed -E 's/[[:alnum:]\/.-]*release.*://')
 
-# FIXME(stbenjam): Temporarily use ipmi as sushy tools currently has the
-# wrong version in CI builds of ironic images.
-export BMC_DRIVER=${BMC_DRIVER:-ipmi}
-
 # Use "ipmi" for 4.3 as it didn't support redfish, for other versions
 # use "redfish", unless its CI where we use "mixed"
-#if [[ "$OPENSHIFT_VERSION" == "4.3" ]]; then
-#  export BMC_DRIVER=${BMC_DRIVER:-ipmi}
-#elif [[ -z "$OPENSHIFT_CI" ]]; then
-#  export BMC_DRIVER=${BMC_DRIVER:-redfish}
-#else
-#  export BMC_DRIVER=${BMC_DRIVER:-mixed}
-#fi
+if [[ "$OPENSHIFT_VERSION" == "4.3" ]]; then
+  export BMC_DRIVER=${BMC_DRIVER:-ipmi}
+elif [[ -z "$OPENSHIFT_CI" ]]; then
+  export BMC_DRIVER=${BMC_DRIVER:-redfish}
+else
+  export BMC_DRIVER=${BMC_DRIVER:-mixed}
+fi
 
 # Both utils.sh and 04_setup_ironic.sh use this log file, so set the
 # name one time. Users should not override this.


### PR DESCRIPTION
This restores redfish as the default for all users, and mixed mode as
the default for CI.