### PR TITLE
add gather_audit_logs target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ ocp_run:
 gather:
 	./must_gather.sh
 
+gather_audit_logs:
+	./must_gather.sh -- /usr/bin/gather_audit_logs
+
 clean: ocp_cleanup ironic_cleanup host_cleanup assisted_deployment_cleanup
 
 assisted_deployment_cleanup:

--- a/must_gather.sh
+++ b/must_gather.sh
@@ -22,4 +22,4 @@ else
   MUST_GATHER_IMAGE=""
 fi
 
-oc --insecure-skip-tls-verify adm must-gather $MUST_GATHER_IMAGE --dest-dir "$MUST_GATHER_PATH" > "$MUST_GATHER_PATH/must-gather.log"
+oc --insecure-skip-tls-verify adm must-gather $MUST_GATHER_IMAGE --dest-dir "$MUST_GATHER_PATH" "$@" > "$MUST_GATHER_PATH/must-gather.log"


### PR DESCRIPTION
gather target no longer collects audit logs. Lack of audit logs in CI for metal-upi is blocking progress on debugging an important problems on that platform