### PR TITLE
Add ENABLE_LOCAL_REGISTRY check in image mirror config

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -50,11 +50,7 @@ fi
 
 export ANSIBLE_FORCE_COLOR=true
 
-
-# Setup the registry for mirroring images
-export ENABLE_LOCAL_REGISTRY=${ENABLE_LOCAL_REGISTRY:-${MIRROR_IMAGES:-${ENABLE_CBO_TEST:-$(env | grep "_LOCAL_IMAGE=")}}}
-
-if [[ ! -z "${ENABLE_LOCAL_REGISTRY}" ]]; then
+if [[ ! -z "${MIRROR_IMAGES}" || $(env | grep "_LOCAL_IMAGE=")  || ! -z "${ENABLE_CBO_TEST}" || ! -z "${ENABLE_LOCAL_REGISTRY}" ]]; then
     setup_local_registry
 fi
 
@@ -215,7 +211,7 @@ echo "${PROVISIONING_HOST_EXTERNAL_IP} ${LOCAL_REGISTRY_DNS_NAME}" | sudo tee -a
 # Remove any previous file, or podman login panics when reading the
 # blank authfile with a "assignment to entry in nil map" error
 rm -f ${REGISTRY_CREDS}
-if [[ ! -z "${ENABLE_LOCAL_REGISTRY}" ]]; then
+if [[ ! -z "${MIRROR_IMAGES}" || $(env | grep "_LOCAL_IMAGE=")  || ! -z "${ENABLE_CBO_TEST}" || ! -z "${ENABLE_LOCAL_REGISTRY}" ]]; then
     # create authfile for local registry
     sudo podman login --authfile ${REGISTRY_CREDS} \
         -u ${REGISTRY_USER} -p ${REGISTRY_PASS} \

--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -133,7 +133,7 @@ EOF
 
 function additional_trust_bundle() {
   if [ ! -z "$ADDITIONAL_TRUST_BUNDLE" ]; then
-    if [ -z $MIRROR_IMAGES ]; then
+    if [ -z "${MIRROR_IMAGES}" && -z "${ENABLE_LOCAL_REGISTRY}" ]; then
       echo "additionalTrustBundle: |"
     fi
     awk '{ print " ", $0 }' "${ADDITIONAL_TRUST_BUNDLE}"

--- a/utils.sh
+++ b/utils.sh
@@ -290,12 +290,12 @@ function generate_metal3_config {
 }
 
 function image_mirror_config {
-    if [ ! -z "${MIRROR_IMAGES}" ]; then
-        . /tmp/mirrored_release_image
-        TAGGED=$(echo $MIRRORED_RELEASE_IMAGE | sed -e 's/release://')
-        RELEASE=$(echo $MIRRORED_RELEASE_IMAGE | grep -o 'registry.ci.openshift.org[^":\@]\+')
+    if [ ! -z "${MIRROR_IMAGES}" || ! -z "${ENABLE_LOCAL_REGISTRY}" ]; then
         INDENTED_CERT=$( cat $REGISTRY_DIR/certs/$REGISTRY_CRT | awk '{ print " ", $0 }' )
-        if [ ! -s ${MIRROR_LOG_FILE} ]; then
+        if [ ! -z "${MIRROR_IMAGES}" && ! -s ${MIRROR_LOG_FILE} ]; then
+            . /tmp/mirrored_release_image
+            TAGGED=$(echo $MIRRORED_RELEASE_IMAGE | sed -e 's/release://')
+            RELEASE=$(echo $MIRRORED_RELEASE_IMAGE | grep -o 'registry.ci.openshift.org[^":\@]\+')
             cat << EOF
 imageContentSources:
 - mirrors:


### PR DESCRIPTION
For IPv4 environments, when `ENABLE_LOCAL_REGISTRY` is enabled, we are getting `x509: certificate signed by unknown authority` in CI workflows. This is due to the fact that `additionalTrustBundle` should be added as well as `imageContentSources` into the install-config, even when `MIRROR_IMAGES` is disabled.

This PR adds enabling this even when MIRROR_IMAGES is disabled environments.
