### PR TITLE
Retrieve ironic image from release payload

### DIFF
--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -131,9 +131,9 @@ if [ ! -z "${MIRROR_IMAGES}" ]; then
     sudo podman image build --authfile $PULL_SECRET_FILE -t $OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE -f $DOCKERFILE
     sudo podman push --tls-verify=false --authfile $PULL_SECRET_FILE $OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE $OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE
 
-    # If we're mirroring images, let's use the local Ironic image instead
-    OPENSHIFT_RELEASE_VERSION=$(openshift_release_version)
-    IRONIC_LOCAL_IMAGE=${IRONIC_LOCAL_IMAGE:-"${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/local-release-image:${OPENSHIFT_RELEASE_VERSION}-ironic"}
+    IRONIC_RELEASE_IMAGE=$(image_for ironic | cut -d '@' -f2)
+    LOCAL_REGISTRY_PREFIX="${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/local-release-image"
+    IRONIC_LOCAL_IMAGE=${IRONIC_LOCAL_IMAGE:-"${LOCAL_REGISTRY_PREFIX}@${IRONIC_RELEASE_IMAGE}"}
 fi
 
 for name in ironic ironic-api ironic-conductor ironic-inspector dnsmasq httpd-${PROVISIONING_NETWORK_NAME} mariadb ipa-downloader; do


### PR DESCRIPTION
Since https://github.com/openshift/oc/pull/646
the format of this image name changed, so use the release image tag instead