### PR TITLE
Add workaround for OKD ironic images

### DIFF
--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -64,6 +64,9 @@ if [[ -n ${CUSTOM_REPO_FILE:-} ]]; then
         echo "${CUSTOM_REPO_FILE} does not exist!"
         exit 1
     fi
+    # Also update the Dockerfile used for the custom-release CVO image
+    echo "RUN rm -f /etc/yum.repos.d/*" >> $DOCKERFILE
+    echo "COPY ${CUSTOM_REPO_FILE} /etc/yum.repos.d/" >> $DOCKERFILE
 fi
 
 for IMAGE_VAR in $(env | grep "_LOCAL_IMAGE=" | grep -o "^[^=]*") ; do


### PR DESCRIPTION
Currently OKD has a dummy/stub image in place for all the ironic*
images, so the current approach with *LOCAL_IMAGE doesn't work,
we end up sedding the stub image everywhere with the first image.

Instead, until the OKD ironic images are ready, we can work around
the problem by explicitly replacing each image, then a config like
this should work I think:

```
export UPSTREAM_IRONIC=true
export OPENSHIFT_RELEASE_IMAGE=registry.svc.ci.openshift.org/origin/release:4.6.0-0.okd-2020-10-28-192548
export IRONIC_MACHINE_OS_DOWNLOADER_LOCAL_IMAGE=quay.io/hroyrh/test:latest
export IRONIC_STATIC_IP_MANAGER_LOCAL_IMAGE=quay.io/hroyrh/test-static-ip-manager:latest
```

I also added `RELEASE_IMAGE_DEBUG` so you can add an export to get
a dump of the relevant files during the release image build.