### PR TITLE
Revert "Add unit to time in "podman wait" command."

### DIFF
--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -160,7 +160,7 @@ then
   sudo podman run -d --net host --privileged --name ipa-downloader --pod ironic-pod \
      -v $IRONIC_DATA_DIR:/shared ${IRONIC_IPA_DOWNLOADER_LOCAL_IMAGE} /usr/local/bin/get-resource.sh
 
-  sudo podman wait -i 1000ms ipa-downloader
+  sudo podman wait -i 1000 ipa-downloader
 fi
 
 function is_running() {


### PR DESCRIPTION
`1000ms` is not a valid syntax, an integer is expected there.
```
$ sudo podman wait -i 1000ms ipa-downloader
Error: invalid argument "1000ms" for "-i, --interval" flag: strconv.ParseUint: parsing "1000ms": invalid syntax
```

Reverts openshift-metal3/dev-scripts#1148