### PR TITLE
Fix exporting provisioning ip for ipv4/ipv6 cases in local-bmo.sh

### DIFF
--- a/metal3-dev/local-bmo.sh
+++ b/metal3-dev/local-bmo.sh
@@ -67,8 +67,9 @@ oc apply -f $OUTDIR/bmo-deployment-dev.yaml -n openshift-machine-api
 # Set some variables the operator expects to have in order to work
 export OPERATOR_NAME=baremetal-operator
 
+CLUSTER_IP=$(wrap_if_ipv6 $CLUSTER_PROVISIONING_IP)
 for var in IRONIC_ENDPOINT IRONIC_INSPECTOR_ENDPOINT DEPLOY_KERNEL_URL DEPLOY_RAMDISK_URL; do
-    export "$var"=$(cat $OUTDIR/bmo-deployment-full.yaml | yq -r ".spec.template.spec.containers[] | select(.name == \"metal3-baremetal-operator\").env[] | select(.name == \"${var}\").value" | sed "s/localhost/${CLUSTER_PROVISIONING_IP}/g")
+    export "$var"=$(cat $OUTDIR/bmo-deployment-full.yaml | yq -r ".spec.template.spec.containers[] | select(.name == \"metal3-baremetal-operator\").env[] | select(.name == \"${var}\").value" | sed "s/localhost/${CLUSTER_IP}/g")
 done
 
 auth_dir=/opt/metal3/auth


### PR DESCRIPTION
Env variables weren't exported correctly in the `local-bmo.sh` script, thus provoking an inspection failure due a parsing error.