### PR TITLE
Handle empty assets/generated dir

### DIFF
--- a/utils.sh
+++ b/utils.sh
@@ -72,12 +72,7 @@ function create_cluster() {
       mv ${assets_dir}/worker.ign ${assets_dir}/worker.ign.orig
       jq -s '.[0] * .[1]' ${IGNITION_EXTRA} ${assets_dir}/worker.ign.orig | tee ${assets_dir}/worker.ign
     fi
-    $OPENSHIFT_INSTALLER --dir "${assets_dir}" --log-level=debug create cluster || true
-    # FIXME(stbenjam): Deploying workers as part of the install now
-    # seems to reliably exceed the 30 minute limit. We're going to have
-    # to implement a 60-minute timeout for install-complete on baremetal
-    # I think.
-    $OPENSHIFT_INSTALLER --dir "${assets_dir}" --log-level=debug wait-for install-complete
+    $OPENSHIFT_INSTALLER --dir "${assets_dir}" --log-level=debug create cluster
 }
 
 function ipversion(){

--- a/utils.sh
+++ b/utils.sh
@@ -16,11 +16,15 @@ function generate_assets() {
 
 function custom_ntp(){
   # TODO - consider adding NTP server config to install-config.yaml instead
-  if [ -z "${NTP_SERVERS}" ] && host clock.redhat.com; then
-    NTP_SERVERS="clock.redhat.com"
+  if [ -z "${NTP_SERVERS}" ]; then
+    if host clock.redhat.com; then
+      NTP_SERVERS="clock.redhat.com"
+    elif host pool.ntp.org; then
+      NTP_SERVERS="pool.ntp.org"
+    fi
   fi
 
-  if [ "$NTP_SERVERS" ]; then
+  if [ -n "$NTP_SERVERS" ]; then
     cp assets/templates/98_worker-chronyd-custom.yaml.optional assets/generated/98_worker-chronyd-custom.yaml
     cp assets/templates/98_master-chronyd-custom.yaml.optional assets/generated/98_master-chronyd-custom.yaml
     NTPFILECONTENT=$(cat assets/files/etc/chrony.conf)

--- a/utils.sh
+++ b/utils.sh
@@ -47,7 +47,7 @@ function create_cluster() {
     generate_templates
 
     mkdir -p ${assets_dir}/openshift
-    cp -rf assets/generated/*.yaml ${assets_dir}/openshift
+    find assets/generated -name '*.yaml' -exec cp -f {} ${assets_dir}/openshift \;
 
     if [[ "${IP_STACK}" == "v4v6" ]]; then
         # The IPv6DualStack feature is not on by default, because it doesn't

--- a/utils.sh
+++ b/utils.sh
@@ -16,7 +16,7 @@ function generate_assets() {
 
 function custom_ntp(){
   # TODO - consider adding NTP server config to install-config.yaml instead
-  if [ -z ${NTP_SERVERS} ] && $(host clock.redhat.com > /dev/null); then
+  if [ -z "${NTP_SERVERS}" ] && host clock.redhat.com; then
     NTP_SERVERS="clock.redhat.com"
   fi
 


### PR DESCRIPTION
It's possible for this to be empty, e.g if we fail the resolution
of clock.redhat.com no custom DNS manifests get created

This appears to currently be the case in CI, so we fail like:

cp: cannot stat 'assets/generated/*.yaml': No such file or directory