### PR TITLE
Configure cluster samples operator and tools image registry

### DIFF
--- a/06_create_cluster.sh
+++ b/06_create_cluster.sh
@@ -26,4 +26,14 @@ done
 oc patch configs.imageregistry.operator.openshift.io \
     cluster --type merge --patch '{"spec":{"storage":{"emptyDir":{}},"managementState":"Managed"}}'
 
+if [[ ! -z "${ENABLE_LOCAL_REGISTRY}" ]]; then        
+    # Configure tools image registry and cluster samples operator 
+    # when local image stream is enabled. These are basically to run CI tests
+    # depend on tools image.
+    add_local_certificate_as_trusted
+    
+    oc patch configs.samples cluster \
+      --type merge --patch "{\"spec\":{\"samplesRegistry\":\"${LOCAL_REGISTRY_DNS_NAME}\"}}"
+fi
+
 echo "Cluster up, you can interact with it via oc --config ${KUBECONFIG} <command>"

--- a/utils.sh
+++ b/utils.sh
@@ -412,6 +412,13 @@ EOF
 
 }
 
+function add_local_certificate_as_trusted() {
+    REGISTRY_CONFIG="registry-config"  
+    oc create configmap ${REGISTRY_CONFIG} \
+      --from-file=${LOCAL_REGISTRY_DNS_NAME}..${LOCAL_REGISTRY_PORT}=${REGISTRY_DIR}/certs/${REGISTRY_CRT} -n openshift-config
+    oc patch image.config.openshift.io/cluster --patch "{\"spec\":{\"additionalTrustedCA\":{\"name\":\"${REGISTRY_CONFIG}\"}}}" --type=merge
+}
+
 function verify_pull_secret() {
   # Do some PULL_SECRET sanity checking
   if [[ "${OPENSHIFT_RELEASE_IMAGE}" == *"registry.ci.openshift.org"* ]]; then


### PR DESCRIPTION
CI runs dev-script with `ENABLE_LOCAL_REGISTRY`(local image registry) to support disconnected environments and this causes unknown certificate error for 60 tests which tries to access tools image stream.

This PR defines local certificate as trusted CA for cluster's image configuration in connected environments (with also configuring cluster samples operator).

Reference: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html-single/images/index#installation-restricted-network-samples_samples-operator-alt-registry 