### PR TITLE
add a script to get the image settings for the active MAO

### DIFF
--- a/docs/custom-mao-and-capbm.md
+++ b/docs/custom-mao-and-capbm.md
@@ -98,8 +98,12 @@ Edit `custom-images.json` to have a modified image for the BareMetal case:
 
 ### 4) Now run the MAO
 
-Change `custom-images.json` to `pkg/operator/fixtures/images.json` if you
-didn’t build a custom CAPBM.
+Use `mao-images.sh` to extract the images being used by the current
+machine-api-operator if you have not customized the list:
+
+```sh
+./mao-images.sh > custom-images.json
+```
 
 Update the `kubeconfig` path to reflect your own environment.
 

--- a/mao-images.sh
+++ b/mao-images.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+oc get configmap -n openshift-machine-api machine-api-operator-images -o jsonpath="{.data.images\.json}"


### PR DESCRIPTION
Sometimes when working with the machine-api-operator it is not
necessary to provide a custom set of images, and the images file in
the machine-api-operator repository may not match the cluster where
development is happening. This new script extracts the image settings
from the running machine-api-operator so they can be used with a
custom build.