### PR TITLE
Don't show generated ironic credentials in the logs

### DIFF
--- a/utils.sh
+++ b/utils.sh
@@ -235,6 +235,7 @@ function sync_repo_and_patch {
 }
 
 function generate_auth_template {
+    set +x
     # clouds.yaml
     OCP_VERSIONS_NOAUTH="4.3 4.4 4.5"
 
@@ -275,6 +276,7 @@ function generate_auth_template {
     # which mounts a config dir into the ironic-client container
     mkdir -p _clouds_yaml
     ln -f clouds.yaml _clouds_yaml
+    set -x
 }
 
 function generate_metal3_config {


### PR DESCRIPTION
The credentials we generate for Ironic and related services end up in
the log. There's not much use of these, since they're ephemeral, and
you'd have to otherwise have access to the host's network to make use of
them, but we should hide them anyway.