### PR TITLE
Always include metal3-inspector 'cloud' in clouds.yaml

### DIFF
--- a/clouds.yaml.template
+++ b/clouds.yaml.template
@@ -8,6 +8,9 @@ clouds:
     auth_type: {{.AuthType}}
     baremetal_endpoint_override: {{.ClusterIronicURL}}
     baremetal_introspection_endpoint_override: {{.ClusterInspectorURL}}
+  metal3-inspector:
+    auth_type: {{.AuthType}}
+    baremetal_introspection_endpoint_override: {{.ClusterInspectorURL}}
 {{- else if eq .AuthType "http_basic"}}
   metal3:
     auth_type: {{.AuthType}}


### PR DESCRIPTION
When the auth method is basic-auth, you have to use
`--os-cloud=metal3-inspector` instead of `--os-cloud=metal3` when talking to
ironic-inspector rather than ironic-api. For consistency, ensure this
also works when the auth method is noauth.