### PR TITLE
Add a way to install extra packages in the images

### DIFF
--- a/config_example.sh
+++ b/config_example.sh
@@ -23,6 +23,12 @@ set -x
 # NOTE: If a checkout already exists in $HOME, it won't be re-created.
 # NOTE: You must set CUSTOM_REPO_FILE to build some OpenShift images, e.g. ironic ones.
 
+# Use <IMAGE_NAME>_EXTRA_PACKAGES to set the path (relative to dev-scripts or
+# absolute) to a file with extra packages to install in the image, one per line.
+# At the moment, this option is supported with ironic-image and ironic-inspector-image
+# For example:
+# export IRONIC_EXTRA_PACKAGES=ironic-extra-pkgs.txt
+
 # Set this variable to point the custom base image to a different location
 # It can be an absolute path or a local path under the dev-scripts dir
 # export BASE_IMAGE_DIR=base-image


### PR DESCRIPTION
Long due change to provide a way to automatically install extra
packages in the local custom built images.
This can be useful to test different versions of packages or just
test new dependencies or tools.

This depends on https://github.com/metal3-io/ironic-inspector-image/pull/72 and https://github.com/metal3-io/ironic-image/pull/227