### PR TITLE
Remove download of headers file when using local ipa-downloader image

### DIFF
--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -199,6 +199,5 @@ while ! curl --fail -g http://$(wrap_if_ipv6 ${PROVISIONING_HOST_IP})/images/${M
 if [ -n "${IRONIC_IPA_DOWNLOADER_LOCAL_IMAGE:-}" ];
 then
   while ! curl --fail --head -g http://$(wrap_if_ipv6 ${PROVISIONING_HOST_IP})/images/ironic-python-agent.initramfs ; do sleep 1; done
-  while ! curl --fail --head -g http://$(wrap_if_ipv6 ${PROVISIONING_HOST_IP})/images/ironic-python-agent.tar.headers ; do sleep 1; done
   while ! curl --fail --head -g http://$(wrap_if_ipv6 ${PROVISIONING_HOST_IP})/images/ironic-python-agent.kernel ; do sleep 1; done
 fi


### PR DESCRIPTION
This is no longer needed.