### PR TITLE
Set OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE when setting MIRROR_IMAGES

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -59,6 +59,3 @@ if [[ -z "$OPENSHIFT_CI" ]]; then
   popd
 fi
 
-if [[ ! -z "${MIRROR_IMAGES}" || $(env | grep "_LOCAL_IMAGE=") ]]; then
-    setup_local_registry
-fi

--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -48,6 +48,11 @@ fi
 
 export ANSIBLE_FORCE_COLOR=true
 
+# Setup the registry for mirroring images
+if [[ ! -z "${MIRROR_IMAGES}" || $(env | grep "_LOCAL_IMAGE=") ]]; then
+    setup_local_registry
+fi
+
 ansible-playbook \
     -e @vm_setup_vars.yml \
     -e "ironic_prefix=${CLUSTER_NAME}_" \

--- a/network.sh
+++ b/network.sh
@@ -91,6 +91,7 @@ elif [[ "$IP_STACK" = "v6" ]]; then
   export SERVICE_SUBNET_V6=${SERVICE_SUBNET_V6:-"fd02::/112"}
   export NETWORK_TYPE=${NETWORK_TYPE:-"OVNKubernetes"}
   export MIRROR_IMAGES=true
+  export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/local-release-image:latest"
 elif [[ "$IP_STACK" = "v4v6" ]]; then
   export PROVISIONING_NETWORK=${PROVISIONING_NETWORK:-"fd00:1101::0/64"}
   export EXTERNAL_SUBNET_V4=${EXTERNAL_SUBNET_V4:-"192.168.111.0/24"}
@@ -103,6 +104,7 @@ elif [[ "$IP_STACK" = "v4v6" ]]; then
   export SERVICE_SUBNET_V6=${SERVICE_SUBNET_V6:-"fd02::/112"}
   export NETWORK_TYPE=${NETWORK_TYPE:-"OVNKubernetes"}
   export MIRROR_IMAGES=true
+  export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/local-release-image:latest"
 else
   echo "Unexpected setting for IP_STACK: '${IP_STACK}'"
   exit 1


### PR DESCRIPTION
OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE needs to be set along with MIRROR_IMAGES=true,
setting it in 04_setup_ironic.sh (where its used), wouldn't work alone as its also needed
in 06_create_cluster.sh