### PR TITLE
Add the latest ansible collections to Openshift CI image

### DIFF
--- a/images/Dockerfile.ci
+++ b/images/Dockerfile.ci
@@ -6,6 +6,7 @@ ENV HOME /output
 RUN INSTALL_PKGS="ansible python-pip" && \
     yum install -y $INSTALL_PKGS && \
     pip install packet-python && \
+    ansible-galaxy collection install community.general && \
     yum clean all && \
     rm -rf /var/cache/yum/* && \         
     chmod g+rwx /output && \

--- a/images/Dockerfile.ci
+++ b/images/Dockerfile.ci
@@ -1,7 +1,7 @@
 # This Dockerfile builds the image used by the e2e-metal-ipi test steps in the OpenShift CI.
 # For more details about the test see https://steps.svc.ci.openshift.org/job/openshift-baremetal-operator-master-e2e-metal-ipi
 
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.14
 ENV HOME /output
 RUN INSTALL_PKGS="ansible python-pip" && \
     yum install -y $INSTALL_PKGS && \
@@ -9,7 +9,7 @@ RUN INSTALL_PKGS="ansible python-pip" && \
     ansible-galaxy collection install community.general && \
     yum clean all && \
     rm -rf /var/cache/yum/* && \         
-    chmod g+rwx /output && \
+    chmod -R g+rwx /output && \
 # TODO: Remove once OpenShift CI will be upgraded to 4.2 (see https://access.redhat.com/articles/4859371)
     chmod g+w /etc/passwd && \
     echo 'echo default:x:$(id -u):$(id -g):Default Application User:/output:/sbin/nologin\ >> /etc/passwd' > /output/fix_uid.sh && \


### PR DESCRIPTION
We need to pull the latest ansible collections into this image in order to start using tags for packet servers.