### PR TITLE
preserve the generated assets for debugging in case the cluster fails

### DIFF
--- a/utils.sh
+++ b/utils.sh
@@ -72,6 +72,12 @@ function create_cluster() {
       mv ${assets_dir}/worker.ign ${assets_dir}/worker.ign.orig
       jq -s '.[0] * .[1]' ${IGNITION_EXTRA} ${assets_dir}/worker.ign.orig | tee ${assets_dir}/worker.ign
     fi
+
+    # Preserve the assets for debugging
+    mkdir -p "${assets_dir}/saved-assets"
+    cp -av "${assets_dir}/openshift" "${assets_dir}/saved-assets"
+    cp -av "${assets_dir}/manifests" "${assets_dir}/saved-assets"
+
     $OPENSHIFT_INSTALLER --dir "${assets_dir}" --log-level=debug create cluster
 }
 


### PR DESCRIPTION
I've found it useful to be able to examine the raw YAML for the generated
assets to understand why a cluster doesn't always come up (especially
when the host resources are invalid).