### PR TITLE
remove support for PULL_SECRET variable

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -274,18 +274,16 @@ export PULL_SECRET_FILE=${PULL_SECRET_FILE:-$WORKING_DIR/pull_secret.json}
 # Ensure a few variables are set, even if empty, to avoid undefined
 # variable errors in the next 2 checks.
 set +x
-export PULL_SECRET=${PULL_SECRET:-}
 export CI_TOKEN=${CI_TOKEN:-}
 set -x
 export PERSONAL_PULL_SECRET=${PERSONAL_PULL_SECRET:-$SCRIPTDIR/pull_secret.json}
 
-# avoid "-z $PULL_SECRET" to ensure the secret is not logged
-if [ ! -s ${PERSONAL_PULL_SECRET} -a ${#PULL_SECRET} = 0 ]; then
+if [ ! -s ${PERSONAL_PULL_SECRET} ]; then
   error "${PERSONAL_PULL_SECRET} is missing or empty"
   error "Get a valid pull secret (json string) from https://cloud.redhat.com/openshift/install/pull-secret"
   exit 1
 fi
-if [ "${OPENSHIFT_CI}" != "true" -a ${#CI_TOKEN} = 0 -a ${#PULL_SECRET} = 0 ]; then
+if [ "${OPENSHIFT_CI}" != "true" -a ${#CI_TOKEN} = 0 ]; then
   error "No valid CI_TOKEN set in ${CONFIG}"
   error "Please login to https://api.ci.openshift.org and copy the token from the login command from the menu in the top right corner to set CI_TOKEN."
   exit 1

--- a/common.sh
+++ b/common.sh
@@ -280,12 +280,22 @@ export PERSONAL_PULL_SECRET=${PERSONAL_PULL_SECRET:-$SCRIPTDIR/pull_secret.json}
 
 if [ ! -s ${PERSONAL_PULL_SECRET} ]; then
   error "${PERSONAL_PULL_SECRET} is missing or empty"
-  error "Get a valid pull secret (json string) from https://cloud.redhat.com/openshift/install/pull-secret"
+  if [ -n "${PULL_SECRET:-}" ]; then
+      error "It looks like you are using the old PULL_SECRET variable."
+      error "Please write the contents of that variable to ${PERSONAL_PULL_SECRET} and try again."
+      error "Refer to https://github.com/openshift-metal3/dev-scripts#configuration for details."
+  else
+      error "Get a valid pull secret (json string) from https://cloud.redhat.com/openshift/install/pull-secret"
+  fi
   exit 1
 fi
 if [ "${OPENSHIFT_CI}" != "true" -a ${#CI_TOKEN} = 0 ]; then
   error "No valid CI_TOKEN set in ${CONFIG}"
+  if [ -n "${PULL_SECRET:-}" ]; then
+      error "It looks like you are using the old PULL_SECRET variable."
+  fi
   error "Please login to https://api.ci.openshift.org and copy the token from the login command from the menu in the top right corner to set CI_TOKEN."
+  error "Refer to https://github.com/openshift-metal3/dev-scripts#configuration for details."
   exit 1
 fi
 

--- a/run_ci.sh
+++ b/run_ci.sh
@@ -62,7 +62,7 @@ sudo mount -o bind /opt/data/occache /home/dev-scripts/oc
 
 sudo chown -R notstack /home/dev-scripts
 
-# Point at our CI custom config file (contains the PULL_SECRET)
+# Point at our CI custom config file
 export CONFIG=/opt/data/config_notstack.sh
 
 sudo yum install -y jq golang make unzip
@@ -166,4 +166,3 @@ wait_for_worker() {
     oc wait node/$worker --for=condition=Ready --timeout=$[${TIMEOUT_MINUTES} * 60]s
 }
 wait_for_worker worker-0
-

--- a/utils.sh
+++ b/utils.sh
@@ -432,23 +432,6 @@ function verify_pull_secret() {
 }
 
 function write_pull_secret() {
-    if [ ${#PULL_SECRET} != 0 ]; then
-        echo "Using PULL_SECRET variable. Consider switching to PERSONAL_PULL_SECRET and CI_TOKEN."
-
-        # Write PULL_SECRET to a file so it can be merged with the
-        # local registry credentials
-        set +x
-        tmppullsecret=$(mktemp --tmpdir "pullsecret--XXXXXXXXXX")
-        _tmpfiles="$_tmpfiles $tmppullsecret"
-        echo "${PULL_SECRET}" > ${tmppullsecret}
-        set -x
-
-        # Combine the personal pull secret with the ones for the CI
-        # registry and the local registry credentials.
-        jq -s '.[0] * .[1]' ${REGISTRY_CREDS} ${tmppullsecret} > ${PULL_SECRET_FILE}
-        return
-    fi
-
     if [ "${OPENSHIFT_CI}" == true ]; then
         # We don't need to fetch a personal pull secret with the
         # token, but we still need to merge what we're given with the


### PR DESCRIPTION
Previous changes moved to using a CI_TOKEN for access to the openshift
CI image registry and a file for the other parts of the pull
secret. The PULL_SECRET variable was retained to allow the CI job to
be updated. That has been done, so now we can remove support for
PULL_SECRET.