### PR TITLE
Add support for GA release types

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -44,9 +44,14 @@ fi
 
 # Install oc client - unless we're in openshift CI
 if [[ -z "$OPENSHIFT_CI" ]]; then
+  oc_version=${OPENSHIFT_VERSION}
+  if [[ "$OPENSHIFT_RELEASE_TYPE" == "ga" ]]; then
+    oc_version=${OPENSHIFT_RELEASE_STREAM}
+  fi
+
   oc_tools_dir="${WORKING_DIR}/oc/${OPENSHIFT_VERSION}"
-  oc_tools_local_file=openshift-client-${OPENSHIFT_VERSION}.tar.gz
-  oc_download_url="https://mirror.openshift.com/pub/openshift-v4/clients/oc/${OPENSHIFT_VERSION}/linux/oc.tar.gz"
+  oc_tools_local_file=openshift-client-${oc_version}.tar.gz
+  oc_download_url="https://mirror.openshift.com/pub/openshift-v4/clients/oc/${oc_version}/linux/oc.tar.gz"
   mkdir -p ${oc_tools_dir}
   pushd ${oc_tools_dir}
   if [ ! -f "${oc_tools_local_file}" ]; then

--- a/config_example.sh
+++ b/config_example.sh
@@ -12,7 +12,8 @@ set -x
 #export OPENSHIFT_RELEASE_STREAM=4.6
 
 # Select a different release type from which to pull the latest image,
-# e.g ci or nightly
+# e.g ci, nightly or ga
+# if using ga then set OPENSHIFT_VERSION to the required version.
 #export OPENSHIFT_RELEASE_TYPE=ci
 
 # Use <NAME>_LOCAL_IMAGE to build or use copy of container images locally e.g.


### PR DESCRIPTION
This enables you to add the following config

```bash
export OPENSHIFT_RELEASE_TYPE=ga
export OPENSHIFT_VERSION=4.5.8
```
and this will create a cluster based off of: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.5.8/release.txt

fixes #1038