### PR TITLE
Add support for infinite DHCP leases

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -243,3 +243,13 @@ if [ "$DISABLE_MULTICAST" == "true" ]; then
         sudo ebtables -A OUTPUT --pkttype-type multicast -p ip6 --ip6-dst ${dst} -j DROP
     done
 fi
+
+# Hack to force use of infinite leases in versions of libvirt that don't
+# support setting the lease time in the network config.
+# This should be removed when we have a new enough version of libvirt to
+# do it properly. I believe any version 6.3.0 or above should have the feature.
+if [ ${INFINITE_LEASES:-0} -eq 1 ]
+then
+    ./infinite-leases.sh &
+    echo "$!" > "${WORKING_DIR}/infinite-lease-pid"
+fi

--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -60,3 +60,9 @@ sudo ebtables --flush
 
 # Kill any lingering proxy
 sudo pkill -f oc.*proxy
+
+# Kill the infinite lease script
+if [ -s "${WORKING_DIR}/infinite-lease-pid" ]; then
+    kill $(cat "${WORKING_DIR}/infinite-lease-pid")
+    rm "${WORKING_DIR}/infinite-lease-pid"
+fi

--- a/infinite-leases.sh
+++ b/infinite-leases.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+NETWORK_NAME=${CLUSTER_NAME}bm
+FILENAME=/var/lib/libvirt/dnsmasq/${NETWORK_NAME}.hostsfile
+
+# We need to keep running even after setting the infinite leases because
+# they are overwritten multiple times in the deployment process.
+while :
+do
+    if grep -q -v infinite $FILENAME
+    then
+        sudo perl -pi -e 's/(.*?)(,infinite|)$/\1,infinite/' $FILENAME
+
+        pid=$(ps aux | grep dnsmasq | grep "$NETWORK_NAME" | grep -v root | awk '{print $2}')
+        sudo kill -s SIGHUP $pid
+        echo "Added infinite leases to $FILENAME"
+    fi
+    sleep 10
+done


### PR DESCRIPTION
The proper way to do this would be to set the lease length in the
libvirt network config, but unfortunately the version of libvirt we
have in CentOS 8 right now doesn't support that. This adds a script
that manually modifies the libvirt dnsmasq configuration to make the
leases infinite. It is started in the background, and killed when
make clean is run. It can be enabled by setting INFINITE_LEASES=1.