### PR TITLE
Add support to generate clouds.yaml with http_basic credentials

### DIFF
--- a/clouds.yaml.template
+++ b/clouds.yaml.template
@@ -1,9 +1,24 @@
 clouds:
+{{- if eq .AuthType "none"}}
   metal3-bootstrap:
-    auth_type: none
+    auth_type: {{.AuthType}}
     baremetal_endpoint_override: {{.BootstrapIronicURL}}
     baremetal_introspection_endpoint_override: {{.BootstrapInspectorURL}}
   metal3:
-    auth_type: none
+    auth_type: {{.AuthType}}
     baremetal_endpoint_override: {{.ClusterIronicURL}}
     baremetal_introspection_endpoint_override: {{.ClusterInspectorURL}}
+{{- else if eq .AuthType "http_basic"}}
+  metal3:
+    auth_type: {{.AuthType}}
+    auth:
+      username: {{.IronicUser}}
+      password: {{.IronicPassword}}
+    baremetal_endpoint_override: {{.ClusterIronicURL}}
+  metal3-inspector:
+    auth_type: {{.AuthType}}
+    auth:
+      username: {{.InspectorUser}}
+      password: {{.InspectorPassword}}
+    baremetal_introspection_endpoint_override: {{.ClusterInspectorURL}}
+{{- end}}

--- a/metal3-templater.go
+++ b/metal3-templater.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"github.com/apparentlymart/go-cidr/cidr"
 	"github.com/openshift/installer/pkg/ipnet"
