### PR TITLE
assume if we are running in ci we do not need a token

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -283,7 +283,7 @@ if [ ! -s ${PERSONAL_PULL_SECRET} -a ${#PULL_SECRET} = 0 ]; then
   error "Get a valid pull secret (json string) from https://cloud.redhat.com/openshift/install/pull-secret"
   exit 1
 fi
-if [ ${#CI_TOKEN} = 0 -a ${#PULL_SECRET} = 0 ]; then
+if [ "${OPENSHIFT_CI}" != "true" -a ${#CI_TOKEN} = 0 -a ${#PULL_SECRET} = 0 ]; then
   error "No valid CI_TOKEN set in ${CONFIG}"
   error "Please login to https://api.ci.openshift.org and copy the token from the login command from the menu in the top right corner to set CI_TOKEN."
   exit 1

--- a/utils.sh
+++ b/utils.sh
@@ -411,6 +411,13 @@ function write_pull_secret() {
         return
     fi
 
+    if [ "${OPENSHIFT_CI}" == true ]; then
+        # Assume that the personal pull secret file we were given
+        # contains everything we need in CI.
+        cp "${PERSONAL_PULL_SECRET}" "${PULL_SECRET_FILE}"
+        return
+    fi
+
     verify_pull_secret
 
     # Get a current pull secret for registry.svc.ci.openshift.org using the token


### PR DESCRIPTION
the pull secret configured in the ci job has everything it needs to
access the registry so we don't have to do anything extra