### PR TITLE
Add nss_wrapper to Dockerfile.ci

### DIFF
--- a/images/Dockerfile.ci
+++ b/images/Dockerfile.ci
@@ -3,7 +3,7 @@
 
 FROM registry.ci.openshift.org/openshift/release:golang-1.14
 ENV HOME /output
-RUN INSTALL_PKGS="ansible python-pip" && \
+RUN INSTALL_PKGS="ansible python-pip nss_wrapper" && \
     yum install -y $INSTALL_PKGS && \
     pip install packet-python && \
     ansible-galaxy collection install community.general && \


### PR DESCRIPTION
Adding nss_wrapper provides for a local, unprivileged passwd file to be specified,
allowing the container to map the required user information to a random UID without 
having to modify the containers /etc/passwd file directly.

Full explanation on https://access.redhat.com/articles/4859371