### PR TITLE
Remove wait for ironic service

### DIFF
--- a/metal3-dev/local-bmo.sh
+++ b/metal3-dev/local-bmo.sh
@@ -93,10 +93,6 @@ get_creds() {
 get_creds ironic
 get_creds ironic-inspector
 
-# Wait for the ironic service to be available
-wait_for_json ironic "$IRONIC_ENDPOINT" 300 \
-              -H "Accept: application/json" -H "Content-Type: application/json"
-
 # Run the operator
 cd $bmo_path
 


### PR DESCRIPTION
BMO now checks explicitly for the availability of Ironic services within the reconcile loop before applying any logic, so the `local-bmo.sh` script can be slightly simplified