### PR TITLE
update local-bmo.sh with new CRD location

### DIFF
--- a/metal3-dev/local-bmo.sh
+++ b/metal3-dev/local-bmo.sh
@@ -98,7 +98,7 @@ cd $bmo_path
 
 # Use our local verison of the CRD, in case it is newer than the one
 # in the cluster now.
-oc apply -f deploy/crds/metal3.io_baremetalhosts_crd.yaml
+oc apply -f config/crd/bases/metal3.io_baremetalhosts.yaml
 
 export RUN_NAMESPACE=openshift-machine-api
 make -e run


### PR DESCRIPTION
As part of the kubebuilder migration, the location of the CRD in the
baremetal-operator repository moved. Update the script for running the
operator locally to look at the new location.

/cc @zaneb