### PR TITLE
Fix COPY instruction for custom repositories file

### DIFF
--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -34,8 +34,8 @@ echo "FROM $OPENSHIFT_RELEASE_IMAGE" > $DOCKERFILE
 # Build a base image if we set a custom repo file in the config file and
 # the file exists
 if [[ -n ${CUSTOM_REPO_FILE:-} ]]; then
-    if [[ -f "${CUSTOM_REPO_FILE}" ]]; then
-        BASE_IMAGE_DIR=${BASE_IMAGE_DIR:-base-image}
+    BASE_IMAGE_DIR=${BASE_IMAGE_DIR:-base-image}
+    if [[ -f "${BASE_IMAGE_DIR}/${CUSTOM_REPO_FILE}" ]]; then
         sudo podman build --tag ${BASE_IMAGE_DIR} --build-arg TestRepo="${CUSTOM_REPO_FILE}" -f "${BASE_IMAGE_DIR}/Dockerfile"
     else
         echo "${CUSTOM_REPO_FILE} does not exist!"
@@ -63,7 +63,7 @@ for IMAGE_VAR in $(env | grep "_LOCAL_IMAGE=" | grep -o "^[^=]*") ; do
         # the Dockerfile to prevent discrepancies between locally built images.
         # Replace all FROM entries with the base-image.
         if [[ -n ${BASE_IMAGE_DIR:-} ]]; then
-            sed -i 's/^FROM [^ ]*/FROM ${BASE_IMAGE_DIR}/g' ${IMAGE_DOCKERFILE}
+            sed -i "s/^FROM [^ ]*/FROM ${BASE_IMAGE_DIR}/g" ${IMAGE_DOCKERFILE}
         fi
         sudo podman build --authfile $COMBINED_AUTH_FILE -t ${!IMAGE_VAR} -f $IMAGE_DOCKERFILE .
         cd -

--- a/config_example.sh
+++ b/config_example.sh
@@ -23,10 +23,10 @@ set -x
 # export BASE_IMAGE_DIR=base-image
 
 # To build custom images based on custom base images with custom repositories
-# put all the custom repositories in a .repo file and set this variable with
-# the absolute path of the .repo file, e.g. if the filename is ocp46.repo and
-# it's in /home/goofy/
-# export CUSTOM_REPO_FILE=/home/goofy/ocp46.repo
+# put all the custom repositories in a .repo file inside the base-image directory
+# (default to dev-scripts/base-image) and set this variable with the name of the
+# .repo file, e.g. if the filename is ocp46.repo
+# export CUSTOM_REPO_FILE=ocp46.repo
 
 # IP stack version.  The default is "v6".  You may also set "v4".
 # For dual stack (IPv4 + IPv6), use "v4v6".


### PR DESCRIPTION
The paths of files and directories in the COPY instructions inside
the Dockerfile are interpreted as relative to the source of the
context of the build.
Therefore, the custom repository file must be created inside the
base-iamge directory or the build will fail.