### PR TITLE
Auth template generate fails for 4.5.0 version

### DIFF
--- a/utils.sh
+++ b/utils.sh
@@ -269,7 +269,11 @@ function sync_repo_and_patch {
 function generate_auth_template {
     # clouds.yaml
     OCP_VERSIONS_NOAUTH="4.3 4.4 4.5"
-    if [[ "$OCP_VERSIONS_NOAUTH" == *"$OPENSHIFT_VERSION"* ]]; then
+
+    # Fix the version if OPENSHIFT_VERSION follows x.y.z format to change it to x.y
+    OPENSHIFT_VERSION_TRIM=$(echo "$OPENSHIFT_VERSION" | grep -oE '^[[:digit:]]+\.[[:digit:]]+' || echo "$OPENSHIFT_VERSION")
+
+    if [[ "$OCP_VERSIONS_NOAUTH" == *"$OPENSHIFT_VERSION_TRIM"* ]]; then
         go run metal3-templater.go "noauth" -template-file=clouds.yaml.template -provisioning-interface="$CLUSTER_PRO_IF" -provisioning-network="$PROVISIONING_NETWORK" -image-url="$MACHINE_OS_IMAGE_URL" -bootstrap-ip="$BOOTSTRAP_PROVISIONING_IP" -cluster-ip="$CLUSTER_PROVISIONING_IP" > clouds.yaml
     else
         IRONIC_USER=$(oc -n openshift-machine-api  get secret/metal3-ironic-password -o template --template '{{.data.username}}' | base64 -d)


### PR DESCRIPTION
Using OPENSHIFT_VERSION=4.5.0 results in failure of
the auth template generation because it take wrong path
as the condition only checks for 4.5 only. Trim the version
if it is of format x.y.z before checking.

Fixes: #1131 