### PR TITLE
Add ENABLE_LOCAL_REGISTRY config var to setup the local registry

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -50,8 +50,11 @@ fi
 
 export ANSIBLE_FORCE_COLOR=true
 
+
 # Setup the registry for mirroring images
-if [[ ! -z "${MIRROR_IMAGES}" || $(env | grep "_LOCAL_IMAGE=")  || ! -z "${ENABLE_CBO_TEST}" ]]; then
+export ENABLE_LOCAL_REGISTRY=${ENABLE_LOCAL_REGISTRY:-${MIRROR_IMAGES:-${ENABLE_CBO_TEST:-$(env | grep "_LOCAL_IMAGE=")}}}
+
+if [[ ! -z "${ENABLE_LOCAL_REGISTRY}" ]]; then
     setup_local_registry
 fi
 
@@ -212,7 +215,7 @@ echo "${PROVISIONING_HOST_EXTERNAL_IP} ${LOCAL_REGISTRY_DNS_NAME}" | sudo tee -a
 # Remove any previous file, or podman login panics when reading the
 # blank authfile with a "assignment to entry in nil map" error
 rm -f ${REGISTRY_CREDS}
-if [[ ! -z "${MIRROR_IMAGES}" || $(env | grep "_LOCAL_IMAGE=")  || ! -z "${ENABLE_CBO_TEST}" ]]; then
+if [[ ! -z "${ENABLE_LOCAL_REGISTRY}" ]]; then
     # create authfile for local registry
     sudo podman login --authfile ${REGISTRY_CREDS} \
         -u ${REGISTRY_USER} -p ${REGISTRY_PASS} \

--- a/config_example.sh
+++ b/config_example.sh
@@ -54,6 +54,9 @@ set -x
 # for an IPv4 install.
 #export MIRROR_IMAGES=true
 
+# Ensure that the local registry will be available
+#export ENABLE_LOCAL_REGISTRY=true
+
 # Switch to upstream metal3-io ironic images instead of openshift ones.
 #export UPSTREAM_IRONIC=true
 


### PR DESCRIPTION
The introduction of ENABLE_LOCAL_REGISTRY will allow then to setup the local registry both explicitly - by setting such variable - or in all the other previous situations where it was required).
This approach will be used to expand the OpenShift CI tests coverage, since it's required to run the e2e suites in disconnected mode (see [1]). To do that, the test workflow will mirror the required images to the local dev-scripts private registry.

[1] https://github.com/openshift/origin/pull/24887
