### PR TITLE
Add GROUP variable for chown where different from USER

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -80,7 +80,7 @@ ansible-playbook \
 if [ ${NUM_EXTRA_WORKERS} -ne 0 ]; then
   ORIG_NODES_FILE="${NODES_FILE}.orig"
   cp -f ${NODES_FILE} ${ORIG_NODES_FILE}
-  sudo chown -R $USER:$USER ${NODES_FILE}
+  sudo chown -R $USER:$GROUP ${NODES_FILE}
   jq "{nodes: .nodes[:$((NUM_MASTERS + NUM_WORKERS))]}" ${ORIG_NODES_FILE} | tee ${NODES_FILE}
   jq "{nodes: .nodes[-${NUM_EXTRA_WORKERS}:]}" ${ORIG_NODES_FILE} | tee ${EXTRA_NODES_FILE}
 fi

--- a/common.sh
+++ b/common.sh
@@ -27,6 +27,7 @@ export MOBY_DISABLE_PIGZ=true
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 USER=`whoami`
+GROUP=`id -gn`
 
 function error () {
     echo $@ 1>&2
@@ -260,7 +261,7 @@ export PERSONAL_PULL_SECRET=${PERSONAL_PULL_SECRET:-$SCRIPTDIR/pull_secret.json}
 if [ ! -d "$WORKING_DIR" ]; then
   error "Creating Working Dir"
   sudo mkdir -p "$WORKING_DIR"
-  sudo chown "${USER}:${USER}" "$WORKING_DIR"
+  sudo chown "${USER}:${GROUP}" "$WORKING_DIR"
   chmod 755 "$WORKING_DIR"
 fi
 
@@ -275,7 +276,7 @@ fi
 # permissions to be owned by the user running dev-scripts.
 if [ ! -f "$IRONIC_IMAGES_DIR/.permissions" ]; then
   error "Resetting permissions on Ironic Images Dir..."
-  sudo chown -R "${USER}:${USER}" "$IRONIC_DATA_DIR"
+  sudo chown -R "${USER}:${GROUP}" "$IRONIC_DATA_DIR"
   sudo find "$IRONIC_DATA_DIR" -type d -print0 | xargs -0 chmod 755
   sudo chmod -R +r "$IRONIC_DATA_DIR"
   touch "$IRONIC_IMAGES_DIR/.permissions"

--- a/metal3-dev/local-bmo.sh
+++ b/metal3-dev/local-bmo.sh
@@ -74,7 +74,7 @@ get_creds() {
     if oc get -n openshift-machine-api secret ${secret} -o name >/dev/null; then
         if [ ! -d ${auth_dir} ]; then
             sudo mkdir -p "${auth_dir}"
-            sudo chown -R $USER:$USER "${auth_dir}/.."
+            sudo chown -R $USER:$GROUP "${auth_dir}/.."
         fi
         if [ ! -d ${cred_dir} ]; then
             mkdir "${cred_dir}"

--- a/utils.sh
+++ b/utils.sh
@@ -348,7 +348,7 @@ function setup_local_registry() {
     sudo yum install -y httpd-tools
 
     sudo mkdir -pv ${REGISTRY_DIR}/{auth,certs,data}
-    sudo chown -R $USER:$USER ${REGISTRY_DIR}
+    sudo chown -R $USER:$GROUP ${REGISTRY_DIR}
 
     pushd $REGISTRY_DIR/certs
 


### PR DESCRIPTION
`whoami` does not always match the group name for
the user. Use `id -gn` to set the group name properly.
Also create GROUP environment variable and replace
USER where appropriate for chown commands.

Fix openshift-metal3/dev-scripts#1154

Signed-off-by: Melvin Hillsman <mrhillsman@redhat.com>