### PR TITLE
Create all workers with a single ansible run

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -55,7 +55,7 @@ ansible-playbook \
     -e "baremetal_network_name=${BAREMETAL_NETWORK_NAME}" \
     -e "working_dir=$WORKING_DIR" \
     -e "num_masters=$NUM_MASTERS" \
-    -e "num_workers=$NUM_WORKERS" \
+    -e "num_workers=$((NUM_WORKERS + NUM_EXTRA_WORKERS))" \
     -e "extradisks=$VM_EXTRADISKS" \
     -e "libvirt_firmware=uefi" \
     -e "virthost=$HOSTNAME" \
@@ -69,29 +69,12 @@ ansible-playbook \
     -i ${VM_SETUP_PATH}/inventory.ini \
     -b -vvv ${VM_SETUP_PATH}/setup-playbook.yml
 
-# Invoke the playbook a second time to generate any extra workers.
 if [ ${NUM_EXTRA_WORKERS} -ne 0 ]; then
-    ansible-playbook \
-        -e @vm_setup_vars.yml \
-        -e "ironic_prefix=${CLUSTER_NAME}_extra_" \
-        -e "cluster_name=${CLUSTER_NAME}" \
-        -e "provisioning_network_name=${PROVISIONING_NETWORK_NAME}" \
-        -e "baremetal_network_name=${BAREMETAL_NETWORK_NAME}" \
-        -e "working_dir=$WORKING_DIR" \
-        -e "num_masters=0" \
-        -e "num_workers=$NUM_EXTRA_WORKERS" \
-        -e "extradisks=$VM_EXTRADISKS" \
-        -e "libvirt_firmware=uefi" \
-        -e "virthost=$HOSTNAME" \
-        -e "vm_platform=$NODES_PLATFORM" \
-        -e "manage_baremetal=$MANAGE_BR_BRIDGE" \
-        -e "provisioning_url_host=$PROVISIONING_URL_HOST" \
-        -e "nodes_file=$EXTRA_NODES_FILE" \
-        -e "virtualbmc_base_port=$((VBMC_BASE_PORT + NUM_MASTERS + NUM_WORKERS))" \
-        -e "master_hostname_format=$MASTER_HOSTNAME_FORMAT" \
-        -e "worker_hostname_format=extra-$WORKER_HOSTNAME_FORMAT" \
-        -i ${VM_SETUP_PATH}/inventory.ini \
-        -b -vvv ${VM_SETUP_PATH}/setup-playbook.yml
+  ORIG_NODES_FILE="${NODES_FILE}.orig"
+  cp -f ${NODES_FILE} ${ORIG_NODES_FILE}
+  sudo chown -R $USER:$USER ${NODES_FILE}
+  jq "{nodes: .nodes[:$((NUM_MASTERS + NUM_WORKERS))]}" ${ORIG_NODES_FILE} | tee ${NODES_FILE}
+  jq "{nodes: .nodes[-${NUM_EXTRA_WORKERS}:]}" ${ORIG_NODES_FILE} | tee ${EXTRA_NODES_FILE}
 fi
 
 # Allow local non-root-user access to libvirt

--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -20,32 +20,13 @@ ansible-playbook \
     -e "baremetal_network_name=${BAREMETAL_NETWORK_NAME}" \
     -e "working_dir=$WORKING_DIR" \
     -e "num_masters=$NUM_MASTERS" \
-    -e "num_workers=$NUM_WORKERS" \
+    -e "num_workers=$((NUM_WORKERS + NUM_EXTRA_WORKERS))" \
     -e "extradisks=$VM_EXTRADISKS" \
     -e "virthost=$HOSTNAME" \
     -e "manage_baremetal=$MANAGE_BR_BRIDGE" \
     -e "nodes_file=$NODES_FILE" \
     -i ${VM_SETUP_PATH}/inventory.ini \
     -b -vvv ${VM_SETUP_PATH}/teardown-playbook.yml
-
-# Invoke the playbook a second time to remove any extra workers.
-if [ ${NUM_EXTRA_WORKERS} -ne 0 ]; then
-    ansible-playbook \
-        -e @vm_setup_vars.yml \
-        -e "ironic_prefix=${CLUSTER_NAME}_extra_" \
-        -e "cluster_name=${CLUSTER_NAME}" \
-        -e "provisioning_network_name=${PROVISIONING_NETWORK_NAME}" \
-        -e "baremetal_network_name=${BAREMETAL_NETWORK_NAME}" \
-        -e "working_dir=$WORKING_DIR" \
-        -e "num_masters=$NUM_MASTERS" \
-        -e "num_workers=$NUM_EXTRA_WORKERS" \
-        -e "extradisks=$VM_EXTRADISKS" \
-        -e "virthost=$HOSTNAME" \
-        -e "manage_baremetal=$MANAGE_BR_BRIDGE" \
-        -e "nodes_file=$EXTRA_NODES_FILE" \
-        -i ${VM_SETUP_PATH}/inventory.ini \
-        -b -vvv ${VM_SETUP_PATH}/teardown-playbook.yml
-fi
 
 sudo rm -rf /etc/NetworkManager/dnsmasq.d/openshift-${CLUSTER_NAME}.conf /etc/yum.repos.d/delorean*
 # There was a bug in this file, it may need to be recreated.


### PR DESCRIPTION
Currently we invoke the ansible roles twice, which results
in missing DHCP reservations in the ostestbm network configuration,
because that network already exists when the second run takes place.

That means on scale out any workers defined via NUM_EXTRA_WORKERS will
fail to join the cluster, since they register as "localhost", but the
machine hostname is "localhost.localdomain", which the machine-approver
rejects.