### PR TITLE
Remove deploy validation in requirements step

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -8,7 +8,7 @@ source sanitychecks.sh
 source utils.sh
 source validation.sh
 
-early_deploy_validation
+early_deploy_validation true
 
 if [ -z "${METAL3_DEV_ENV}" ]; then
   export REPO_PATH=${WORKING_DIR}

--- a/validation.sh
+++ b/validation.sh
@@ -51,6 +51,8 @@ function early_either_validation() {
 # build a cluster.
 function early_deploy_validation() {
 
+    CHECK_OC_TOOL_PRESENCE=${1:-"false"}
+
     early_either_validation
 
     if [ ! -s ${PERSONAL_PULL_SECRET} ]; then
@@ -75,8 +77,12 @@ function early_deploy_validation() {
         exit 1
     fi
 
+    LOGIN_CHECK="true"
+    if [ "${CHECK_OC_TOOL_PRESENCE}" == "true" -a ! -x "$(command -v oc)" ]; then
+        LOGIN_CHECK="false"
+    fi
     # Verify that the token we have is valid
-    if [ ${#CI_TOKEN} != 0 ]; then
+    if [ ${#CI_TOKEN} != 0 -a ${LOGIN_CHECK} == "true" ]; then
         _test_token=$(mktemp --tmpdir "test-token--XXXXXXXXXX")
         _tmpfiles="$_tmpfiles $_test_token"
         if ! oc login https://api.ci.openshift.org --kubeconfig=$_test_token --token=${CI_TOKEN}; then


### PR DESCRIPTION
oc command will be installed on the requirements step.
But deploy validation tries to login with the provided
ci token to validate the token. Allow the requirements to
install oc cli, then proceed with the validation in next step.