### PR TITLE
Configure storage for image registry

### DIFF
--- a/06_create_cluster.sh
+++ b/06_create_cluster.sh
@@ -22,4 +22,8 @@ for name in dnsmasq ironic-inspector ; do
     sudo podman ps | grep -w "$name$" && sudo podman stop $name
 done
 
+# Configure storage for the image registry
+oc patch configs.imageregistry.operator.openshift.io \
+    cluster --type merge --patch '{"spec":{"storage":{"emptyDir":{}},"managementState":"Managed"}}'
+
 echo "Cluster up, you can interact with it via oc --config ${KUBECONFIG} <command>"


### PR DESCRIPTION
By default, on baremetal platforms, the image registry operator is
configured without persistent storage.  Here, we configure it with
"emptyDir".  This is needed for e2e test.

[Ref](https://docs.openshift.com/container-platform/4.3/registry/configuring_registry_storage/configuring-registry-storage-baremetal.html#installation-registry-storage-non-production_configuring-registry-storage-baremetal)