### PR TITLE
Add network.sh to must_gather.sh

### DIFF
--- a/must_gather.sh
+++ b/must_gather.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 
-set -xe
+set -xeu
 
 source logging.sh
 source common.sh
 source utils.sh
+source network.sh
 
 MUST_GATHER_PATH=${MUST_GATHER_PATH:-$LOGDIR/$CLUSTER_NAME/must-gather}
 if [ ! -d "$MUST_GATHER_PATH" ]; then


### PR DESCRIPTION
Otherwise MIRROR_IMAGES isn't defined when testing, and we see
a failure to pull the image in the CI logs when test ipv6