### PR TITLE
Gather rhcos assets using print-stream-json if available

### DIFF
--- a/03_build_installer.sh
+++ b/03_build_installer.sh
@@ -23,7 +23,7 @@ save_release_info ${OPENSHIFT_RELEASE_IMAGE} ${OCP_DIR}
 if [ -z "$KNI_INSTALL_FROM_GIT" ]; then
   # Extract openshift-install from the release image
   extract_installer "${OPENSHIFT_RELEASE_IMAGE}" $OCP_DIR
-  extract_rhcos_json "${OPENSHIFT_RELEASE_IMAGE}" $OCP_DIR
+  ${OPENSHIFT_INSTALLER} coreos print-stream-json 1>/dev/null 2&1 || extract_rhcos_json "${OPENSHIFT_RELEASE_IMAGE}" $OCP_DIR
 else
   # Clone and build the installer from source
   clone_installer

--- a/rhcos.sh
+++ b/rhcos.sh
@@ -1,35 +1,54 @@
-if [[ ! -f "$OCP_DIR/rhcos.json" ]]; then
-  if [[ -v JOB_NAME ]] && [[ "$JOB_NAME" =~ "openshift-installer" ]]; then
-    # Get the SHA from the PR if we're in CI
-    OPENSHIFT_INSTALL_COMMIT=${PULL_PULL_SHA:-$(echo "$JOB_SPEC" | jq -r '.refs.pulls[0].sha')}
-  else
+if $OPENSHIFT_INSTALLER coreos print-stream-json >/dev/null 2>&1; then
+    $OPENSHIFT_INSTALLER coreos print-stream-json > $OCP_DIR/rhcos.json
+    export MACHINE_OS_INSTALLER_IMAGE_URL=$(jq -r '.architectures.x86_64.artifacts.openstack.formats["qcow2.gz"].disk.location' $OCP_DIR/rhcos.json)
+    export MACHINE_OS_INSTALLER_IMAGE_SHA256=$(jq -r '.architectures.x86_64.artifacts.openstack.formats["qcow2.gz"].disk["sha256"]' $OCP_DIR/rhcos.json)
+    export MACHINE_OS_IMAGE_URL=${MACHINE_OS_IMAGE_URL:-${MACHINE_OS_INSTALLER_IMAGE_URL}}
+    export MACHINE_OS_IMAGE_NAME=$(basename ${MACHINE_OS_IMAGE_URL})
+    export MACHINE_OS_IMAGE_SHA256=${MACHINE_OS_IMAGE_SHA256:-${MACHINE_OS_INSTALLER_IMAGE_SHA256}}
+
+    export MACHINE_OS_INSTALLER_BOOTSTRAP_IMAGE_URL=$(jq -r '.architectures.x86_64.artifacts.qemu.formats["qcow2.gz"].disk.location' $OCP_DIR/rhcos.json)
+    export MACHINE_OS_INSTALLER_BOOTSTRAP_IMAGE_SHA256=$(jq -r '.architectures.x86_64.artifacts.qemu.formats["qcow2.gz"].disk["sha256"]' $OCP_DIR/rhcos.json)
+    export MACHINE_OS_BOOTSTRAP_IMAGE_URL=${MACHINE_OS_BOOTSTRAP_IMAGE_URL:-${MACHINE_OS_INSTALLER_BOOTSTRAP_IMAGE_URL}}
+    export MACHINE_OS_BOOTSTRAP_IMAGE_NAME=$(basename ${MACHINE_OS_BOOTSTRAP_IMAGE_URL})
+    export MACHINE_OS_BOOTSTRAP_IMAGE_URL=${MACHINE_OS_BOOTSTRAP_IMAGE_URL:-${MACHINE_OS_INSTALLER_BOOTSTRAP_IMAGE_URL}}
+    export MACHINE_OS_BOOTSTRAP_IMAGE_SHA256=${MACHINE_OS_BOOTSTRAP_IMAGE_SHA256:-${MACHINE_OS_INSTALLER_BOOTSTRAP_IMAGE_SHA256}}
+
+    export MACHINE_OS_INSTALLER_BOOTSTRAP_IMAGE_UNCOMPRESSED_SHA256=$(jq -r '.architectures.x86_64.artifacts.qemu.formats["qcow2.gz"].disk["uncompressed-sha256"]' $OCP_DIR/rhcos.json)
+    export MACHINE_OS_BOOTSTRAP_IMAGE_UNCOMPRESSED_SHA256=${MACHINE_OS_BOOTSTRAP_IMAGE_UNCOMPRESSED_SHA256:-${MACHINE_OS_INSTALLER_BOOTSTRAP_IMAGE_UNCOMPRESSED_SHA256}}
+else
+  if [[ ! -f "$OCP_DIR/rhcos.json" ]]; then
+    if [[ -v JOB_NAME ]] && [[ "$JOB_NAME" =~ "openshift-installer" ]]; then
+      # Get the SHA from the PR if we're in CI
+      OPENSHIFT_INSTALL_COMMIT=${PULL_PULL_SHA:-$(echo "$JOB_SPEC" | jq -r '.refs.pulls[0].sha')}
+    else
+      # Get the git commit that the openshift installer was built from
+      OPENSHIFT_INSTALL_COMMIT=$($OPENSHIFT_INSTALLER version | grep commit | cut -d' ' -f4)
+    fi
+  
     # Get the git commit that the openshift installer was built from
     OPENSHIFT_INSTALL_COMMIT=$($OPENSHIFT_INSTALLER version | grep commit | cut -d' ' -f4)
