### PR TITLE
fetch a ci token as needed for the pull secret

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,10 @@ config_*.sh
 clouds.yaml
 _clouds_yaml
 metal3-dev/deployment-*.yaml
-
 assets/generated
 
 # Conditionally created for appropriate environments
 assets/templates/99_master-chronyd-redhat.yaml
 assets/templates/99_worker-chronyd-redhat.yaml
+
+pull_secret.json

--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -6,7 +6,6 @@ source logging.sh
 source common.sh
 source sanitychecks.sh
 source utils.sh
-source ocp_install_env.sh
 
 if [ -z "${METAL3_DEV_ENV}" ]; then
   export REPO_PATH=${WORKING_DIR}
@@ -58,4 +57,3 @@ if [[ -z "$OPENSHIFT_CI" ]]; then
   oc version --client -o json
   popd
 fi
-

--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -5,7 +5,6 @@ source logging.sh
 source common.sh
 source network.sh
 source utils.sh
-source ocp_install_env.sh
 
 # Generate user ssh key
 if [ ! -f $HOME/.ssh/id_rsa.pub ]; then

--- a/03_build_installer.sh
+++ b/03_build_installer.sh
@@ -8,6 +8,8 @@ source network.sh
 source utils.sh
 source ocp_install_env.sh
 
+write_pull_secret
+
 # Extract an updated client tools from the release image
 extract_oc "${OPENSHIFT_RELEASE_IMAGE}"
 

--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -19,6 +19,7 @@ rm -f assets/templates/99_local-registry.yaml $OPENSHIFT_INSTALL_PATH/data/data/
 
 # Various commands here need the Pull Secret in a file
 export REGISTRY_AUTH_FILE=$(mktemp --tmpdir "pullsecret--XXXXXXXXXX")
+build_pull_secret
 _tmpfiles=$REGISTRY_AUTH_FILE
 { echo "${PULL_SECRET}" ; } 2> /dev/null > $REGISTRY_AUTH_FILE
 

--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -17,16 +17,7 @@ source utils.sh
 #export BAREMETAL_OPERATOR_LOCAL_IMAGE=192.168.111.1:5000/localimages/bmo:latest
 rm -f assets/templates/99_local-registry.yaml $OPENSHIFT_INSTALL_PATH/data/data/bootstrap/baremetal/files/etc/containers/registries.conf
 
-# Various commands here need the Pull Secret in a file
-export REGISTRY_AUTH_FILE=$(mktemp --tmpdir "pullsecret--XXXXXXXXXX")
-build_pull_secret
-_tmpfiles=$REGISTRY_AUTH_FILE
-{ echo "${PULL_SECRET}" ; } 2> /dev/null > $REGISTRY_AUTH_FILE
-
-# Combine pull-secret with registry's password
-COMBINED_AUTH_FILE=$(mktemp --tmpdir "combined-pullsecret--XXXXXXXXXX")
-_tmpfiles="$_tmpfiles $COMBINED_AUTH_FILE"
-jq -s '.[0] * .[1]' ${REGISTRY_AUTH_FILE} ${REGISTRY_CREDS} > ${COMBINED_AUTH_FILE}
+write_pull_secret
 
 DOCKERFILE=$(mktemp --tmpdir "release-update--XXXXXXXXXX")
 _tmpfiles="$_tmpfiles $DOCKERFILE"
@@ -48,7 +39,7 @@ fi
 for IMAGE_VAR in $(env | grep "_LOCAL_IMAGE=" | grep -o "^[^=]*") ; do
     IMAGE=${!IMAGE_VAR}
 
-    sudo -E podman pull --authfile $COMBINED_AUTH_FILE $OPENSHIFT_RELEASE_IMAGE
+    sudo -E podman pull --authfile $PULL_SECRET_FILE $OPENSHIFT_RELEASE_IMAGE
 
     # Is it a git repo?
     if [[ "$IMAGE" =~ "://" ]] ; then
@@ -67,9 +58,9 @@ for IMAGE_VAR in $(env | grep "_LOCAL_IMAGE=" | grep -o "^[^=]*") ; do
         if [[ -n ${BASE_IMAGE_DIR:-} ]]; then
             sed -i "s/^FROM [^ ]*/FROM ${BASE_IMAGE_DIR}/g" ${IMAGE_DOCKERFILE}
         fi
