### PR TITLE
Fix known_hosts cleanup

### DIFF
--- a/ocp_cleanup.sh
+++ b/ocp_cleanup.sh
@@ -3,6 +3,7 @@ set -x
 
 source logging.sh
 source common.sh
+source network.sh
 source ocp_install_env.sh
 
 sudo systemctl stop fix_certs.timer


### PR DESCRIPTION
The cleanup of known_hosts file in ocp_cleanup.sh requires
EXTERNAL_SUBNET_V{4,6} to be set. If one does not have that set in
config.sh, then the known_hosts cleanup does not happen, since
network.sh isn't included in the cleanup. This adds network.sh to
be sourced in the cleanup script.