### PR TITLE
Use appropriate ignition version for chronyd config

### DIFF
--- a/assets/templates/98_master-chronyd-custom.yaml.optional
+++ b/assets/templates/98_master-chronyd-custom.yaml.optional
@@ -8,7 +8,7 @@ metadata:
 spec:
   config:
     ignition:
-      version: 2.2.0
+      version: IGNITION_VERSION
     storage:
       files:
       - contents:
@@ -17,3 +17,4 @@ spec:
         filesystem: root
         mode: 0644
         path: /etc/chrony.conf
+        overwrite: true

--- a/assets/templates/98_worker-chronyd-custom.yaml.optional
+++ b/assets/templates/98_worker-chronyd-custom.yaml.optional
@@ -8,7 +8,7 @@ metadata:
 spec:
   config:
     ignition:
-      version: 2.2.0
+      version: IGNITION_VERSION
     storage:
       files:
       - contents:
@@ -17,3 +17,4 @@ spec:
         filesystem: root
         mode: 0644
         path: /etc/chrony.conf
+        overwrite: true

--- a/common.sh
+++ b/common.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export PATH="/usr/local/go/bin:$PATH"
+export PATH="/usr/local/go/bin:$HOME/.local/bin:$PATH"
 
 # Set a PS4 value which logs the script name and line #.
 export PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'

--- a/ignition/file_example.ign
+++ b/ignition/file_example.ign
@@ -1,1 +1,1 @@
-{"ignition": {"version": "2.3.0"}, "storage": {"files": [{"path": "/etc/test", "filesystem": "root", "mode": 436, "contents": {"source": "data:,test-foo%0A"}}]}}
+{"ignition": {"version": "3.1.0"}, "storage": {"files": [{"path": "/etc/test", "mode": 436, "contents": {"source": "data:,test-foo%0A"}}]}}


### PR DESCRIPTION
The version from 4.6 onwards switched to ignition 3.1.0 so
we should update the version, the schema for the files
changed slightly so we have to remove the filesystem for
3.x but otherwise the existing config should work.