### PR TITLE
[tiny] update README.md with correct CI registry hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Considering that this is a new install on a clean OS, the next tasks should be p
 
 Make a copy of the `config_example.sh` to `config_$USER.sh`.
 
-Go to https://api.ci.openshift.org, click on your name in the top
+Go to https://console-openshift-console.apps.ci.l2s4.p1.openshiftapps.com/, click on your name in the top
 right, copy the login command, extract the token from the command and
 use it to set `CI_TOKEN` in `config_$USER.sh`.
 


### PR DESCRIPTION
I noticed config_example comments and README had a different hostname to get the CI_TOKEN, and validations were checking against the one in config_example.

Signed-off-by: Rohan CJ <rohantmp@gmail.com>