### PR TITLE
Allow testing with custom base images

### DIFF
--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -1,0 +1,8 @@
+ARG TestRepo
+
+FROM ubi8
+
+RUN rm -f /etc/yum.repos.d/*
+COPY ${TestRepo:-"custom.repo"} /etc/yum.repos.d/
+
+RUN dnf upgrade -y

--- a/config_example.sh
+++ b/config_example.sh
@@ -18,6 +18,16 @@ set -x
 #export IRONIC_LOCAL_IMAGE=quay.io/username/ironic
 #export MACHINE_CONFIG_OPERATOR_LOCAL_IMAGE=https://github.com/openshift/machine-config-operator
 
+# Set this variable to point the custom base image to a different location
+# It can be an absolute path or a local path under the dev-scripts dir
+# export BASE_IMAGE_DIR=base-image
+
+# To build custom images based on custom base images with custom repositories
+# put all the custom repositories in a .repo file and set this variable with
+# the absolute path of the .repo file, e.g. if the filename is ocp46.repo and
+# it's in /home/goofy/
+# export CUSTOM_REPO_FILE=/home/goofy/ocp46.repo
+
 # IP stack version.  The default is "v6".  You may also set "v4".
 # For dual stack (IPv4 + IPv6), use "v4v6".
 # NOTE: dual stack is not expected to fully work yet.


### PR DESCRIPTION
One problem we have at the moment is testing with custom built
images using the same repositories and configuration from Openshift
upstream and downstream customization.
This patch introduces a bsae-image container that can be used to build
local images using for example custom repositories.
To be able to do that, we introduce 1 new variable that can be set
in the config file: CUSTOM_REPO_FILE
The CUSTOM_REPO_FILE is the name of a file that contains the custom
repositories that we want to use to install packages from, e.g.
export CUSTOM_REPO_FILE=ocp46.repo
The file needs to be present in the base-image dir.