### PR TITLE
add host cleanup commands to revert NetworkManager dnsmasq config

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -199,7 +199,7 @@ fi
 
 # Switch NetworkManager to internal DNS
 if [ "$MANAGE_BR_BRIDGE" == "y" ]; then
-  swtich_to_internal_dns
+  switch_to_internal_dns
 fi
 
 # Add a /etc/hosts entry for $LOCAL_REGISTRY_DNS_NAME

--- a/assisted_deployment.sh
+++ b/assisted_deployment.sh
@@ -21,7 +21,7 @@ function install_assisted_env() {
   popd
 
   if ! [ "$MANAGE_BR_BRIDGE" == "y" ];then
-    swtich_to_internal_dns
+    switch_to_internal_dns
   fi
 
 }

--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -32,6 +32,14 @@ ansible-playbook \
     -b -vvv ${VM_SETUP_PATH}/teardown-playbook.yml
 
 sudo rm -rf /etc/NetworkManager/dnsmasq.d/openshift-${CLUSTER_NAME}.conf /etc/yum.repos.d/delorean*
+sudo rm -rf /etc/NetworkManager/conf.d/dnsmasq.conf
+sudo rm -rf /etc/NetworkManager/dnsmasq.d/upstream.conf
+if systemctl is-active --quiet NetworkManager; then
+  sudo systemctl reload NetworkManager
+else
+  sudo systemctl restart NetworkManager
+fi
+
 # There was a bug in this file, it may need to be recreated.
 # delete the interface as it can cause issues when not rebooting
 if [ "$MANAGE_PRO_BRIDGE" == "y" ]; then

--- a/utils.sh
+++ b/utils.sh
@@ -445,7 +445,7 @@ function write_pull_secret() {
     jq -s '.[0] * .[1] * .[2]' ${PERSONAL_PULL_SECRET} ${REGISTRY_CREDS} ${tmppullsecret} > ${PULL_SECRET_FILE}
 }
 
-function swtich_to_internal_dns() {
+function switch_to_internal_dns() {
   sudo mkdir -p /etc/NetworkManager/conf.d/
   ansible localhost -b -m ini_file -a "path=/etc/NetworkManager/conf.d/dnsmasq.conf section=main option=dns value=dnsmasq"
   if [ "$ADDN_DNS" ] ; then


### PR DESCRIPTION
A deployment would lay down the `/etc/NetworkManager/conf.d/dnsmasq.conf` file to enable the NetworkManager dnsmasq service, but a `make clean` would not clean up this configuration and revert the system back to a state without NetworkManager dnsmasq. This simply adds the additional cleanup to the `host_cleanup.sh` script.

Also corrected a function name typo.