### PR TITLE
[WIP] Bump metal3-dev-env version and disable dnf upgrade

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -24,7 +24,12 @@ if [ -z "${METAL3_DEV_ENV}" ]; then
 fi
 
 # Update to latest packages first
-sudo dnf -y upgrade
+# FIXME(stbenjam): Temporarily disabled. The latest CentOS release has a
+# conflict. This dnf upgrade updates us to gnutls 3.6.14-8.el8_3, but
+# there's not a corresponding update to gnutls-utils yet, it's still
+# stuck at -7. When the metal3-dev-env playbooks later on go to install
+# libvirt which requires gnutls-utils, it fails.
+# sudo dnf -y upgrade
 
 # Install additional repos as needed for each OS version
 # shellcheck disable=SC1091

--- a/common.sh
+++ b/common.sh
@@ -220,6 +220,7 @@ else
   export METAL3_DEV_ENV_PATH="${METAL3_DEV_ENV}"
 fi
 export VM_SETUP_PATH="${METAL3_DEV_ENV_PATH}/vm-setup"
+export CONTAINER_RUNTIME="podman"
 
 export NUM_MASTERS=${NUM_MASTERS:-"3"}
 export NUM_WORKERS=${NUM_WORKERS:-"2"}


### PR DESCRIPTION
This updates metal3-dev-env but comments out the dnf upgrade temporarily. The latest CentOS release has
a conflict. This dnf upgrade updates us to gnutls 3.6.14-8.el8_3, but
there's not a corresponding update to gnutls-utils yet, it's still
stuck at -7. When the metal3-dev-env playbooks later on go to install
libvirt which requires gnutls-utils, it fails:

```
[36mINFO[0m[2021-04-16T00:02:29Z] +(./01_install_requirements.sh:27): main(): sudo dnf -y upgrade
[36mINFO[0m[2021-04-16T00:02:29Z] Last metadata expiration check: 0:00:07 ago on Fri Apr 16 00:01:29 2021.
[36mINFO[0m[2021-04-16T00:02:29Z] Dependencies resolved.
[36mINFO[0m[2021-04-16T00:02:29Z] ================================================================================
[36mINFO[0m[2021-04-16T00:02:29Z]  Package         Architecture    Version                  Repository       Size
[36mINFO[0m[2021-04-16T00:02:29Z] ================================================================================
[36mINFO[0m[2021-04-16T00:02:29Z] Upgrading:
[36mINFO[0m[2021-04-16T00:02:29Z]  gnutls          x86_64          3.6.14-8.el8_3           baseos          1.0 M
[36mINFO[0m[2021-04-16T00:02:29Z]  nettle          x86_64          3.4.1-4.el8_3            baseos          301 k
[36mINFO[0m[2021-04-16T00:02:29Z]
```

Later on in CI we see:

```
[36mINFO[0m[2021-04-16T00:02:29Z] [0;31m    "msg": "Depsolve Error occured: \n Problem 1: package libvirt-6.0.0-28.1.module_el8.3.0+755+88436ea4.x86_64 requires libvirt-client = 6.0.0-28.1.module_el8.3.0+755+88436ea4, but none of the providers can be installed\n  - package libvirt-client-6.0.0-28.1.module_el8.3.0+755+88436ea4.x86_64 requires gnutls-utils, but none of the providers can be installed\n  - conflicting requests\n  - nothing provides gnutls(x86-64) = 3.6.14-7.el8_3 needed by gnutls-utils-3.6.14-7.el8_3.x86_64\n Problem 2: package virt-install-2.2.1-3.el8.noarch requires libvirt-client, but none of the providers can be installed\n  - package libvirt-client-6.0.0-28.1.module_el8.3.0+755+88436ea4.x86_64 requires gnutls-utils, but none of the providers can be installed\n  - conflicting requests\n  - nothing provides gnutls(x86-64) = 3.6.14-7.el8_3 needed by gnutls-utils-3.6.14-7.el8_3.x86_64",[0m
```