### PR TITLE
Support lease expiry option

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -19,7 +19,7 @@ if [ -z "${METAL3_DEV_ENV}" ]; then
   # TODO -- come up with a plan for continuously updating this
   # Note we only do this in the case where METAL3_DEV_ENV is
   # unset, to enable developer testing of local checkouts
-  git reset 8908da5241d52e25a7e1b2e60d6d604cf797f890 --hard
+  git reset 184d0afaab77424872f0441c9e11e23a620e5b57 --hard
   popd
 fi
 
@@ -43,7 +43,7 @@ sudo alternatives --set python /usr/bin/python3
 
 pushd ${METAL3_DEV_ENV_PATH}
 ansible-galaxy install -r vm-setup/requirements.yml
-ansible-galaxy collection install ansible.netcommon ansible.posix
+ansible-galaxy collection install ansible.netcommon ansible.posix community.general
 ANSIBLE_FORCE_COLOR=true ansible-playbook \
   -e "working_dir=$WORKING_DIR" \
   -e "virthost=$HOSTNAME" \

--- a/common.sh
+++ b/common.sh
@@ -214,6 +214,8 @@ MANAGE_INT_BRIDGE=${MANAGE_INT_BRIDGE:-y}
 INT_IF=${INT_IF:-}
 #Root disk to deploy coreOS - use /dev/sda on BM
 ROOT_DISK_NAME=${ROOT_DISK_NAME-"/dev/sda"}
+# Length of DHCP leases
+export DHCP_LEASE_EXPIRY=${DHCP_LEASE_EXPIRY:-60}
 
 FILESYSTEM=${FILESYSTEM:="/"}
 

--- a/config_example.sh
+++ b/config_example.sh
@@ -248,6 +248,9 @@ set -x
 #export METALLB_IMAGE_BASE=
 #export METALLB_IMAGE_TAG=
 
+# Set the DHCP lease time
+#export DHCP_LEASE_EXPIRY=60
+
 ##
 ## Multi-cluster/Hive variables
 ##

--- a/utils.sh
+++ b/utils.sh
@@ -548,12 +548,18 @@ function bootstrap_ip {
     pref_ip=ipv4
   fi
 
-  sudo virsh net-dhcp-leases ${BAREMETAL_NETWORK_NAME} \
+  # TODO(bnemec): Remove this logic once we have libvirt 7.0 or higher.
+  # Older versions fail on infinite leases.
+  if [ "$DHCP_LEASE_EXPIRY" -ne "0" ]; then
+    sudo virsh net-dhcp-leases ${BAREMETAL_NETWORK_NAME} \
                       | grep -v master \
                       | grep "${pref_ip}" \
                       | tail -n1 \
                       | awk '{print $5}' \
                       | sed -e 's/\(.*\)\/.*/\1/'
+  else
+    echo "Unable to retrieve bootstrap IP with infinite leases enabled." 1>&2
+  fi
 }
 
 function image_for() {

--- a/vm_setup_vars.yml
+++ b/vm_setup_vars.yml
@@ -65,6 +65,7 @@ external_network:
     dhcp_range_v6:
       - "{{ baremetal_network_cidr_v6|nthhost(20) }}"
       - "{{ baremetal_network_cidr_v6|nthhost(60) }}"
+    lease_expiry: "{{ lookup('env', 'DHCP_LEASE_EXPIRY') }}"
     nat_port_range:
       - 1024
       - 65535


### PR DESCRIPTION
This was added to metal3-dev-env in [0]. Expose the setting for
dev-scripts too.

With the current version of libvirt available, we are not able to run
virsh net-dhcp-leases when infinite leases are enabled. I've added
logic to skip that step when LEASE_EXPIRY=0. It just means we
can't retrieve clouds.yaml from the bootstrap.
    
0: https://github.com/metal3-io/metal3-dev-env/pull/599