### PR TITLE
Empty metal3 deployment for CBO testing

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -48,7 +48,7 @@ fi
 export ANSIBLE_FORCE_COLOR=true
 
 # Setup the registry for mirroring images
-if [[ ! -z "${MIRROR_IMAGES}" || $(env | grep "_LOCAL_IMAGE=") ]]; then
+if [[ ! -z "${MIRROR_IMAGES}" || $(env | grep "_LOCAL_IMAGE=")  || ! -z "${ENABLE_CBO_TEST}" ]]; then
     setup_local_registry
 fi
 
@@ -206,7 +206,7 @@ echo "${PROVISIONING_HOST_EXTERNAL_IP} ${LOCAL_REGISTRY_DNS_NAME}" | sudo tee -a
 # Remove any previous file, or podman login panics when reading the
 # blank authfile with a "assignment to entry in nil map" error
 rm -f ${REGISTRY_CREDS}
-if [[ ! -z "${MIRROR_IMAGES}" || $(env | grep "_LOCAL_IMAGE=") ]]; then
+if [[ ! -z "${MIRROR_IMAGES}" || $(env | grep "_LOCAL_IMAGE=")  || ! -z "${ENABLE_CBO_TEST}" ]]; then
     # create authfile for local registry
     sudo podman login --authfile ${REGISTRY_CREDS} \
         -u ${REGISTRY_USER} -p ${REGISTRY_PASS} \

--- a/assets/metal3-cbo-deployment.yaml
+++ b/assets/metal3-cbo-deployment.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    deployment.kubernetes.io/revision: "1"
+    baremetal.openshift.io/owned: ""
+  generation: 1
+  labels:
+    api: clusterapi
+    k8s-app: controller
+  name: metal3
+  namespace: openshift-machine-api
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      api: clusterapi
+      k8s-app: controller
+  template:
+    metadata:
+      labels:
+        api: clusterapi
+        k8s-app: controller
+    spec:
+      containers:
+      - name: metal3-empty
+        image: virthost.ostest.test.metalkube.org:5000/localimages/empty:latest        
+      hostNetwork: true
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext:
+        runAsNonRoot: false
+      serviceAccount: machine-api-controllers
+      serviceAccountName: machine-api-controllers
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 120
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 120

--- a/utils.sh
+++ b/utils.sh
@@ -61,6 +61,15 @@ function create_cluster() {
         cp assets/ipv6-dual-stack-no-upgrade.yaml ${assets_dir}/openshift/.
     fi
 
+    if [[  ! -z "${ENABLE_CBO_TEST}" ]]; then
+      # Create an empty image to be used by the CBO test deployment
+      EMPTY_IMAGE=${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/empty:latest
+      echo -e "FROM quay.io/quay/busybox\nCMD [\"sleep\", \"infinity\"]" | sudo podman build -t ${EMPTY_IMAGE} -f - .
+      sudo podman push --tls-verify=false --authfile ${REGISTRY_CREDS} ${EMPTY_IMAGE} ${EMPTY_IMAGE}
+
+      cp assets/metal3-cbo-deployment.yaml ${assets_dir}/openshift/.
+    fi
+
     if [ ! -z "${IGNITION_EXTRA:-}" ]; then
       $OPENSHIFT_INSTALLER --dir "${assets_dir}" --log-level=debug create ignition-configs
       if ! jq . ${IGNITION_EXTRA}; then


### PR DESCRIPTION
This PR adds an empty metal3 deployment used to test CBO ownership