### PR TITLE
Local cbo script

### DIFF
--- a/metal3-dev/local-cbo.sh
+++ b/metal3-dev/local-cbo.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -xe
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+
+LOGDIR=${SCRIPTDIR}/logs
+source $SCRIPTDIR/logging.sh
+
+source $SCRIPTDIR/common.sh
+source $SCRIPTDIR/utils.sh
+
+cbo_path=$GOPATH/src/github.com/openshift/cluster-baremetal-operator
+if [ ! -d $cbo_path ]; then
+    echo "Did not find $cbo_path" 1>&2
+    exit 1
+fi
+
+# Run the operator
+cd $cbo_path
+
+export RUN_NAMESPACE=openshift-machine-api
+make run
+


### PR DESCRIPTION
This PR adds a new script to test a local Cluster Baremetal Operator checkout. The script copies an existing metal3 deployment into a new one and adds the required annotation to grant the ownership to cbo.