-        sudo podman build --authfile $COMBINED_AUTH_FILE -t ${!IMAGE_VAR} -f $IMAGE_DOCKERFILE .
+        sudo podman build --authfile $PULL_SECRET_FILE -t ${!IMAGE_VAR} -f $IMAGE_DOCKERFILE .
         cd -
-        sudo podman push --tls-verify=false --authfile $COMBINED_AUTH_FILE ${!IMAGE_VAR} ${!IMAGE_VAR}
+        sudo podman push --tls-verify=false --authfile $PULL_SECRET_FILE ${!IMAGE_VAR} ${!IMAGE_VAR}
     fi
 
     IMAGE_NAME=$(echo ${IMAGE_VAR/_LOCAL_IMAGE} | tr '[:upper:]_' '[:lower:]-')
@@ -88,7 +79,7 @@ if [ ! -z "${MIRROR_IMAGES}" ]; then
 
     oc adm release mirror \
        --insecure=true \
-        -a ${COMBINED_AUTH_FILE}  \
+        -a ${PULL_SECRET_FILE}  \
         --from ${OPENSHIFT_RELEASE_IMAGE} \
         --to-release-image ${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/local-release-image:${OPENSHIFT_RELEASE_TAG} \
         --to ${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/local-release-image 2>&1 | tee ${MIRROR_LOG_FILE}
@@ -97,7 +88,7 @@ if [ ! -z "${MIRROR_IMAGES}" ]; then
     #To ensure that you use the correct images for the version of OpenShift Container Platform that you selected,
     #you must extract the installation program from the mirrored content:
     if [ -z "$KNI_INSTALL_FROM_GIT" ]; then
-      oc adm release extract --registry-config "${COMBINED_AUTH_FILE}" \
+      oc adm release extract --registry-config "${PULL_SECRET_FILE}" \
         --command=openshift-baremetal-install --to "${EXTRACT_DIR}" \
         "${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/local-release-image:${OPENSHIFT_RELEASE_TAG}"
 
@@ -105,11 +96,11 @@ if [ ! -z "${MIRROR_IMAGES}" ]; then
     fi
 
     # Build a local release image, if no *_LOCAL_IMAGE env variables are set then this is just a copy of the release image
-    sudo podman image build --authfile $COMBINED_AUTH_FILE -t $OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE -f $DOCKERFILE
-    sudo podman push --tls-verify=false --authfile $COMBINED_AUTH_FILE $OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE $OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE
+    sudo podman image build --authfile $PULL_SECRET_FILE -t $OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE -f $DOCKERFILE
+    sudo podman push --tls-verify=false --authfile $PULL_SECRET_FILE $OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE $OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE
 
     # If we're mirroring images, let's use the local Ironic image instead
-    OPENSHIFT_RELEASE_VERSION=$(oc adm release info --registry-config="$REGISTRY_AUTH_FILE" "$OPENSHIFT_RELEASE_IMAGE" -o json | jq -r ".config.config.Labels.\"io.openshift.release\"")
+    OPENSHIFT_RELEASE_VERSION=$(oc adm release info --registry-config="$PULL_SECRET_FILE" "$OPENSHIFT_RELEASE_IMAGE" -o json | jq -r ".config.config.Labels.\"io.openshift.release\"")
     IRONIC_LOCAL_IMAGE=${IRONIC_LOCAL_IMAGE:-"${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/local-release-image:${OPENSHIFT_RELEASE_VERSION}-ironic"}
 fi
 
@@ -129,7 +120,7 @@ sudo podman pod create -n ironic-pod
 IRONIC_IMAGE=${IRONIC_LOCAL_IMAGE:-$IRONIC_IMAGE}
 
 for IMAGE in ${IRONIC_IMAGE} ${VBMC_IMAGE} ${SUSHY_TOOLS_IMAGE} ; do
-    sudo -E podman pull --authfile $COMBINED_AUTH_FILE $IMAGE || echo "WARNING: Could not pull latest $IMAGE; will try to use cached images instead"
+    sudo -E podman pull --authfile $PULL_SECRET_FILE $IMAGE || echo "WARNING: Could not pull latest $IMAGE; will try to use cached images instead"
 done
 
 CACHED_MACHINE_OS_IMAGE="${IRONIC_DATA_DIR}/html/images/${MACHINE_OS_IMAGE_NAME}"
@@ -154,7 +145,7 @@ sudo podman run -d --net host --privileged --name httpd-${PROVISIONING_NETWORK_N
 # IPA Downloader - for testing
 if [ -n "${IRONIC_IPA_DOWNLOADER_LOCAL_IMAGE:-}" ];
 then
-  sudo -E podman pull --authfile $COMBINED_AUTH_FILE $IRONIC_IPA_DOWNLOADER_LOCAL_IMAGE
+  sudo -E podman pull --authfile $PULL_SECRET_FILE $IRONIC_IPA_DOWNLOADER_LOCAL_IMAGE
 
   sudo podman run -d --net host --privileged --name ipa-downloader --pod ironic-pod \
      -v $IRONIC_DATA_DIR:/shared ${IRONIC_IPA_DOWNLOADER_LOCAL_IMAGE} /usr/local/bin/get-resource.sh

--- a/05_create_install_config.sh
+++ b/05_create_install_config.sh
@@ -9,8 +9,6 @@ source utils.sh
 source ocp_install_env.sh
 source rhcos.sh
 
-verify_pull_secret
-
 # NOTE: This is equivalent to the external API DNS record pointing the API to the API VIP
 if [ "$MANAGE_BR_BRIDGE" == "y" ] ; then
     if [[ -z "${EXTERNAL_SUBNET_V4}" ]]; then

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ other components of OpenShift via support for a baremetal platform type.
 - ideally on a bare metal host with at least 64G of RAM
 - run as a user with passwordless sudo access
 - get a valid pull secret (json string) from https://cloud.redhat.com/openshift/install/pull-secret
+- get a login token from https://api.ci.openshift.org
 - hostnames for masters and workers must be in the format XX-master-# (e.g. openshift-master-0), or XX-worker-# (e.g. openshift-worker-0)
 
 # Instructions
@@ -24,7 +25,11 @@ other components of OpenShift via support for a baremetal platform type.
 ## Configuration
 
 Make a copy of the `config_example.sh` to `config_$USER.sh`, and set the
-`PULL_SECRET` variable to the secret obtained from cloud.openshift.com.
+`PERSONAL_PULL_SECRET` variable to the secret obtained from cloud.openshift.com.
+
+Go to https://api.ci.openshift.org, click on your name in the top
+right, copy the login command, extract the token from the command and
+use it to set `CI_TOKEN` in `config_$USER.sh`.
 
 There are variable defaults set in both the `common.sh` and the `ocp_install_env.sh`
 scripts, which may be important to override for your particular environment. You can

--- a/README.md
+++ b/README.md
@@ -24,12 +24,14 @@ other components of OpenShift via support for a baremetal platform type.
 
 ## Configuration
 
-Make a copy of the `config_example.sh` to `config_$USER.sh`, and set the
-`PERSONAL_PULL_SECRET` variable to the secret obtained from cloud.openshift.com.
+Make a copy of the `config_example.sh` to `config_$USER.sh`.
 
 Go to https://api.ci.openshift.org, click on your name in the top
 right, copy the login command, extract the token from the command and
 use it to set `CI_TOKEN` in `config_$USER.sh`.
+
+Save the secret obtained from cloud.openshift.com to
+`pull_secret.json`.
 
 There are variable defaults set in both the `common.sh` and the `ocp_install_env.sh`
 scripts, which may be important to override for your particular environment. You can

--- a/common.sh
+++ b/common.sh
@@ -269,10 +269,21 @@ case ${FSTYPE} in
   ;;
 esac
 
-# avoid "-z $PULL_SECRET" to ensure the secret is not logged
-if [ ${#PULL_SECRET} = 0 ]; then
-  error "No valid PULL_SECRET set in ${CONFIG}"
+# Ensure a few variables are set, even if empty, to avoid undefined
+# variable errors in the next 2 checks.
+export PULL_SECRET=${PULL_SECRET:-}
+export PERSONAL_PULL_SECRET=${PERSONAL_PULL_SECRET:-}
+export CI_TOKEN=${CI_TOKEN:-}
+
+# avoid "-z $PERSONAL_PULL_SECRET" to ensure the secret is not logged
+if [ ${#PERSONAL_PULL_SECRET} = 0 -a ${#PULL_SECRET} = 0 ]; then
+  error "No valid PERSONAL_PULL_SECRET set in ${CONFIG}"
   error "Get a valid pull secret (json string) from https://cloud.redhat.com/openshift/install/pull-secret"
+  exit 1
+fi
+if [ ${#CI_TOKEN} = 0 -a ${#PULL_SECRET} = 0 ]; then
+  error "No valid CI_TOKEN set in ${CONFIG}"
+  error "Please login to https://api.ci.openshift.org and copy the token from the login command from the menu in the top right corner to set CI_TOKEN."
   exit 1
 fi
 

--- a/common.sh
+++ b/common.sh
@@ -269,15 +269,17 @@ case ${FSTYPE} in
   ;;
 esac
 
+export PULL_SECRET_FILE=${PULL_SECRET_FILE:-$WORKING_DIR/pull_secret.json}
+
 # Ensure a few variables are set, even if empty, to avoid undefined
 # variable errors in the next 2 checks.
 export PULL_SECRET=${PULL_SECRET:-}
-export PERSONAL_PULL_SECRET=${PERSONAL_PULL_SECRET:-}
+export PERSONAL_PULL_SECRET=${PERSONAL_PULL_SECRET:-$SCRIPTDIR/pull_secret.json}
 export CI_TOKEN=${CI_TOKEN:-}
 
-# avoid "-z $PERSONAL_PULL_SECRET" to ensure the secret is not logged
-if [ ${#PERSONAL_PULL_SECRET} = 0 -a ${#PULL_SECRET} = 0 ]; then
-  error "No valid PERSONAL_PULL_SECRET set in ${CONFIG}"
+# avoid "-z $PULL_SECRET" to ensure the secret is not logged
+if [ ! -s ${PERSONAL_PULL_SECRET} -a ${#PULL_SECRET} = 0 ]; then
+  error "${PERSONAL_PULL_SECRET} is missing or empty"
   error "Get a valid pull secret (json string) from https://cloud.redhat.com/openshift/install/pull-secret"
   exit 1
 fi

--- a/config_example.sh
+++ b/config_example.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-# You can get this secret from https://cloud.redhat.com/openshift/install/pull-secret
-set +x
-export PERSONAL_SECRET=''
-set -x
-
 # You can get this token from https://api.ci.openshift.org/ by
 # clicking on your name in the top right corner and coping the login
 # command (the token is part of the command)

--- a/config_example.sh
+++ b/config_example.sh
@@ -2,7 +2,14 @@
 
 # You can get this secret from https://cloud.redhat.com/openshift/install/pull-secret
 set +x
-export PULL_SECRET=''
+export PERSONAL_SECRET=''
+set -x
+
+# You can get this token from https://api.ci.openshift.org/ by
+# clicking on your name in the top right corner and coping the login
+# command (the token is part of the command)
+set +x
+export CI_TOKEN=''
 set -x
 
 # Select a different release stream from which to pull the latest image, if the

--- a/must_gather.sh
+++ b/must_gather.sh
@@ -14,14 +14,10 @@ fi
 # must-gather doesn't correctly work in disconnected environment, so we
 # have to calculcate the pullspec for the image and pass it to oc
 if [ -n "${MIRROR_IMAGES}" ]; then
-  build_pull_secret
-  pullsecret_file=$(mktemp --tmpdir "pullsecret--XXXXXXXXXX")
-  _tmpfiles="$_tmpfiles $pullsecret_file"
-  echo "${PULL_SECRET}" > "${pullsecret_file}"
+  write_pull_secret
 
-  OPENSHIFT_RELEASE_VERSION=$(oc adm release info --registry-config="$pullsecret_file" "$OPENSHIFT_RELEASE_IMAGE" -o json | jq -r ".config.config.Labels.\"io.openshift.release\"")
+  OPENSHIFT_RELEASE_VERSION=$(oc adm release info --registry-config="$PULL_SECRET_FILE" "$OPENSHIFT_RELEASE_IMAGE" -o json | jq -r ".config.config.Labels.\"io.openshift.release\"")
   MUST_GATHER_IMAGE="--image=${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/local-release-image:${OPENSHIFT_RELEASE_VERSION}-must-gather"
-  rm -f "$pullsecret_file"
 else
   MUST_GATHER_IMAGE=""
 fi

--- a/must_gather.sh
+++ b/must_gather.sh
@@ -4,6 +4,7 @@ set -xe
 
 source logging.sh
 source common.sh
+source utils.sh
 
 MUST_GATHER_PATH=${MUST_GATHER_PATH:-$LOGDIR/$CLUSTER_NAME/must-gather}
 if [ ! -d "$MUST_GATHER_PATH" ]; then
@@ -13,7 +14,9 @@ fi
 # must-gather doesn't correctly work in disconnected environment, so we
 # have to calculcate the pullspec for the image and pass it to oc
 if [ -n "${MIRROR_IMAGES}" ]; then
+  build_pull_secret
   pullsecret_file=$(mktemp --tmpdir "pullsecret--XXXXXXXXXX")
+  _tmpfiles="$_tmpfiles $pullsecret_file"
   echo "${PULL_SECRET}" > "${pullsecret_file}"
 
   OPENSHIFT_RELEASE_VERSION=$(oc adm release info --registry-config="$pullsecret_file" "$OPENSHIFT_RELEASE_IMAGE" -o json | jq -r ".config.config.Labels.\"io.openshift.release\"")

--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -11,12 +11,9 @@ function extract_command() {
     outdir="$3"
 
     extract_dir=$(mktemp --tmpdir -d "installer--XXXXXXXXXX")
-    pullsecret_file=$(mktemp --tmpdir "pullsecret--XXXXXXXXXX")
-    _tmpfiles="$_tmpfiles $extract_dir $pullsecret_file"
+    _tmpfiles="$_tmpfiles $extract_dir"
 
-    build_pull_secret
-    echo "${PULL_SECRET}" > "${pullsecret_file}"
-    oc adm release extract --registry-config "${pullsecret_file}" --command=$cmd --to "${extract_dir}" ${release_image}
+    oc adm release extract --registry-config "${PULL_SECRET_FILE}" --command=$cmd --to "${extract_dir}" ${release_image}
 
     mv "${extract_dir}/${cmd}" "${outdir}"
 }
@@ -48,11 +45,8 @@ function extract_rhcos_json() {
     pullsecret_file=$(mktemp --tmpdir "pullsecret--XXXXXXXXXX")
     _tmpfiles="$_tmpfiles $pullsecret_file"
 
-    build_pull_secret
-    echo "${PULL_SECRET}" > "${pullsecret_file}"
-
-    baremetal_image=$(oc adm release info --image-for=baremetal-installer --registry-config "$pullsecret_file" "$release_image")
-    baremetal_container=$(podman create --authfile "$pullsecret_file" "$baremetal_image")
+    baremetal_image=$(oc adm release info --image-for=baremetal-installer --registry-config "$PULL_SECRET_FILE" "$release_image")
+    baremetal_container=$(podman create --authfile "$PULL_SECRET_FILE" "$baremetal_image")
 
     # This is OK to fail as rhcos.json isn't available in every release,
     # we'll download it from github if it's not available
@@ -151,10 +145,12 @@ function generate_ocp_install_config() {
 
     outdir="$1"
 
-    # when using local mirror set pull secret to this mirror
-    # also this should ensure we don't accidentally pull from upstream
+    # when using local mirror set pull secret to just this mirror to
+    # ensure we don't accidentally pull from upstream
     if [ ! -z "${MIRROR_IMAGES}" ]; then
-        export PULL_SECRET=$(cat ${REGISTRY_CREDS})
+        export install_config_pull_secret="${REGISTRY_CREDS}"
+    else
+        export install_config_pull_secret="${PULL_SECRET_FILE}"
     fi
 
     mkdir -p "${outdir}"
@@ -198,7 +194,7 @@ $(node_map_to_install_config_hosts $NUM_MASTERS 0 master)
 $(node_map_to_install_config_hosts $NUM_WORKERS $NUM_MASTERS worker)
 $(image_mirror_config)
 pullSecret: |
-  $(echo $PULL_SECRET | jq -c .)
+  $(jq -c . $install_config_pull_secret)
 sshKey: |
   ${SSH_PUB_KEY}
 fips: ${FIPS_MODE:-false}

--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -42,8 +42,6 @@ function extract_rhcos_json() {
 
     release_image="$1"
     outdir="$2"
-    pullsecret_file=$(mktemp --tmpdir "pullsecret--XXXXXXXXXX")
-    _tmpfiles="$_tmpfiles $pullsecret_file"
 
     baremetal_image=$(oc adm release info --image-for=baremetal-installer --registry-config "$PULL_SECRET_FILE" "$release_image")
     baremetal_container=$(podman create --authfile "$PULL_SECRET_FILE" "$baremetal_image")

--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -14,6 +14,7 @@ function extract_command() {
     pullsecret_file=$(mktemp --tmpdir "pullsecret--XXXXXXXXXX")
     _tmpfiles="$_tmpfiles $extract_dir $pullsecret_file"
 
+    build_pull_secret
     echo "${PULL_SECRET}" > "${pullsecret_file}"
     oc adm release extract --registry-config "${pullsecret_file}" --command=$cmd --to "${extract_dir}" ${release_image}
 
@@ -47,6 +48,7 @@ function extract_rhcos_json() {
     pullsecret_file=$(mktemp --tmpdir "pullsecret--XXXXXXXXXX")
     _tmpfiles="$_tmpfiles $pullsecret_file"
 
+    build_pull_secret
     echo "${PULL_SECRET}" > "${pullsecret_file}"
 
     baremetal_image=$(oc adm release info --image-for=baremetal-installer --registry-config "$pullsecret_file" "$release_image")

--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -148,9 +148,9 @@ function generate_ocp_install_config() {
     # when using local mirror set pull secret to just this mirror to
     # ensure we don't accidentally pull from upstream
     if [ ! -z "${MIRROR_IMAGES}" ]; then
-        export install_config_pull_secret="${REGISTRY_CREDS}"
+        install_config_pull_secret="${REGISTRY_CREDS}"
     else
-        export install_config_pull_secret="${PULL_SECRET_FILE}"
+        install_config_pull_secret="${PULL_SECRET_FILE}"
     fi
 
     mkdir -p "${outdir}"

--- a/utils.sh
+++ b/utils.sh
@@ -396,9 +396,18 @@ function verify_pull_secret() {
 function write_pull_secret() {
     if [ ${#PULL_SECRET} != 0 ]; then
         echo "Using PULL_SECRET variable. Consider switching to PERSONAL_PULL_SECRET and CI_TOKEN."
+
+        # Write PULL_SECRET to a file so it can be merged with the
+        # local registry credentials
         set +x
-        echo "${PULL_SECRET}" > ${PULL_SECRET_FILE}
+        tmppullsecret=$(mktemp --tmpdir "pullsecret--XXXXXXXXXX")
+        _tmpfiles="$_tmpfiles $tmppullsecret"
+        echo "${PULL_SECRET}" > ${tmppullsecret}
         set -x
+
+        # Combine the personal pull secret with the ones for the CI
+        # registry and the local registry credentials.
+        jq -s '.[0] * .[1]' ${REGISTRY_CREDS} ${tmppullsecret} > ${PULL_SECRET_FILE}
         return
     fi
 


### PR DESCRIPTION
The user-specific pull secret granted by logging in to
api.ci.openshift.org expires. Rather than forcing users to manually
get a new one, use the login command to get it ourselves and combine
it with the more static parts of the pull secret.

This change deprecates the PULL_SECRET variable in favor of
PERSONAL_PULL_SECRET and CI_TOKEN variables.