### PR TITLE
Extract code to build base-image for custom images

### DIFF
--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -33,23 +33,7 @@ echo "FROM $OPENSHIFT_RELEASE_IMAGE" > $DOCKERFILE
 # Build a base image if we set a custom repo file in the config file and
 # the file exists
 if [[ -n ${CUSTOM_REPO_FILE:-} ]]; then
-    BASE_IMAGE_DIR=${BASE_IMAGE_DIR:-base-image}
-    if [[ ! -f "${BASE_IMAGE_DIR}/${CUSTOM_REPO_FILE}" ]]; then
-        echo "${CUSTOM_REPO_FILE} does not exist!"
-        exit 1
-    fi
-
-    BUILD_COMMAND_ARGS="--build-arg TEST_REPO=${CUSTOM_REPO_FILE}"
-
-    # we can change the image used to build the base-image setting the BASE_IMAGE_FROM variable
-    # in the config file, for example export BASE_IMAGE_FROM=centos:8
-    if [[ -n ${BASE_IMAGE_FROM:-} ]]; then
-        BUILD_COMMAND_ARGS+=" --build-arg BASE_IMAGE_FROM=${BASE_IMAGE_FROM}"
-        BUILD_COMMAND_ARGS+=" --build-arg REMOVE_OLD_REPOS=no"
-    fi
-
-    sudo podman build --tag ${BASE_IMAGE_DIR} ${BUILD_COMMAND_ARGS} -f "${BASE_IMAGE_DIR}/Dockerfile"
-
+    ./build-base-image.sh ${BASE_IMAGE_DIR:-base-image} $CUSTOM_REPO_FILE
 fi
 
 for IMAGE_VAR in $(env | grep "_LOCAL_IMAGE=" | grep -o "^[^=]*") ; do

--- a/build-base-image.sh
+++ b/build-base-image.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+BASE_IMAGE_DIR=${1:-base-image}
+CUSTOM_REPO_FILE=${2:-custom.repo}
+
+REPO_FILE_PATH="${BASE_IMAGE_DIR}/${CUSTOM_REPO_FILE}"
+
+[ ! -f "${REPO_FILE_PATH}" ] && { echo "${REPO_FILE_PATH} does not exist!"; exit 1; }
+[ ! -s "${REPO_FILE_PATH}" ] && { echo "WARNING! ${REPO_FILE_PATH} is empty!"; }
+
+BUILD_COMMAND_ARGS="--build-arg TEST_REPO=${CUSTOM_REPO_FILE}"
+
+# we can change the image used to build the base-image setting the BASE_IMAGE_FROM variable
+# in the config file, for example export BASE_IMAGE_FROM=centos:8
+if [[ -n ${BASE_IMAGE_FROM:-} ]]; then
+    BUILD_COMMAND_ARGS+=" --build-arg BASE_IMAGE_FROM=${BASE_IMAGE_FROM}"
+    BUILD_COMMAND_ARGS+=" --build-arg REMOVE_OLD_REPOS=no"
+fi
+
+sudo podman build --tag ${BASE_IMAGE_DIR} ${BUILD_COMMAND_ARGS} -f "${BASE_IMAGE_DIR}/Dockerfile"


### PR DESCRIPTION
Let's start simplifying a little the 04_setup_ironic.sh moving build
base-image code to its own independent script.