### PR TITLE
Increase the default for MASTER_DISK too 30G

### DIFF
--- a/vm_setup_vars.yml
+++ b/vm_setup_vars.yml
@@ -12,7 +12,7 @@ num_workers: 1
 flavors:
   master:
     memory: "{{ lookup('env', 'MASTER_MEMORY') | default('16384', true) }}"
-    disk: "{{ lookup('env', 'MASTER_DISK') | default('20', true) }}"
+    disk: "{{ lookup('env', 'MASTER_DISK') | default('30', true) }}"
     vcpu: "{{ lookup('env', 'MASTER_VCPU') | default('8', true) }}"
     extradisks: false
 


### PR DESCRIPTION
On a default virtual env the master node running metal3
can only have 3G free, give us some extra head room so
that we can play with ironic if we need to.

The underlying qcow files are thinly provisioned so shouldn't
use up much extra space unless its needed.