### PR TITLE
Cleanup /var/lib/libvirt/openshift-images

### DIFF
--- a/ocp_cleanup.sh
+++ b/ocp_cleanup.sh
@@ -49,6 +49,12 @@ for vm in $(sudo virsh list --all --name | grep "^${CLUSTER_NAME}.*bootstrap"); 
   sudo virsh destroy $vm
   sudo virsh undefine $vm --remove-all-storage
 done
+
+# For some reason --remove-all-storage doesn't actually remove the storage...
+if [ -d /var/lib/libvirt/openshift-images ]; then
+  sudo rm -fr /var/lib/libvirt/openshift-images/${CLUSTER_NAME}-*
+fi
+
 # The .ign volume isn't deleted via --remove-all-storage
 VOLS="$(sudo virsh vol-list --pool default | awk '{print $1}' | grep "^${CLUSTER_NAME}.*bootstrap")"
 for v in $VOLS; do


### PR DESCRIPTION
For some reason the virsh --remove-all-storage isn't actually removing
the storage, this may be because we moved to a non-default pool?

This can quickly use up space as each leaked directory is about 2.2G
so lets clean it up until we can find a more robust way to handle
this in the installer.