### PR TITLE
local-bmo.sh make BMO path configurable

### DIFF
--- a/metal3-dev/local-bmo.sh
+++ b/metal3-dev/local-bmo.sh
@@ -15,9 +15,9 @@ if ! which yq 2>&1 >/dev/null ; then
     exit 1
 fi
 
-bmo_path=$GOPATH/src/github.com/metal3-io/baremetal-operator
-if [ ! -d $bmo_path ]; then
-    echo "Did not find $bmo_path" 1>&2
+BMO_PATH=${BAREMETAL_OPERATOR_PATH:-$GOPATH/src/github.com/metal3-io/baremetal-operator}
+if [ ! -d $BMO_PATH ]; then
+    echo "Did not find $BMO_PATH" 1>&2
     exit 1
 fi
 
@@ -94,7 +94,7 @@ get_creds ironic
 get_creds ironic-inspector
 
 # Run the operator
-cd $bmo_path
+cd $BMO_PATH
 
 # Use our local verison of the CRD, in case it is newer than the one
 # in the cluster now.


### PR DESCRIPTION
Adds the option to override the default path via the
BAREMETAL_OPERATOR_PATH variable.

This is useful when you want to modify the checkout consumed
via BAREMETAL_OPERATOR_LOCAL_IMAGE, which ends up in $HOME
not the regular GOPATH location.