### PR TITLE
Make dev-scripts default 'nightly' instead of 'ci'

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -87,7 +87,7 @@ export REGISTRY_CRT=registry.2.crt
 # Set this variable to build the installer from source
 export KNI_INSTALL_FROM_GIT=${KNI_INSTALL_FROM_GIT:-}
 
-export OPENSHIFT_RELEASE_TYPE=${OPENSHIFT_RELEASE_TYPE:-ci}
+export OPENSHIFT_RELEASE_TYPE=${OPENSHIFT_RELEASE_TYPE:-nightly}
 export OPENSHIFT_RELEASE_STREAM=${OPENSHIFT_RELEASE_STREAM:-4.7}
 if [[ "$OPENSHIFT_RELEASE_TYPE" == "ga" ]]; then
     if [[ -z "$OPENSHIFT_VERSION" ]]; then

--- a/config_example.sh
+++ b/config_example.sh
@@ -14,7 +14,7 @@ set -x
 # Select a different release type from which to pull the latest image,
 # e.g ci, nightly or ga
 # if using ga then set OPENSHIFT_VERSION to the required version.
-#export OPENSHIFT_RELEASE_TYPE=ci
+#export OPENSHIFT_RELEASE_TYPE=nightly
 
 # Use <NAME>_LOCAL_IMAGE to build or use copy of container images locally e.g.
 #export IRONIC_INSPECTOR_LOCAL_IMAGE=https://github.com/metal3-io/ironic-inspector


### PR DESCRIPTION
Nightlies for 4.7 now block on e2e-metal-ipi, which means these builds
*should* always install successfully (except for
flakes/misconfiguration) as any accepted nightly will be guaranteed to
have a successful install on baremetal.

One can continue using CI builds by setting `OPENSHIFT_RELEASE_TYPE=ci`.