### PR TITLE
Edit local-cbo to create required paths

### DIFF
--- a/metal3-dev/local-cbo.sh
+++ b/metal3-dev/local-cbo.sh
@@ -9,19 +9,8 @@ source $SCRIPTDIR/common.sh
 source $SCRIPTDIR/utils.sh
 
 # Stop already running CBO.
-pushd $SCRIPTDIR
+cd $SCRIPTDIR
 $SCRIPTDIR/stop-cbo.sh
-
-CBO_LOCAL_IMAGE_PATH="/etc/cluster-baremetal-operator/images"
-
-# Copy cbo-images.json into the CBO_LOCAL_IMAGE_PATH to run CBO locally. 
-# CBO needs image.json file in this path.
-if [[ ! -f "${CBO_LOCAL_IMAGE_PATH}/images.json" ]]; then
-    sudo mkdir -p $CBO_LOCAL_IMAGE_PATH
-    sudo cp ${OCP_DIR}/cbo-images.json ${CBO_LOCAL_IMAGE_PATH}/images.json
-fi
-
-popd
 
 cbo_path=$GOPATH/src/github.com/openshift/cluster-baremetal-operator
 if [ ! -d $cbo_path ]; then
@@ -33,11 +22,5 @@ fi
 cd $cbo_path
 
 export RUN_NAMESPACE=openshift-machine-api
-oc apply -f manifests/0000_31_cluster-baremetal-operator_01_images.configmap.yaml
-oc apply -f manifests/0000_31_cluster-baremetal-operator_02_metal3provisioning.crd.yaml
-oc apply -f manifests/0000_31_cluster-baremetal-operator_03_baremetalhost.crd.yaml
-oc apply -f manifests/0000_31_cluster-baremetal-operator_04_serviceaccount.yaml
-oc apply -f manifests/0000_31_cluster-baremetal-operator_05_rbac.yaml
-oc apply -f manifests/0000_31_cluster-baremetal-operator_07_clusteroperator.cr.yaml
-make run
+make run -e ${OCP_DIR}/cbo-images.json
 

--- a/metal3-dev/local-cbo.sh
+++ b/metal3-dev/local-cbo.sh
@@ -8,6 +8,21 @@ source $SCRIPTDIR/logging.sh
 source $SCRIPTDIR/common.sh
 source $SCRIPTDIR/utils.sh
 
+# Stop already running CBO.
+pushd $SCRIPTDIR
+$SCRIPTDIR/stop-cbo.sh
+
+CBO_LOCAL_IMAGE_PATH="/etc/cluster-baremetal-operator/images"
+
+# Copy cbo-images.json into the CBO_LOCAL_IMAGE_PATH to run CBO locally. 
+# CBO needs image.json file in this path.
+if [[ ! -f "${CBO_LOCAL_IMAGE_PATH}/images.json" ]]; then
+    sudo mkdir -p $CBO_LOCAL_IMAGE_PATH
+    sudo cp ${OCP_DIR}/cbo-images.json ${CBO_LOCAL_IMAGE_PATH}/images.json
+fi
+
+popd
+
 cbo_path=$GOPATH/src/github.com/openshift/cluster-baremetal-operator
 if [ ! -d $cbo_path ]; then
     echo "Did not find $cbo_path" 1>&2
@@ -18,6 +33,11 @@ fi
 cd $cbo_path
 
 export RUN_NAMESPACE=openshift-machine-api
-oc apply -f manifests/
+oc apply -f manifests/0000_31_cluster-baremetal-operator_01_images.configmap.yaml
+oc apply -f manifests/0000_31_cluster-baremetal-operator_02_metal3provisioning.crd.yaml
+oc apply -f manifests/0000_31_cluster-baremetal-operator_03_baremetalhost.crd.yaml
+oc apply -f manifests/0000_31_cluster-baremetal-operator_04_serviceaccount.yaml
+oc apply -f manifests/0000_31_cluster-baremetal-operator_05_rbac.yaml
+oc apply -f manifests/0000_31_cluster-baremetal-operator_07_clusteroperator.cr.yaml
 make run
 

--- a/metal3-dev/local-cbo.sh
+++ b/metal3-dev/local-cbo.sh
@@ -22,5 +22,5 @@ fi
 cd $cbo_path
 
 export RUN_NAMESPACE=openshift-machine-api
-make run -e ${OCP_DIR}/cbo-images.json
+make run IMAGES_JSON=$SCRIPTDIR/$OCP_DIR/cbo-images.json
 


### PR DESCRIPTION
* Add stopping of already running CBO.
* cluster-baremetal-operator fails when there is no path `/etc/cluster-baremetal-operator/images` in local. Added path creation when running `local-cbo.sh`
* `local-cbo.sh` also applies `0000_31_cluster-baremetal-operator_06_deployment.yaml`, which might conflict with the local operator and it is filtered.