### PR TITLE
Line-buffer log output

### DIFF
--- a/logging.sh
+++ b/logging.sh
@@ -11,4 +11,4 @@ if [ ! -d "$(dirname $LOGFILE)" ]; then
 fi
 echo "Logging to $LOGFILE"
 # Set fd 1 and 2 to write to the log file
-exec 1> >( awk '{ print strftime("%Y-%m-%d %H:%M:%S"), $0; fflush() }' | tee "${LOGFILE}" ) 2>&1
+exec &> >(tee >(awk '{ print strftime("%Y-%m-%d %H:%M:%S"), $0; fflush() }' >"${LOGFILE}"))

--- a/logging.sh
+++ b/logging.sh
@@ -11,4 +11,4 @@ if [ ! -d "$(dirname $LOGFILE)" ]; then
 fi
 echo "Logging to $LOGFILE"
 # Set fd 1 and 2 to write to the log file
-exec 1> >( awk '{ print strftime("%Y-%m-%d %H:%M:%S"), $0 }' | tee "${LOGFILE}" ) 2>&1
+exec 1> >( awk '{ print strftime("%Y-%m-%d %H:%M:%S"), $0; fflush() }' | tee "${LOGFILE}" ) 2>&1


### PR DESCRIPTION
Because there is a pipe (from awk to tee) in our log output pipeline,
output is now buffered, which is bad for watching in real time. awk
doesn't provide an option to line-buffer the output even though it is
not going to a terminal, so explicitly call fflush() after each line.

Fixes #1121