### PR TITLE
Remove ARG default for custom repo file in base-image

### DIFF
--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -32,7 +32,7 @@ echo "FROM $OPENSHIFT_RELEASE_IMAGE" > $DOCKERFILE
 if [[ -n ${CUSTOM_REPO_FILE:-} ]]; then
     BASE_IMAGE_DIR=${BASE_IMAGE_DIR:-base-image}
     if [[ -f "${BASE_IMAGE_DIR}/${CUSTOM_REPO_FILE}" ]]; then
-        sudo podman build --tag ${BASE_IMAGE_DIR} --build-arg TestRepo="${CUSTOM_REPO_FILE}" -f "${BASE_IMAGE_DIR}/Dockerfile"
+        sudo podman build --tag ${BASE_IMAGE_DIR} --build-arg TEST_REPO="${CUSTOM_REPO_FILE}" -f "${BASE_IMAGE_DIR}/Dockerfile"
     else
         echo "${CUSTOM_REPO_FILE} does not exist!"
         exit 1

--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -1,8 +1,8 @@
-ARG TestRepo
+ARG TEST_REPO
 
 FROM ubi8
 
 RUN rm -f /etc/yum.repos.d/*
-COPY ${TestRepo:-"custom.repo"} /etc/yum.repos.d/
+COPY $TEST_REPO /etc/yum.repos.d/
 
 RUN dnf upgrade -y


### PR DESCRIPTION
The bash way doesn't always work and could cause issues during build time.
Make TEST_REPO ARG mandatory for base-image.