### PR TITLE
Update version detection and make dnsVIP conditional

### DIFF
--- a/03_build_installer.sh
+++ b/03_build_installer.sh
@@ -18,6 +18,8 @@ extract_oc "${OPENSHIFT_RELEASE_IMAGE}"
 
 mkdir -p $OCP_DIR
 
+save_release_info ${OPENSHIFT_RELEASE_IMAGE} ${OCP_DIR}
+
 if [ -z "$KNI_INSTALL_FROM_GIT" ]; then
   # Extract openshift-install from the release image
   extract_installer "${OPENSHIFT_RELEASE_IMAGE}" $OCP_DIR

--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -122,7 +122,7 @@ if [ ! -z "${MIRROR_IMAGES}" ]; then
     sudo podman push --tls-verify=false --authfile $PULL_SECRET_FILE $OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE $OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE
 
     # If we're mirroring images, let's use the local Ironic image instead
-    OPENSHIFT_RELEASE_VERSION=$(oc adm release info --registry-config="$PULL_SECRET_FILE" "$OPENSHIFT_RELEASE_IMAGE" -o json | jq -r ".config.config.Labels.\"io.openshift.release\"")
+    OPENSHIFT_RELEASE_VERSION=$(openshift_release_version)
     IRONIC_LOCAL_IMAGE=${IRONIC_LOCAL_IMAGE:-"${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/local-release-image:${OPENSHIFT_RELEASE_VERSION}-ironic"}
 fi
 

--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -114,6 +114,15 @@ EOF
   fi
 }
 
+function dnsvip() {
+  # dnsVIP was removed from 4.5
+  if printf '%s\n4.4\n' "$(openshift_version)" | sort -V -C; then
+cat <<EOF
+    dnsVIP: ${DNS_VIP}
+EOF
+  fi
+}
+
 function libvirturi() {
     if [[ "$REMOTE_LIBVIRT" -ne 0 ]]; then
 cat <<EOF
@@ -224,7 +233,7 @@ $(baremetal_network_configuration)
     clusterOSImage: http://$(wrap_if_ipv6 $MIRROR_IP)/images/${MACHINE_OS_IMAGE_NAME}?sha256=${MACHINE_OS_IMAGE_SHA256}
     apiVIP: ${API_VIP}
     ingressVIP: ${INGRESS_VIP}
-    dnsVIP: ${DNS_VIP}
+$(dnsvip)
     hosts:
 $(node_map_to_install_config_hosts $NUM_MASTERS 0 master)
 $(node_map_to_install_config_hosts $NUM_WORKERS $NUM_MASTERS worker)

--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -46,8 +46,15 @@ function save_release_info() {
     oc adm release info --registry-config "$PULL_SECRET_FILE" "$release_image" -o json > ${outdir}/release_info.json
 }
 
+# Gives e.g 4.7.0-0.nightly-2020-10-27-051128
 function openshift_release_version() {
-    jq -r ".config.config.Labels.\"io.openshift.release\"" ${OCP_DIR}/release_info.json
+    jq -r ".metadata.version" ${OCP_DIR}/release_info.json
+}
+
+# Gives us e.g 4.7 because although OPENSHIFT_VERSION is set by users,
+# but is not set in CI
+function openshift_version() {
+    jq -r ".metadata.version" ${OCP_DIR}/release_info.json | grep -oP "\d\.\d+"
 }
 
 function image_for() {
@@ -88,7 +95,7 @@ function build_installer() {
 }
 
 function baremetal_network_configuration() {
-  if [[ "$OPENSHIFT_VERSION" == "4.3" ]]; then
+  if [[ "$(openshift_version $OCP_DIR)" == "4.3" ]]; then
     return
   fi
 

--- a/utils.sh
+++ b/utils.sh
@@ -270,18 +270,17 @@ function generate_auth_template {
     # clouds.yaml
     OCP_VERSIONS_NOAUTH="4.3 4.4 4.5"
 
-    # Fix the version if OPENSHIFT_VERSION follows x.y.z format to change it to x.y
-    OPENSHIFT_VERSION_TRIM=$(echo "$OPENSHIFT_VERSION" | grep -oE '^[[:digit:]]+\.[[:digit:]]+' || echo "$OPENSHIFT_VERSION")
+    VERSION=$(openshift_version $OCP_DIR)
 
-    if [[ "$OCP_VERSIONS_NOAUTH" == *"$OPENSHIFT_VERSION_TRIM"* ]]; then
+    if [[ "$OCP_VERSIONS_NOAUTH" == *"$VERSION"* ]]; then
         go run metal3-templater.go "noauth" -template-file=clouds.yaml.template -provisioning-interface="$CLUSTER_PRO_IF" -provisioning-network="$PROVISIONING_NETWORK" -image-url="$MACHINE_OS_IMAGE_URL" -bootstrap-ip="$BOOTSTRAP_PROVISIONING_IP" -cluster-ip="$CLUSTER_PROVISIONING_IP" > clouds.yaml
     else
         IRONIC_USER=$(oc -n openshift-machine-api  get secret/metal3-ironic-password -o template --template '{{.data.username}}' | base64 -d)
         IRONIC_PASSWORD=$(oc -n openshift-machine-api  get secret/metal3-ironic-password -o template --template '{{.data.password}}' | base64 -d)
-	IRONIC_CREDS="$IRONIC_USER:$IRONIC_PASSWORD"
+        IRONIC_CREDS="$IRONIC_USER:$IRONIC_PASSWORD"
         INSPECTOR_USER=$(oc -n openshift-machine-api  get secret/metal3-ironic-inspector-password -o template --template '{{.data.username}}' | base64 -d)
         INSPECTOR_PASSWORD=$(oc -n openshift-machine-api  get secret/metal3-ironic-inspector-password -o template --template '{{.data.password}}' | base64 -d)
-	INSPECTOR_CREDS="$INSPECTOR_USER:$INSPECTOR_PASSWORD"
+        INSPECTOR_CREDS="$INSPECTOR_USER:$INSPECTOR_PASSWORD"
 
         go run metal3-templater.go "http_basic" -ironic-basic-auth="$IRONIC_CREDS" -inspector-basic-auth="$INSPECTOR_CREDS" -template-file=clouds.yaml.template -provisioning-interface="$CLUSTER_PRO_IF" -provisioning-network="$PROVISIONING_NETWORK" -image-url="$MACHINE_OS_IMAGE_URL" -bootstrap-ip="$BOOTSTRAP_PROVISIONING_IP" -cluster-ip="$CLUSTER_PROVISIONING_IP" > clouds.yaml
     fi


### PR DESCRIPTION
Updates detection of the openshift version because although users can set OPENSHIFT_VERSION, and we can derive it from most user specified release versions, the release images generated in CI don't work because they look like `registry.build02.ci.openshift.org/ci-op-xyz`

Instead we can save the release info locally, and look at the release version directly, which should result in version logic that works both for local testing and in CI.