### PR TITLE
Set bootstrap provisioning ip only when the openshift version is < 4.7

### DIFF
--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -103,8 +103,12 @@ function baremetal_network_configuration() {
 cat <<EOF
     provisioningNetwork: "${PROVISIONING_NETWORK_PROFILE}"
     provisioningHostIP: "${CLUSTER_PROVISIONING_IP}"
+EOF
+  if printf '%s\n4.6\n' "$(openshift_version)" | sort -V -C; then
+cat <<EOF
     bootstrapProvisioningIP: "${BOOTSTRAP_PROVISIONING_IP}"
 EOF
+    fi
   else
 cat <<EOF
     provisioningBridge: ${PROVISIONING_NETWORK_NAME}


### PR DESCRIPTION
This builds on top of @hardys https://github.com/openshift-metal3/dev-scripts/pull/1146 
and depends on https://github.com/openshift/installer/pull/4390 