### PR TITLE
Fetch oc tools from different URL

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -45,26 +45,6 @@ if sudo systemctl is-active docker-distribution.service; then
   sudo systemctl disable --now docker-distribution.service
 fi
 
-# Install oc client - unless we're in openshift CI
-if [[ -z "$OPENSHIFT_CI" ]]; then
-  if [[ "$OPENSHIFT_RELEASE_TYPE" == "ga" ]]; then
-    oc_version=${OPENSHIFT_RELEASE_STREAM}
-  elif [[ "$OPENSHIFT_VERSION" == "4.7" ]]; then
-    oc_version="latest"
-  else
-    oc_version=${OPENSHIFT_VERSION}
-  fi
-
-  oc_tools_dir="${WORKING_DIR}/oc/${OPENSHIFT_VERSION}"
-  oc_tools_local_file=openshift-client-${oc_version}.tar.gz
-  oc_download_url="https://mirror.openshift.com/pub/openshift-v4/clients/oc/${oc_version}/linux/oc.tar.gz"
-  mkdir -p ${oc_tools_dir}
-  pushd ${oc_tools_dir}
-  if [ ! -f "${oc_tools_local_file}" ]; then
-    curl -L -o ${oc_tools_local_file} ${oc_download_url}
-    tar xvzf ${oc_tools_local_file}
-  fi
-  sudo cp oc /usr/local/bin/
-  oc version --client -o json
-  popd
-fi
+curl --retry 5 "$OPENSHIFT_CLIENT_TOOLS_URL" | sudo tar -U -C /usr/local/bin -xzf -
+sudo chmod +x /usr/local/bin/oc
+oc version --client -o json

--- a/common.sh
+++ b/common.sh
@@ -88,6 +88,8 @@ export REGISTRY_CRT=registry.2.crt
 # Set this variable to build the installer from source
 export KNI_INSTALL_FROM_GIT=${KNI_INSTALL_FROM_GIT:-}
 
+export OPENSHIFT_CLIENT_TOOLS_URL=https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz
+
 export OPENSHIFT_RELEASE_TYPE=${OPENSHIFT_RELEASE_TYPE:-nightly}
 export OPENSHIFT_RELEASE_STREAM=${OPENSHIFT_RELEASE_STREAM:-4.7}
 if [[ "$OPENSHIFT_RELEASE_TYPE" == "ga" ]]; then


### PR DESCRIPTION
The current URL we are using for `oc` was removed, so we need to get the
tools from another location. This also removes the dependency on
calculating the version based on the pullspec, meaning this code works
for CI builds too.

We only use these tools to bootstrap getting the ones from the release
payload, so the actual version isn't super important as we just
overwrite it anyway a little bit later on.