### PR TITLE
using slash delimiters in sysctl for handling vlan NICs

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -43,7 +43,7 @@ if [[ "${HOST_IP_STACK}" != "v4" ]]; then
   # This comes from libvirt when trying to create the ostestbm network.
   for n in /proc/sys/net/ipv6/conf/* ; do
     if [ -f $n/accept_ra ]; then
-      sudo sysctl -w net.ipv6.conf.$(basename $n).accept_ra=2
+      sudo sysctl -w net/ipv6/conf/$(basename $n)/accept_ra=2
     fi
   done
 fi


### PR DESCRIPTION
Happened to me on a scalelab machine.
Figured out we can handle it in this way.

/hold