### PR TITLE
metal3-dev: Fix scripts returning to MAO control

### DIFF
--- a/metal3-dev/mao-bmo.sh
+++ b/metal3-dev/mao-bmo.sh
@@ -5,6 +5,8 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 LOGDIR=${SCRIPTDIR}/logs
 source $SCRIPTDIR/logging.sh
 
+source $SCRIPTDIR/common.sh
+
 # Scale down dev deployment
 oc scale deployment -n openshift-machine-api --replicas=0 metal3-development
 if oc get pod -o name -n openshift-machine-api | grep -q metal3-development; then

--- a/metal3-dev/mao-capbm.sh
+++ b/metal3-dev/mao-capbm.sh
@@ -5,6 +5,8 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 LOGDIR=${SCRIPTDIR}/logs
 source $SCRIPTDIR/logging.sh
 
+source $SCRIPTDIR/common.sh
+
 # Scale down dev deployment
 oc scale deployment -n openshift-machine-api --replicas=0 capbm-development
 if oc get pod -o name -n openshift-machine-api | grep -q capbm-development; then


### PR DESCRIPTION
We need to source common.sh in order to have the kubeconfig path set in
the environment before running oc commands.