### PR TITLE
Improve clouds.yaml generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,12 +292,17 @@ should not clean or deploy one environment while another is deploying
 
 ## Interacting with Ironic directly
 
-The dev-scripts repository contains a `clouds.yaml` file with
+The `./06_create_cluster.sh` script generates a `clouds.yaml` file with
 connection settings for both instances of Ironic. The copy of Ironic
 that runs on the bootstrap node during installation can be accessed by
 using the cloud name `metal3-bootstrap` and the copy running inside
 the cluster once deployment is finished can be accessed by using the
 cloud name `metal3`.
+
+Note that the `clouds.yaml` is generated on exit from `./06_create_cluster.sh`
+(on success, and also on failure if possible), however it can be useful
+to generate the file during deployment, in which case `generate_clouds_yaml.sh`
+may be run manually.
 
 The dev-scripts will install the `baremetal` command line tool on the
 provisioning host as part of setting up the cluster.  The `baremetal`

--- a/generate_clouds_yaml.sh
+++ b/generate_clouds_yaml.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -xe
+
+source common.sh
+source utils.sh
+source network.sh
+source ocp_install_env.sh
+
+generate_auth_template

--- a/show_bootstrap_log.sh
+++ b/show_bootstrap_log.sh
@@ -1,19 +1,9 @@
 #!/bin/bash
 
 source common.sh
+source network.sh
+source utils.sh
 
-if [[ "${IP_STACK}" == "v6" ]]; then
-    pref_ip=ipv6
-else
-    pref_ip=ipv4
-fi
-
-BOOTSTRAP_VM_IP=$(sudo virsh net-dhcp-leases ${BAREMETAL_NETWORK_NAME} \
-                      | grep -v master \
-                      | grep "${pref_ip}" \
-                      | tail -n1 \
-                      | awk '{print $5}' \
-                      | sed -e 's/\(.*\)\/.*/\1/')
-
+BOOTSTRAP_VM_IP=$(bootstrap_ip)
 echo "Attempting to follow $1 on ${BOOTSTRAP_VM_IP} ..."
 ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no core@${BOOTSTRAP_VM_IP} journalctl -b -f -u $1

--- a/utils.sh
+++ b/utils.sh
@@ -481,6 +481,21 @@ function swtich_to_internal_dns() {
   fi
 }
 
+function bootstrap_ip {
+  if [[ "${IP_STACK}" == "v6" ]]; then
+    pref_ip=ipv6
+  else
+    pref_ip=ipv4
+  fi
+
+  sudo virsh net-dhcp-leases ${BAREMETAL_NETWORK_NAME} \
+                      | grep -v master \
+                      | grep "${pref_ip}" \
+                      | tail -n1 \
+                      | awk '{print $5}' \
+                      | sed -e 's/\(.*\)\/.*/\1/'
+}
+
 _tmpfiles=
 function removetmp(){
     [ -n "$_tmpfiles" ] && rm -rf $_tmpfiles || true

--- a/utils.sh
+++ b/utils.sh
@@ -97,9 +97,8 @@ function create_cluster() {
       jq -s '.[0] * .[1]' ${IGNITION_EXTRA} ${assets_dir}/worker.ign.orig | tee ${assets_dir}/worker.ign
     fi
 
+    trap auth_template_and_removetmp EXIT
     $OPENSHIFT_INSTALLER --dir "${assets_dir}" --log-level=debug create cluster
-
-    generate_auth_template
 }
 
 function ipversion(){
@@ -275,14 +274,23 @@ function generate_auth_template {
     if [[ "$OCP_VERSIONS_NOAUTH" == *"$VERSION"* ]]; then
         go run metal3-templater.go "noauth" -template-file=clouds.yaml.template -provisioning-interface="$CLUSTER_PRO_IF" -provisioning-network="$PROVISIONING_NETWORK" -image-url="$MACHINE_OS_IMAGE_URL" -bootstrap-ip="$BOOTSTRAP_PROVISIONING_IP" -cluster-ip="$CLUSTER_PROVISIONING_IP" > clouds.yaml
     else
-        IRONIC_USER=$(oc -n openshift-machine-api  get secret/metal3-ironic-password -o template --template '{{.data.username}}' | base64 -d)
-        IRONIC_PASSWORD=$(oc -n openshift-machine-api  get secret/metal3-ironic-password -o template --template '{{.data.password}}' | base64 -d)
+        IRONIC_USER=$((oc -n openshift-machine-api  get secret/metal3-ironic-password -o template --template '{{.data.username}}' || echo "") | base64 -d)
+        IRONIC_PASSWORD=$((oc -n openshift-machine-api  get secret/metal3-ironic-password -o template --template '{{.data.password}}' || echo "") | base64 -d)
         IRONIC_CREDS="$IRONIC_USER:$IRONIC_PASSWORD"
-        INSPECTOR_USER=$(oc -n openshift-machine-api  get secret/metal3-ironic-inspector-password -o template --template '{{.data.username}}' | base64 -d)
-        INSPECTOR_PASSWORD=$(oc -n openshift-machine-api  get secret/metal3-ironic-inspector-password -o template --template '{{.data.password}}' | base64 -d)
+        INSPECTOR_USER=$((oc -n openshift-machine-api  get secret/metal3-ironic-inspector-password -o template --template '{{.data.username}}' || echo "") | base64 -d)
+        INSPECTOR_PASSWORD=$((oc -n openshift-machine-api  get secret/metal3-ironic-inspector-password -o template --template '{{.data.password}}' || echo "") | base64 -d)
         INSPECTOR_CREDS="$INSPECTOR_USER:$INSPECTOR_PASSWORD"
 
         go run metal3-templater.go "http_basic" -ironic-basic-auth="$IRONIC_CREDS" -inspector-basic-auth="$INSPECTOR_CREDS" -template-file=clouds.yaml.template -provisioning-interface="$CLUSTER_PRO_IF" -provisioning-network="$PROVISIONING_NETWORK" -image-url="$MACHINE_OS_IMAGE_URL" -bootstrap-ip="$BOOTSTRAP_PROVISIONING_IP" -cluster-ip="$CLUSTER_PROVISIONING_IP" > clouds.yaml
+
+        BOOTSTRAP_VM_IP=$(bootstrap_ip)
+        if [ ! -z "${BOOTSTRAP_VM_IP}" ]; then
+            if ping -c 1 ${BOOTSTRAP_VM_IP}; then
+                # From 4.7 basic_auth is also enabled on the bootstrap VM
+                # There's a clouds.yaml we can copy in that case
+                ($SSH core@${BOOTSTRAP_VM_IP} sudo cat /opt/metal3/auth/clouds.yaml || echo "") | sed "s/^clouds://" >> clouds.yaml
+            fi
+        fi
     fi
 
     # For compatibility with metal3-dev-env openstackclient.sh
@@ -500,4 +508,10 @@ _tmpfiles=
 function removetmp(){
     [ -n "$_tmpfiles" ] && rm -rf $_tmpfiles || true
 }
+
+function auth_template_and_removetmp(){
+    generate_auth_template
+    removetmp
+}
+
 trap removetmp EXIT


### PR DESCRIPTION
Currently this is only generated on a successful deployment, but the time you need it most is during/after a failed deploy for debugging.

So try to generate a clouds.yaml (including for the bootstrap VM) even on a failed deploy, and add a script that allows us to generate the file during a deployment if needed.