### PR TITLE
Always create the provisioning network

### DIFF
--- a/vm_setup_vars.yml
+++ b/vm_setup_vars.yml
@@ -66,4 +66,4 @@ external_network:
         - domain: "apps.{{ cluster_domain }}"
           addr: "127.0.0.1"
 
-networks: "{{ (provisioning_network if lookup('env', 'PROVISIONING_NETWORK_PROFILE') != 'Disabled' else []) + external_network }}"
+networks: "{{ provisioning_network + external_network }}"


### PR DESCRIPTION
With the day-2 capability to manage the provisioning network, it is desirable to always create the provisioning bridge in dev-scripts.