### PR TITLE
Switch default NETWORK_TYPE to OVNKubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ BASE_DOMAIN=your.valid.domain.com
 CLUSTER_NAME=clustername
 # Set your valid DNS VIP, such as 1.1.1.1 for 'ns1.example.com'
 DNS_VIP="1.1.1.1"
-# Set your default network type, `OpenShiftSDN` or `OVNKubernetes`, defaults to `OpenShiftSDN`
+# Set your default network type, `OpenShiftSDN` or `OVNKubernetes`, defaults to `OVNKubernetes`
 NETWORK_TYPE="OpenShiftSDN"
 # Set to the subnet in use on the external (baremetal) network
 EXTERNAL_SUBNET_V4="192.168.111.0/24"

--- a/config_example.sh
+++ b/config_example.sh
@@ -90,7 +90,7 @@ set -x
 #export DNS_VIP="11.0.0.2"
 
 # Network type
-#export NETWORK_TYPE="OpenShiftSDN"
+#export NETWORK_TYPE="OVNKubernetes"
 
 # Provisioning network
 #export PROVISIONING_NETWORK="172.23.0.0/16"

--- a/network.sh
+++ b/network.sh
@@ -78,7 +78,7 @@ then
   export CLUSTER_HOST_PREFIX_V6=""
   export SERVICE_SUBNET_V4=${SERVICE_SUBNET_V4:-"172.30.0.0/16"}
   export SERVICE_SUBNET_V6=""
-  export NETWORK_TYPE=${NETWORK_TYPE:-"OpenShiftSDN"}
+  export NETWORK_TYPE=${NETWORK_TYPE:-"OVNKubernetes"}
 elif [[ "$IP_STACK" = "v6" ]]; then
   export PROVISIONING_NETWORK=${PROVISIONING_NETWORK:-"fd00:1101::0/64"}
   export EXTERNAL_SUBNET_V4=""
@@ -89,7 +89,6 @@ elif [[ "$IP_STACK" = "v6" ]]; then
   export CLUSTER_HOST_PREFIX_V6=${CLUSTER_HOST_PREFIX_V6:-"64"}
   export SERVICE_SUBNET_V4=""
   export SERVICE_SUBNET_V6=${SERVICE_SUBNET_V6:-"fd02::/112"}
-  export NETWORK_TYPE=${NETWORK_TYPE:-"OVNKubernetes"}
   export MIRROR_IMAGES=true
   export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/local-release-image:latest"
 elif [[ "$IP_STACK" = "v4v6" ]]; then


### PR DESCRIPTION
Currently if we switch between ipv4 and ipv6 testing we get two
different SDN implementations, it may be better to make this
consistent, or e.g we lose all OVN coverage while CI is temporarily
switched to ipv4.