### PR TITLE
Switch to the Standalone ironic client

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -216,13 +216,11 @@ else
     echo '{}' | sudo dd of=${REGISTRY_CREDS}
 fi
 
-# metal3-dev-env contains a script to run the openstack client in a
-# container, place a link to it in $PATH if we don't already have the
-# openstack command installed
-OPENSTACKCLIENT_PATH="${OPENSTACKCLIENT_PATH:-/usr/local/bin/openstack}"
-if ! command -v openstack | grep -v "${OPENSTACKCLIENT_PATH}"; then
-    sudo ln -sf "${METAL3_DEV_ENV_PATH}/openstackclient.sh" "${OPENSTACKCLIENT_PATH}"
-    sudo ln -sf "${METAL3_DEV_ENV_PATH}/openstackclient.sh" "$(dirname "$OPENSTACKCLIENT_PATH")/baremetal"
+# metal3-dev-env contains a script to run the baremetal ironic client in a
+# container, place a link to it if its not installed
+IRONICCLIENT_PATH="${IRONICCLIENT_PATH:-/usr/local/bin/baremetal}"
+if ! command -v baremetal | grep -v "${IRONICCLIENT_PATH}"; then
+    sudo ln -sf "${METAL3_DEV_ENV_PATH}/openstackclient.sh" "${IRONICCLIENT_PATH}"
 fi
 
 # Block Multicast with ebtables

--- a/README.md
+++ b/README.md
@@ -236,24 +236,17 @@ using the cloud name `metal3-bootstrap` and the copy running inside
 the cluster once deployment is finished can be accessed by using the
 cloud name `metal3`.
 
-The dev-scripts will install the `openstack` command line tool on the
-provisioning host as part of setting up the cluster.  The `openstack`
-tool will look for `clouds.yaml` in the current directory or you can
-copy it to `~/.config/openstack/clouds.yaml`.  Version 3.19.0 or
-higher is needed to interact with ironic using `clouds.yaml`.
+The dev-scripts will install the `baremetal` command line tool on the
+provisioning host as part of setting up the cluster.  The `baremetal`
+tool will look for `clouds.yaml` in the `_clouds_yaml` directory.
 
-```
-$ openstack --version
-openstack 3.19.0
-```
-
-For manual debugging via the openstack client connecting to the bootstrap
+For manual debugging via the baremetal client connecting to the bootstrap
 VM, which is ephemeral and won't be available once the masters have
 been deployed:
 
 ```
 export OS_CLOUD=metal3-bootstrap
-openstack baremetal node list
+baremetal node list
 ...
 ```
 
@@ -261,7 +254,16 @@ To access the Ironic instance running in the baremetal-operator pod:
 
 ```
 export OS_CLOUD=metal3
-openstack baremetal node list
+baremetal node list
+...
+```
+
+And to access the Ironic inspector instance running in the baremetal-operator pod:
+
+```
+export OS_CLOUD=metal3-inspector
+baremetal introspection list
+...
 ```
 
 NOTE: If you use a provisioning network other than the default, you

--- a/utils.sh
+++ b/utils.sh
@@ -260,7 +260,7 @@ function generate_auth_template {
     # For compatibility with metal3-dev-env openstackclient.sh
     # which mounts a config dir into the ironic-client container
     mkdir -p _clouds_yaml
-    cp clouds.yaml _clouds_yaml
+    ln -f clouds.yaml _clouds_yaml
 }
 
 function generate_metal3_config {
@@ -281,7 +281,7 @@ function generate_metal3_config {
     go run metal3-templater.go "bootstrap" -template-file=clouds.yaml.template -bootstrap-ip="$BOOTSTRAP_PROVISIONING_IP" > clouds.yaml
 
     mkdir -p _clouds_yaml
-    cp clouds.yaml _clouds_yaml
+    ln -f clouds.yaml _clouds_yaml/clouds.yaml
 }
 
 function image_mirror_config {


### PR DESCRIPTION
The openstack client isn't currently working with auth turned on
and the standalone baremetal command is now the prefered client.

Also link clouds.yaml and _clouds_yaml/clouds.yaml together so
changes in one are reflected in both(users mightn't realise the
file _clouds_yaml/clouds.yaml exists).