### PR TITLE
Add unit to time in "podman wait" command.

### DIFF
--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -160,7 +160,7 @@ then
   sudo podman run -d --net host --privileged --name ipa-downloader --pod ironic-pod \
      -v $IRONIC_DATA_DIR:/shared ${IRONIC_IPA_DOWNLOADER_LOCAL_IMAGE} /usr/local/bin/get-resource.sh
 
-  sudo podman wait -i 1000 ipa-downloader
+  sudo podman wait -i 1000s ipa-downloader
 fi
 
 function is_running() {

--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -160,7 +160,7 @@ then
   sudo podman run -d --net host --privileged --name ipa-downloader --pod ironic-pod \
      -v $IRONIC_DATA_DIR:/shared ${IRONIC_IPA_DOWNLOADER_LOCAL_IMAGE} /usr/local/bin/get-resource.sh
 
-  sudo podman wait -i 1000s ipa-downloader
+  sudo podman wait -i 1000ms ipa-downloader
 fi
 
 function is_running() {


### PR DESCRIPTION
Changes made in 04_setup_ironic.sh file to fix error raised when `podman wait` executes with no unit for time.