@@ -19,56 +20,138 @@ type templater struct {
 	MachineOSImageURL          string
 
 	// Ironic clouds.yaml data
+	AuthType              string
 	BootstrapIronicURL    string
 	BootstrapInspectorURL string
 	ClusterIronicURL      string
 	ClusterInspectorURL   string
+	IronicUser            string
+	IronicPassword        string
+	InspectorUser         string
+	InspectorPassword     string
 }
 
 func main() {
+
+	var templateFile string
+	var bootstrapIP string
+
+	bootstrapCmd := flag.NewFlagSet("bootstrap", flag.ExitOnError)
+	bootstrapCmd.StringVar(&templateFile, "template-file", "", "Template File")
+	bootstrapCmd.StringVar(&bootstrapIP, "bootstrap-ip", "", "Bootstrap IP address")
+
+	var provisioningInterface string
+	var provisioningNetwork string
+	var clusterIP string
+	var imageURL string
+
+	noauthCmd := flag.NewFlagSet("noauth", flag.ExitOnError)
+	noauthCmd.StringVar(&templateFile, "template-file", "", "Template File")
+	noauthCmd.StringVar(&provisioningInterface, "provisioning-interface", "", "Cluster provisioning Interface")
+	noauthCmd.StringVar(&provisioningNetwork, "provisioning-network", "", "Provisioning Network CIDR")
+	noauthCmd.StringVar(&imageURL, "image-url", "", "Image URL")
+	noauthCmd.StringVar(&bootstrapIP, "bootstrap-ip", "", "Bootstrap IP address")
+	noauthCmd.StringVar(&clusterIP, "cluster-ip", "", "Cluster IP address")
+
+	httpBasicCmd := flag.NewFlagSet("http_basic", flag.ExitOnError)
+	httpBasicCmd.StringVar(&templateFile, "template-file", "", "Template File")
+	httpBasicCmd.StringVar(&provisioningInterface, "provisioning-interface", "", "Cluster provisioning Interface")
+	httpBasicCmd.StringVar(&provisioningNetwork, "provisioning-network", "", "Provisioning Network CIDR")
+	httpBasicCmd.StringVar(&imageURL, "image-url", "", "Image URL")
+	httpBasicCmd.StringVar(&bootstrapIP, "bootstrap-ip", "", "Bootstrap IP address")
+	httpBasicCmd.StringVar(&clusterIP, "cluster-ip", "", "Cluster IP address")
+
+	ironicCred := httpBasicCmd.String("ironic-basic-auth", "", "ironic credentials <user>:<password>")
+	inspectorCred := httpBasicCmd.String("inspector-basic-auth", "", "inspector crdentials <user>:<password>")
+
+	if len(os.Args) < 2 {
+		fmt.Printf("Expected 'bootstrap' 'noauth' or 'http_basic' subcommands\n")
+		os.Exit(1)
+	}
+
+	var auth = os.Args[1]
 	var templateData templater
 
-	if len(os.Args) < 7 {
-		fmt.Printf("usage: <prog> TEMPLATE_FILE INTERFACE NETWORK BOOTSTRAP_IP CLUSTER_IP IMAGE_URL\n")
+	switch auth {
+	case "bootstrap":
+		bootstrapCmd.Parse(os.Args[2:])
+		if !(bootstrapCmd.NFlag() == 2 && bootstrapCmd.NArg() == 0) {
+			os.Exit(1)
+		}
+
+		templateData.BootstrapIronicURL = fmt.Sprintf("http://%s", net.JoinHostPort(bootstrapIP, "6385"))
+		templateData.BootstrapInspectorURL = fmt.Sprintf("http://%s", net.JoinHostPort(bootstrapIP, "5050"))
+	case "noauth":
+		noauthCmd.Parse(os.Args[2:])
+		if !(noauthCmd.NFlag() == 6 && noauthCmd.NArg() == 0) {
+			fmt.Printf("Usage: <prog> noauth -template-file=TEMPLATE_FILE -provisioning-interface=INTERFACE -provisioning-network=NETWORK -bootstrap-ip=BOOTSTRAP_IP -cluster-ip=CLUSTER_IP -image-url=IMAGE_URL\n")
+			os.Exit(1)
+		}
+
+		templateData.AuthType = "none"
+	case "http_basic":
+		httpBasicCmd.Parse(os.Args[2:])
+		if !(httpBasicCmd.NFlag() == 8 && httpBasicCmd.NArg() == 0) {
+			fmt.Printf("Usage: <prog> http_basic -ironic-basic-auth=<user>:<password> -inspector-basic-auth=<user>:<password> -template-file=TEMPLATE_FILE -provisioning-interface=INTERFACE -provisioning-network=NETWORK -bootstrap-ip=BOOTSTRAP_IP -cluster-ip=CLUSTER_IP -image-url=IMAGE_URL\n")
+			os.Exit(1)
+		}
+
+		if !strings.Contains(*ironicCred, ":") {
+			fmt.Printf("The value for ironic-basic-auth should contain ':' as delimiter to separate username and password")
+			os.Exit(1)
+		}
+		if !strings.Contains(*inspectorCred, ":") {
+			fmt.Printf("The value for inspector-basic-auth should contain ':' as delimiter to separate username and password")
+			os.Exit(1)
+		}
+
+		ironicAuth := strings.Split(*ironicCred, ":")
+		inspectorAuth := strings.Split(*inspectorCred, ":")
+
+		templateData.AuthType = "http_basic"
+		templateData.IronicUser = ironicAuth[0]
+		templateData.IronicPassword = ironicAuth[1]
+		templateData.InspectorUser = inspectorAuth[0]
+		templateData.InspectorPassword = inspectorAuth[1]
+	default:
+		fmt.Println("Expected 'bootstrap' 'noauth' or 'http_basic' subcommands\n")
 		os.Exit(1)
 	}
 
-	templateFile := os.Args[1]
+	if auth != "bootstrap" {
+		templateData.ProvisioningInterface = provisioningInterface
 
-	templateData.ProvisioningInterface = os.Args[2]
+		ipnet := ipnet.MustParseCIDR(provisioningNetwork)
 
-	ipnet := ipnet.MustParseCIDR(os.Args[3])
+		// Image URL
+		url, err := url.Parse(imageURL)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		templateData.MachineOSImageURL = url.String()
 
-	// Image URL
-	url, err := url.Parse(os.Args[4])
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-	templateData.MachineOSImageURL = url.String()
+		// DHCP Range
+		startIP, _ := cidr.Host(&ipnet.IPNet, 10)
+		endIP, _ := cidr.Host(&ipnet.IPNet, 100)
+		templateData.ProvisioningDHCPRange = fmt.Sprintf("%s,%s", startIP, endIP)
 
-	// DHCP Range
-	startIP, _ := cidr.Host(&ipnet.IPNet, 10)
-	endIP, _ := cidr.Host(&ipnet.IPNet, 100)
-	templateData.ProvisioningDHCPRange = fmt.Sprintf("%s,%s", startIP, endIP)
+		// BootstrapIP
+		templateData.BootstrapIronicURL = fmt.Sprintf("http://%s", net.JoinHostPort(bootstrapIP, "6385"))
+		templateData.BootstrapInspectorURL = fmt.Sprintf("http://%s", net.JoinHostPort(bootstrapIP, "5050"))
 
-	// BootstrapIP
-	bootstrapIP := os.Args[5]
-	templateData.BootstrapIronicURL = fmt.Sprintf("http://%s", net.JoinHostPort(bootstrapIP, "6385"))
-	templateData.BootstrapInspectorURL = fmt.Sprintf("http://%s", net.JoinHostPort(bootstrapIP, "5050"))
+		// ProvisioningIP
+		size, _ := ipnet.IPNet.Mask.Size()
+		templateData.ProvisioningIP = fmt.Sprintf("%s/%d", clusterIP, size)
+		templateData.ClusterIronicURL = fmt.Sprintf("http://%s", net.JoinHostPort(clusterIP, "6385"))
+		templateData.ClusterInspectorURL = fmt.Sprintf("http://%s", net.JoinHostPort(clusterIP, "5050"))
 
-	// ProvisioningIP
-	ip := os.Args[6]
-	size, _ := ipnet.IPNet.Mask.Size()
-	templateData.ProvisioningIP = fmt.Sprintf("%s/%d", ip, size)
-	templateData.ClusterIronicURL = fmt.Sprintf("http://%s", net.JoinHostPort(ip, "6385"))
-	templateData.ClusterInspectorURL = fmt.Sprintf("http://%s", net.JoinHostPort(ip, "5050"))
-
-	// URL Host
-	if strings.Contains(ip, ":") {
-		templateData.ClusterProvisioningURLHost = fmt.Sprintf("[%s]", ip)
-	} else {
-		templateData.ClusterProvisioningURLHost = ip
+		// URL Host
+		if strings.Contains(clusterIP, ":") {
+			templateData.ClusterProvisioningURLHost = fmt.Sprintf("[%s]", clusterIP)
+		} else {
+			templateData.ClusterProvisioningURLHost = clusterIP
+		}
 	}
 
 	t, err := template.New(templateFile).ParseFiles(templateFile)
@@ -82,4 +165,5 @@ func main() {
 		fmt.Println(err)
 		os.Exit(1)
 	}
+
 }

--- a/utils.sh
+++ b/utils.sh
@@ -48,7 +48,7 @@ function create_cluster() {
 
     generate_assets
     custom_ntp
-    generate_templates
+    generate_metal3_config
 
     mkdir -p ${assets_dir}/openshift
     find assets/generated -name '*.yaml' -exec cp -f {} ${assets_dir}/openshift \;
@@ -73,6 +73,8 @@ function create_cluster() {
       jq -s '.[0] * .[1]' ${IGNITION_EXTRA} ${assets_dir}/worker.ign.orig | tee ${assets_dir}/worker.ign
     fi
     $OPENSHIFT_INSTALLER --dir "${assets_dir}" --log-level=debug create cluster
+
+    generate_auth_template
 }
 
 function ipversion(){
@@ -223,24 +225,45 @@ function sync_repo_and_patch {
     popd
 }
 
-function generate_templates {
-    MACHINE_OS_IMAGE_URL="http:///$(wrap_if_ipv6 $MIRROR_IP)/images/${MACHINE_OS_IMAGE_NAME}?sha256=${MACHINE_OS_BOOTSTRAP_IMAGE_SHA256}"
+function generate_auth_template {
+    # clouds.yaml
+    OCP_VERSIONS_NOAUTH="4.3 4.4 4.5"
+    if [[ "$OCP_VERSIONS_NOAUTH" == *"$OPENSHIFT_VERSION"* ]]; then
+        go run metal3-templater.go "noauth" -template-file=clouds.yaml.template -provisioning-interface="$CLUSTER_PRO_IF" -provisioning-network="$PROVISIONING_NETWORK" -image-url="$MACHINE_OS_IMAGE_URL" -bootstrap-ip="$BOOTSTRAP_PROVISIONING_IP" -cluster-ip="$CLUSTER_PROVISIONING_IP" > clouds.yaml
+    else
+        IRONIC_USER=$(oc -n openshift-machine-api  get secret/metal3-ironic-password -o template --template '{{.data.username}}' | base64 -d)
+        IRONIC_PASSWORD=$(oc -n openshift-machine-api  get secret/metal3-ironic-password -o template --template '{{.data.password}}' | base64 -d)
+	IRONIC_CREDS="$IRONIC_USER:$IRONIC_PASSWORD"
+        INSPECTOR_USER=$(oc -n openshift-machine-api  get secret/metal3-ironic-inspector-password -o template --template '{{.data.username}}' | base64 -d)
+        INSPECTOR_PASSWORD=$(oc -n openshift-machine-api  get secret/metal3-ironic-inspector-password -o template --template '{{.data.password}}' | base64 -d)
+	INSPECTOR_CREDS="$INSPECTOR_USER:$INSPECTOR_PASSWORD"
 
+        go run metal3-templater.go "http_basic" -ironic-basic-auth="$IRONIC_CREDS" -inspector-basic-auth="$INSPECTOR_CREDS" -template-file=clouds.yaml.template -provisioning-interface="$CLUSTER_PRO_IF" -provisioning-network="$PROVISIONING_NETWORK" -image-url="$MACHINE_OS_IMAGE_URL" -bootstrap-ip="$BOOTSTRAP_PROVISIONING_IP" -cluster-ip="$CLUSTER_PROVISIONING_IP" > clouds.yaml
+    fi
+
+    # For compatibility with metal3-dev-env openstackclient.sh
+    # which mounts a config dir into the ironic-client container
+    mkdir -p _clouds_yaml
+    cp clouds.yaml _clouds_yaml
+}
+
+function generate_metal3_config {
+    MACHINE_OS_IMAGE_URL="http:///$(wrap_if_ipv6 $MIRROR_IP)/images/${MACHINE_OS_IMAGE_NAME}?sha256=${MACHINE_OS_BOOTSTRAP_IMAGE_SHA256}"
     # metal3-config.yaml
     mkdir -p ${OCP_DIR}/deploy
     go get github.com/apparentlymart/go-cidr/cidr github.com/openshift/installer/pkg/ipnet
 
     if [[ "$OPENSHIFT_VERSION" == "4.3" ]]; then
-      go run metal3-templater.go metal3-config.yaml.template "$CLUSTER_PRO_IF" "$PROVISIONING_NETWORK" "$MACHINE_OS_IMAGE_URL" "$BOOTSTRAP_PROVISIONING_IP" "$CLUSTER_PROVISIONING_IP" > ${OCP_DIR}/deploy/metal3-config.yaml
+      go run metal3-templater.go noauth -template-file=metal3-config.yaml.template -provisioning-interface="$CLUSTER_PRO_IF" -provisioning-network="$PROVISIONING_NETWORK" -image-url="$MACHINE_OS_IMAGE_URL" -bootstrap-ip="$BOOTSTRAP_PROVISIONING_IP" -cluster-ip="$CLUSTER_PROVISIONING_IP" > ${OCP_DIR}/deploy/metal3-config.yaml
       cp ${OCP_DIR}/deploy/metal3-config.yaml assets/generated/98_metal3-config.yaml
     else
       echo "OpenShift Version is > 4.3; skipping config map"
     fi
 
-    # clouds.yaml
-    go run metal3-templater.go clouds.yaml.template "$CLUSTER_PRO_IF" "$PROVISIONING_NETWORK" "$MACHINE_OS_IMAGE_URL" "$BOOTSTRAP_PROVISIONING_IP" "$CLUSTER_PROVISIONING_IP" > clouds.yaml
-    # For compatibility with metal3-dev-env openstackclient.sh
-    # which mounts a config dir into the ironic-client container
+
+    # Function to generate the bootstrap cloud information
+    go run metal3-templater.go "bootstrap" -template-file=clouds.yaml.template -bootstrap-ip="$BOOTSTRAP_PROVISIONING_IP" > clouds.yaml
+
     mkdir -p _clouds_yaml
     cp clouds.yaml _clouds_yaml
 }


### PR DESCRIPTION
This PR aims to provide a generic way to generate the `clouds.yaml`, in 4.6 we enabled the `http_basic` for ironic an ironic-inspector.

- metal3-templater now can generate specific config for the bootstrap, and for ironic and ironic-inspector according to the auth_type.
- clouds.yaml.template was updated to support the structure for `http_basic`
- utils.sh was update to generate the correct `clouds.yaml` according to the OCP version.