### PR TITLE
Disable TLS verification in clouds.yaml

### DIFF
--- a/clouds.yaml.template
+++ b/clouds.yaml.template
@@ -4,13 +4,16 @@ clouds:
     auth_type: {{.AuthType}}
     baremetal_endpoint_override: {{.BootstrapIronicURL}}
     baremetal_introspection_endpoint_override: {{.BootstrapInspectorURL}}
+    verify: false
   metal3:
     auth_type: {{.AuthType}}
     baremetal_endpoint_override: {{.ClusterIronicURL}}
     baremetal_introspection_endpoint_override: {{.ClusterInspectorURL}}
+    verify: false
   metal3-inspector:
     auth_type: {{.AuthType}}
     baremetal_introspection_endpoint_override: {{.ClusterInspectorURL}}
+    verify: false
 {{- else if eq .AuthType "http_basic"}}
   metal3:
     auth_type: {{.AuthType}}
@@ -18,10 +21,12 @@ clouds:
       username: {{.IronicUser}}
       password: {{.IronicPassword}}
     baremetal_endpoint_override: {{.ClusterIronicURL}}
+    verify: false
   metal3-inspector:
     auth_type: {{.AuthType}}
     auth:
       username: {{.InspectorUser}}
       password: {{.InspectorPassword}}
     baremetal_introspection_endpoint_override: {{.ClusterInspectorURL}}
+    verify: false
 {{- end}}

--- a/utils.sh
+++ b/utils.sh
@@ -251,6 +251,8 @@ function generate_auth_template {
         INSPECTOR_CREDS="$INSPECTOR_USER:$INSPECTOR_PASSWORD"
         CLUSTER_IRONIC_IP=$(oc get pods -n openshift-machine-api -l baremetal.openshift.io/cluster-baremetal-operator=metal3-state -o jsonpath="{.items[0].status.hostIP}" || echo "")
 
+        # TODO(dtantsur): fetch the TLS public key, store it locally and link from clouds.yaml.
+
         if [ ! -z "${CLUSTER_IRONIC_IP}" ]; then
             go run metal3-templater.go "http_basic" -ironic-basic-auth="$IRONIC_CREDS" -inspector-basic-auth="$INSPECTOR_CREDS" -template-file=clouds.yaml.template -provisioning-interface="$CLUSTER_PRO_IF" -provisioning-network="$PROVISIONING_NETWORK" -image-url="$MACHINE_OS_IMAGE_URL" -bootstrap-ip="$BOOTSTRAP_PROVISIONING_IP" -cluster-ip="$CLUSTER_IRONIC_IP" > clouds.yaml
         else


### PR DESCRIPTION
In theory it should be possible to load the public key from secrets, but
I don't have an environment to figure it out yet.