### PR TITLE
Add support to lauch remote site VMs in their own L2 network

### DIFF
--- a/05_create_install_config.sh
+++ b/05_create_install_config.sh
@@ -58,5 +58,5 @@ fi
 # Generate the assets for extra worker VMs
 if [ -f "${EXTRA_NODES_FILE}" ]; then
     jq '.nodes' "${EXTRA_NODES_FILE}" | tee "${EXTRA_BAREMETALHOSTS_FILE}"
-    generate_ocp_host_manifest ${OCP_DIR} ${EXTRA_BAREMETALHOSTS_FILE}
+    generate_ocp_host_manifest ${OCP_DIR} ${EXTRA_BAREMETALHOSTS_FILE} extra_host_manifests.yaml openshift-machine-api
 fi

--- a/README.md
+++ b/README.md
@@ -469,7 +469,7 @@ machineset.machine.openshift.io/ostest-worker-0 scaled
 ### Deploying dummy remote cluster nodes
 
 It is possible to add remote site nodes along with their own L2 network. To do so, use the 
-`remote-cluster.sh` script to create/teardown definitions of VMs and their corresponding network.
+`create_remote_nodes.sh` script to create the definitions of VMs and their corresponding network.
 Additional configuration can be made by altering the environment variables within the script.
 
 Create remote cluster VMs and their network using. The script requires a single `namespace` argument:

--- a/README.md
+++ b/README.md
@@ -472,7 +472,10 @@ It is possible to add remote site nodes along with their own L2 network. To do s
 `create_remote_nodes.sh` script to create the definitions of VMs and their corresponding network.
 Additional configuration can be made by altering the environment variables within the script.
 
-Create remote cluster VMs and their network using. The script requires a single `namespace` argument:
+Create remote cluster VMs and their network using the `create_remote_nodes.sh` script.
+The script accepts an optional namespace argument.  If omitted, the namespace will default
+to `openshift-machine-api`.
+
 ```
-./create_remote_nodes.sh <namespace>
+./create_remote_nodes.sh [namespace]
 ```