+  
+    # Get the rhcos.json for that commit
+    OPENSHIFT_INSTALLER_MACHINE_OS=${OPENSHIFT_INSTALLER_MACHINE_OS:-https://raw.githubusercontent.com/openshift/installer/$OPENSHIFT_INSTALL_COMMIT/data/data/rhcos.json}
+  
+    # Get the rhcos.json for that commit, and find the baseURI and openstack image path
+    curl -o $OCP_DIR/rhcos.json "${OPENSHIFT_INSTALLER_MACHINE_OS}"
   fi
-
-  # Get the git commit that the openshift installer was built from
-  OPENSHIFT_INSTALL_COMMIT=$($OPENSHIFT_INSTALLER version | grep commit | cut -d' ' -f4)
-
-  # Get the rhcos.json for that commit
-  OPENSHIFT_INSTALLER_MACHINE_OS=${OPENSHIFT_INSTALLER_MACHINE_OS:-https://raw.githubusercontent.com/openshift/installer/$OPENSHIFT_INSTALL_COMMIT/data/data/rhcos.json}
-
-  # Get the rhcos.json for that commit, and find the baseURI and openstack image path
-  curl -o $OCP_DIR/rhcos.json "${OPENSHIFT_INSTALLER_MACHINE_OS}"
+  
+  export MACHINE_OS_INSTALLER_IMAGE_URL=$(jq -r '.baseURI + .images.openstack.path' $OCP_DIR/rhcos.json)
+  export MACHINE_OS_INSTALLER_IMAGE_SHA256=$(jq -r '.images.openstack.sha256' $OCP_DIR/rhcos.json)
+  export MACHINE_OS_IMAGE_URL=${MACHINE_OS_IMAGE_URL:-${MACHINE_OS_INSTALLER_IMAGE_URL}}
+  export MACHINE_OS_IMAGE_NAME=$(basename ${MACHINE_OS_IMAGE_URL})
+  export MACHINE_OS_IMAGE_SHA256=${MACHINE_OS_IMAGE_SHA256:-${MACHINE_OS_INSTALLER_IMAGE_SHA256}}
+  
+  export MACHINE_OS_INSTALLER_BOOTSTRAP_IMAGE_URL=$(jq -r '.baseURI + .images.qemu.path' $OCP_DIR/rhcos.json)
+  export MACHINE_OS_INSTALLER_BOOTSTRAP_IMAGE_SHA256=$(jq -r '.images.qemu.sha256' $OCP_DIR/rhcos.json)
+  export MACHINE_OS_BOOTSTRAP_IMAGE_URL=${MACHINE_OS_BOOTSTRAP_IMAGE_URL:-${MACHINE_OS_INSTALLER_BOOTSTRAP_IMAGE_URL}}
+  export MACHINE_OS_BOOTSTRAP_IMAGE_NAME=$(basename ${MACHINE_OS_BOOTSTRAP_IMAGE_URL})
+  export MACHINE_OS_BOOTSTRAP_IMAGE_SHA256=${MACHINE_OS_BOOTSTRAP_IMAGE_SHA256:-${MACHINE_OS_INSTALLER_BOOTSTRAP_IMAGE_SHA256}}
+  
+  # FIXME the installer cache expects an uncompressed sha256
+  # https://github.com/openshift/installer/issues/2845
+  export MACHINE_OS_INSTALLER_BOOTSTRAP_IMAGE_UNCOMPRESSED_SHA256=$(jq -r '.images.qemu["uncompressed-sha256"]' $OCP_DIR/rhcos.json)
+  export MACHINE_OS_BOOTSTRAP_IMAGE_UNCOMPRESSED_SHA256=${MACHINE_OS_BOOTSTRAP_IMAGE_UNCOMPRESSED_SHA256:-${MACHINE_OS_INSTALLER_BOOTSTRAP_IMAGE_UNCOMPRESSED_SHA256}}
 fi
-
-export MACHINE_OS_INSTALLER_IMAGE_URL=$(jq -r '.baseURI + .images.openstack.path' $OCP_DIR/rhcos.json)
-export MACHINE_OS_INSTALLER_IMAGE_SHA256=$(jq -r '.images.openstack.sha256' $OCP_DIR/rhcos.json)
-export MACHINE_OS_IMAGE_URL=${MACHINE_OS_IMAGE_URL:-${MACHINE_OS_INSTALLER_IMAGE_URL}}
-export MACHINE_OS_IMAGE_NAME=$(basename ${MACHINE_OS_IMAGE_URL})
-export MACHINE_OS_IMAGE_SHA256=${MACHINE_OS_IMAGE_SHA256:-${MACHINE_OS_INSTALLER_IMAGE_SHA256}}
-
-export MACHINE_OS_INSTALLER_BOOTSTRAP_IMAGE_URL=$(jq -r '.baseURI + .images.qemu.path' $OCP_DIR/rhcos.json)
-export MACHINE_OS_INSTALLER_BOOTSTRAP_IMAGE_SHA256=$(jq -r '.images.qemu.sha256' $OCP_DIR/rhcos.json)
-export MACHINE_OS_BOOTSTRAP_IMAGE_URL=${MACHINE_OS_BOOTSTRAP_IMAGE_URL:-${MACHINE_OS_INSTALLER_BOOTSTRAP_IMAGE_URL}}
-export MACHINE_OS_BOOTSTRAP_IMAGE_NAME=$(basename ${MACHINE_OS_BOOTSTRAP_IMAGE_URL})
-export MACHINE_OS_BOOTSTRAP_IMAGE_SHA256=${MACHINE_OS_BOOTSTRAP_IMAGE_SHA256:-${MACHINE_OS_INSTALLER_BOOTSTRAP_IMAGE_SHA256}}
-
-# FIXME the installer cache expects an uncompressed sha256
-# https://github.com/openshift/installer/issues/2845
-export MACHINE_OS_INSTALLER_BOOTSTRAP_IMAGE_UNCOMPRESSED_SHA256=$(jq -r '.images.qemu["uncompressed-sha256"]' $OCP_DIR/rhcos.json)
-export MACHINE_OS_BOOTSTRAP_IMAGE_UNCOMPRESSED_SHA256=${MACHINE_OS_BOOTSTRAP_IMAGE_UNCOMPRESSED_SHA256:-${MACHINE_OS_INSTALLER_BOOTSTRAP_IMAGE_UNCOMPRESSED_SHA256}}


### PR DESCRIPTION
This allows to use openshift-install coreos print-stream-json if available to gather openstack and qemu images from installer binary