### PR TITLE
Add some extra image/volume cleanup

### DIFF
--- a/ocp_cleanup.sh
+++ b/ocp_cleanup.sh
@@ -50,13 +50,13 @@ for vm in $(sudo virsh list --all --name | grep "^${CLUSTER_NAME}.*bootstrap"); 
   sudo virsh undefine $vm --remove-all-storage
 done
 
-# For some reason --remove-all-storage doesn't actually remove the storage...
+# For some reason --remove-all-storage doesn't actually remove the storage
+# so we do some extra cleanup of volumes
 if [ -d /var/lib/libvirt/openshift-images ]; then
   sudo rm -fr /var/lib/libvirt/openshift-images/${CLUSTER_NAME}-*
 fi
 
-# The .ign volume isn't deleted via --remove-all-storage
-VOLS="$(sudo virsh vol-list --pool default | awk '{print $1}' | grep "^${CLUSTER_NAME}.*bootstrap")"
+VOLS=$(sudo virsh vol-list --pool default | awk '{print $1}' | grep -e "^${CLUSTER_NAME}.*bootstrap" -e "^configdrive-" -e "^boot-.*-iso-")
 for v in $VOLS; do
   sudo virsh vol-delete $v --pool default
 done

--- a/podman_cleanup.sh
+++ b/podman_cleanup.sh
@@ -8,3 +8,4 @@ source validation.sh
 early_cleanup_validation
 
 sudo podman image prune --all
+sudo podman volume prune


### PR DESCRIPTION
When testing the virtualmedia flow, I noticed that we're
leaking boot images, and also that on realclean we don't
clean any dangling podman volumes.