--- a/README.md
+++ b/README.md
@@ -466,3 +466,13 @@ $ oc scale machineset ostest-worker-0 --replicas=3 -n openshift-machine-api
 machineset.machine.openshift.io/ostest-worker-0 scaled
 ```
 
+### Deploying dummy remote cluster nodes
+
+It is possible to add remote site nodes along with their own L2 network. To do so, use the 
+`remote-cluster.sh` script to create/teardown definitions of VMs and their corresponding network.
+Additional configuration can be made by altering the environment variables within the script.
+
+Create remote cluster VMs and their network using. The script requires a single `namespace` argument:
+```
+./create_remote_nodes.sh <namespace>
+```

--- a/create_remote_nodes.sh
+++ b/create_remote_nodes.sh
@@ -5,10 +5,7 @@ source logging.sh
 source common.sh
 source ocp_install_env.sh
 
-namespace=$1
-if [ $namespace == "" ]; then
-	namespace=openshift-machine-api
-fi
+namespace=${1:-openshift-machine-api}
 
 export REMOTE_CLUSTER_NAME=${REMOTE_CLUSTER_NAME:-${CLUSTER_NAME}rc}
 export REMOTE_CLUSTER_NUM_MASTERS=${REMOTE_CLUSTER_NUM_MASTERS:-1}

--- a/create_remote_nodes.sh
+++ b/create_remote_nodes.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
+set -xe
 
+source logging.sh
 source common.sh
 source ocp_install_env.sh
 
 namespace=$1
 if [ $namespace == "" ]; then
-	echo "Error: Insufficient arguments. Please specify the namespace"
-	echo "Usage: $0 <namespace>"
-	exit 1
+	namespace=openshift-machine-api
 fi
 
 export REMOTE_CLUSTER_NAME=${REMOTE_CLUSTER_NAME:-${CLUSTER_NAME}rc}

--- a/create_remote_nodes.sh
+++ b/create_remote_nodes.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+source common.sh
+source ocp_install_env.sh
+
+namespace=$1
+if [ $namespace == "" ]; then
+	echo "Error: Insufficient arguments. Please specify the namespace"
+	echo "Usage: $0 <namespace>"
+	exit 1
+fi
+
+export REMOTE_CLUSTER_NAME=${REMOTE_CLUSTER_NAME:-${CLUSTER_NAME}rc}
+export REMOTE_CLUSTER_NUM_MASTERS=${REMOTE_CLUSTER_NUM_MASTERS:-1}
+export REMOTE_CLUSTER_NUM_WORKERS=${REMOTE_CLUSTER_NUM_WORKERS:-0}
+export REMOTE_CLUSTER_SUBNET_V4=${REMOTE_CLUSTER_SUBNET_V4:-"192.168.133.0/24"}
+export REMOTE_CLUSTER_SUBNET_V6=${REMOTE_CLUSTER_SUBNET_V6:-"fd2e:6f44:5dd8:c960::/120"}
+export REMOTE_NODE_BMC_DRIVER=redfish-virtualmedia
+export REMOTE_NODES_FILE=${REMOTE_NODES_FILE:-"${WORKING_DIR}/${CLUSTER_NAME}/remote_nodes.json"}
+export REMOTE_BAREMETALHOSTS_FILE=${REMOTE_BAREMETALHOSTS_FILE:-"${OCP_DIR}/remote_baremetalhosts.json"}
+export PROVISIONING_NETWORK_PROFILE=Disabled
+export MANAGE_BR_BRIDGE=y
+
+ansible-playbook \
+    -e @vm_setup_vars.yml \
+    -e "ironic_prefix=${REMOTE_CLUSTER_NAME}_" \
+    -e "cluster_name=${REMOTE_CLUSTER_NAME}" \
+    -e "working_dir=$WORKING_DIR" \
+    -e "extradisks=$VM_EXTRADISKS" \
+    -e "libvirt_firmware=uefi" \
+    -e "virthost=$HOSTNAME" \
+    -e "vm_platform=$NODES_PLATFORM" \
+    -e "provisioning_url_host=$PROVISIONING_URL_HOST" \
+    -e "nodes_file=$REMOTE_NODES_FILE" \
+    -e "vm_driver=$REMOTE_NODE_BMC_DRIVER" \
+    -e "virtualbmc_base_port=$VBMC_BASE_PORT" \
+    -e "master_hostname_format=$MASTER_HOSTNAME_FORMAT" \
+    -e "worker_hostname_format=$WORKER_HOSTNAME_FORMAT" \
+    -e "provisioning_network_name=noprov" \
+    -e "num_masters=$REMOTE_CLUSTER_NUM_MASTERS" \
+    -e "num_workers=$REMOTE_CLUSTER_NUM_WORKERS" \
+    -e "baremetal_network_name=$REMOTE_CLUSTER_NAME" \
+    -e "baremetal_network_cidr_v4=$REMOTE_CLUSTER_SUBNET_V4" \
+    -e "baremetal_network_cidr_v6=$REMOTE_CLUSTER_SUBNET_V6" \
+    -i ${VM_SETUP_PATH}/inventory.ini \
+    -b -vvv ${VM_SETUP_PATH}/setup-playbook.yml
+
+# Generate the assets for extra worker VMs
+cp -f ${REMOTE_NODES_FILE} ${REMOTE_NODES_FILE}.orig
+jq '.nodes' "${REMOTE_NODES_FILE}" | tee "${REMOTE_BAREMETALHOSTS_FILE}"
+
+generate_ocp_host_manifest ${OCP_DIR} ${REMOTE_BAREMETALHOSTS_FILE} remote_host_manifests.yaml ${namespace}

--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -250,6 +250,8 @@ function generate_ocp_host_manifest() {
 
     outdir="$1"
     host_input="$2"
+    host_output="$3"
+    namespace="$4"
 
     mkdir -p "${outdir}"
     rm -f "${outdir}/extra_hosts.yaml"
@@ -260,13 +262,13 @@ function generate_ocp_host_manifest() {
         encoded_username=$(echo -n "$username" | base64)
         encoded_password=$(echo -n "$password" | base64)
 
-    cat >> "${outdir}/extra_host_manifests.yaml" << EOF
+    cat >> "${outdir}/${host_output}" << EOF
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: ${name}-bmc-secret
-  namespace: openshift-machine-api
+  namespace: $namespace
 type: Opaque
 data:
   username: $encoded_username
@@ -277,7 +279,7 @@ apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
 metadata:
   name: $name
-  namespace: openshift-machine-api
+  namespace: $namespace
 spec:
   online: ${EXTRA_WORKERS_ONLINE_STATUS}
   bootMACAddress: $mac


### PR DESCRIPTION
This PR adds support to create a 'remote cluster' VM nodes and their own L2 network. The network is a libvirt NAT network.

To create a new remote cluster VM(s) and their corresponding network, just invoke the: `create_remote_nodes.sh` with a namespace as an argument.

e.g 
```
./create_remote_nodes.sh mynamespace
```