### PR TITLE
Add a basic squid proxy for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ clouds.yaml
 _clouds_yaml
 metal3-dev/deployment-*.yaml
 assets/generated
+squid.conf
 
 # Conditionally created for appropriate environments
 assets/templates/99_master-chronyd-redhat.yaml

--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -54,6 +54,13 @@ if [[ ! -z "${MIRROR_IMAGES}" || $(env | grep "_LOCAL_IMAGE=")  || ! -z "${ENABL
     setup_local_registry
 fi
 
+if [[ ! -z "${SQUID_PROXY}" ]]; then
+  sudo podman run -d --rm \
+     --net host \
+     --volume $PWD/squid.conf:/etc/squid/squid.conf \
+     sameersbn/squid:latest
+fi
+
 ansible-playbook \
     -e @vm_setup_vars.yml \
     -e "ironic_prefix=${CLUSTER_NAME}_" \

--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -61,7 +61,7 @@ if [[ ! -z "${SQUID_PROXY}" ]]; then
      --net host \
      --volume $PWD/squid.conf:/etc/squid/squid.conf \
      --name squid \
-     sameersbn/squid:latest
+     docker.io/sameersbn/squid:3.5.27-2
 fi
 
 ansible-playbook \

--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -55,6 +55,8 @@ if [[ ! -z "${MIRROR_IMAGES}" || $(env | grep "_LOCAL_IMAGE=")  || ! -z "${ENABL
 fi
 
 if [[ ! -z "${SQUID_PROXY}" ]]; then
+  generate_squid_conf > squid.conf
+
   sudo podman run -d --rm \
      --net host \
      --volume $PWD/squid.conf:/etc/squid/squid.conf \

--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -60,6 +60,7 @@ if [[ ! -z "${SQUID_PROXY}" ]]; then
   sudo podman run -d --rm \
      --net host \
      --volume $PWD/squid.conf:/etc/squid/squid.conf \
+     --name squid \
      sameersbn/squid:latest
 fi
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: default all requirements configure ironic ocp_run install_config clean ocp_cleanup ironic_cleanup host_cleanup cache_cleanup registry_cleanup workingdir_cleanup podman_cleanup bell
+.PHONY: default all requirements configure ironic ocp_run install_config clean ocp_cleanup ironic_cleanup host_cleanup cache_cleanup registry_cleanup squid_cleanup workingdir_cleanup podman_cleanup bell
 default: requirements configure build_installer ironic install_config ocp_run bell
 
 all: default
@@ -29,7 +29,7 @@ ocp_run:
 gather:
 	./must_gather.sh
 
-clean: ocp_cleanup ironic_cleanup host_cleanup assisted_deployment_cleanup
+clean: ocp_cleanup ironic_cleanup squid_cleanup host_cleanup assisted_deployment_cleanup
 
 assisted_deployment_cleanup:
 	./assisted_deployment_cleanup.sh
@@ -50,6 +50,9 @@ cache_cleanup:
 
 registry_cleanup:
 	./registry_cleanup.sh
+
+squid_cleanup:
+	./squid_cleanup.sh
 
 workingdir_cleanup:
 	./workingdir_cleanup.sh

--- a/common.sh
+++ b/common.sh
@@ -64,6 +64,9 @@ export SSH_PUB_KEY="${SSH_PUB_KEY:-$(cat $HOME/.ssh/id_rsa.pub)}"
 # mirror images for installation in restricted network
 export MIRROR_IMAGES=${MIRROR_IMAGES:-}
 
+# Setup a local squid proxy for testing
+export SQUID_PROXY=${SQUID_PROXY:-}
+
 # Hypervisor details
 export REMOTE_LIBVIRT=${REMOTE_LIBVIRT:-0}
 export PROVISIONING_HOST_USER=${PROVISIONING_HOST_USER:-$USER}

--- a/config_example.sh
+++ b/config_example.sh
@@ -59,6 +59,9 @@ set -x
 # for an IPv4 install.
 #export MIRROR_IMAGES=true
 
+# Enable a squid proxy
+#export SQUID_PROXY=true
+
 # Ensure that the local registry will be available
 #export ENABLE_LOCAL_REGISTRY=true
 

--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -179,6 +179,14 @@ EOF
     echo "Unexpected IP_STACK value: '${IP_STACK}'"
     exit 1
   fi
+if [[ ! -z "${SQUID_PROXY}" ]]; then
+cat <<EOF
+proxy:
+  httpProxy: http://$(wrap_if_ipv6 ${PROVISIONING_HOST_IP}):3128
+  httpsProxy: http://$(wrap_if_ipv6 ${PROVISIONING_HOST_IP}):3128
+  noProxy: ${PROVISIONING_NETWORK}
+EOF
+fi
 }
 
 function generate_ocp_install_config() {

--- a/squid.conf
+++ b/squid.conf
@@ -1,0 +1,6 @@
+acl all src 0.0.0.0/0
+http_access allow all
+http_port 3128
+debug_options ALL,1 33,2 28,9
+dns_v4_first on
+coredump_dir /var/spool/squid

--- a/squid.conf
+++ b/squid.conf
@@ -1,6 +1,0 @@
-acl all src 0.0.0.0/0
-http_access allow all
-http_port 3128
-debug_options ALL,1 33,2 28,9
-dns_v4_first on
-coredump_dir /var/spool/squid

--- a/squid_cleanup.sh
+++ b/squid_cleanup.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -x
+
+source logging.sh
+source common.sh
+source validation.sh
+
+early_cleanup_validation
+
+sudo podman kill squid
+sudo podman rm squid
+
+sudo rm -f squid.conf

--- a/utils.sh
+++ b/utils.sh
@@ -477,6 +477,28 @@ function image_for() {
     jq -r ".references.spec.tags[] | select(.name == \"$1\") | .from.name" ${OCP_DIR}/release_info.json
 }
 
+function generate_squid_conf() {
+  echo "acl all src $PROVISIONING_NETWORK"
+
+  if [[ ! -z "${EXTERNAL_SUBNET_V4}" ]]
+  then
+    echo "acl all src $EXTERNAL_SUBNET_V4"
+  fi
+
+  if [[ ! -z "${EXTERNAL_SUBNET_V6}" ]]
+  then
+    echo "acl all src $EXTERNAL_SUBNET_V6"
+  fi
+
+  cat <<EOF
+http_access allow all
+http_port 3128
+debug_options ALL,1 33,2 28,9
+dns_v4_first on
+coredump_dir /var/spool/squid
+EOF
+}
+
 _tmpfiles=
 function removetmp(){
     [ -n "$_tmpfiles" ] && rm -rf $_tmpfiles || true


### PR DESCRIPTION
This change allows standing up a squid proxy for testing the cluster-wide OCP proxy (export SQUID_PROXY=true). It doesn't block external egress but it's still useful for testing whether the proxy is working or not.