### PR TITLE
chown private mirror creds file

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -224,6 +224,12 @@ else
     # Create a blank authfile in order to have something valid when we read it in 04_setup_ironic.sh
     echo '{}' | sudo dd of=${REGISTRY_CREDS}
 fi
+# Since podman 2.2.1 the REGISTRY_CREDS file gets written out as
+# o600, where as in previous versions it was 644 - to enable reading
+# as $USER elsewhere we chown here, but in future we should probably
+# consider moving all podman calls to rootless mode (e.g remove sudo)
+sudo chown $USER:$USER ${REGISTRY_CREDS}
+ls -l ${REGISTRY_CREDS}
 
 # metal3-dev-env contains a script to run the baremetal ironic client in a
 # container, place a link to it if its not installed


### PR DESCRIPTION
In recent (2.2.1 tested) podman versions, this file ends up
unreadable as $USER e.g in utils.sh (previously it ended up as 644, now it's 600)

```
$ sudo podman login --authfile /tmp/test.json ...
Login Succeeded!
-rw-------. 1 root root 107 Feb 17 12:00 /tmp/test.json
```
In future we should probably test removing all the `sudo podman`
calls to use rootless mode, but since that has historically been
buggy, this is a lower risk interim fix.