### PR TITLE
Remove warning that dual-stack is not expected to work

### DIFF
--- a/config_example.sh
+++ b/config_example.sh
@@ -33,7 +33,6 @@ set -x
 
 # IP stack version.  The default is "v6".  You may also set "v4".
 # For dual stack (IPv4 + IPv6), use "v4v6".
-# NOTE: dual stack is not expected to fully work yet.
 #export IP_STACK=v4
 
 # BMC type. Valid values are redfish, redfish-virtualmedia, or ipmi.


### PR DESCRIPTION
Dual-stack installs work now, and I assume the comment here was only talking about dev-scripts support for dual-stack, not about whether OCP fully supports the feature.

/cc @stbenjam 