### PR TITLE
Fix CUSTOM_REPO_FILE arg

### DIFF
--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -35,7 +35,7 @@ echo "FROM $OPENSHIFT_RELEASE_IMAGE" > $DOCKERFILE
 if [[ -n ${CUSTOM_REPO_FILE:-} ]]; then
     BASE_IMAGE_DIR=${BASE_IMAGE_DIR:-base-image}
     if [[ -f "${BASE_IMAGE_DIR}/${CUSTOM_REPO_FILE}" ]]; then
-        sudo podman build --tag ${BASE_IMAGE_DIR} --build-arg TEST_REPO="${CUSTOM_REPO_FILE}" -f "${BASE_IMAGE_DIR}/Dockerfile"
+        sudo podman build --tag ${BASE_IMAGE_DIR} --build-arg TEST_REPO=${CUSTOM_REPO_FILE} -f "${BASE_IMAGE_DIR}/Dockerfile"
     else
         echo "${CUSTOM_REPO_FILE} does not exist!"
         exit 1


### PR DESCRIPTION
When passed to the build command, the CUSTOM_REPO_FILE arg should
not be enclosed in quotes, otherwise the parser in base-image will
give an error.