### PR TITLE
[WIP] fix deployment with HOST_IP_STACK=v4v6 and IP_STACK=v6

### DIFF
--- a/vm_setup_vars.yml
+++ b/vm_setup_vars.yml
@@ -35,7 +35,17 @@ dns_extrahosts:
       - "ns1"
   - ip: "{{ baremetal_network_cidr | nthhost(1) }}"
     hostnames:
+     - "virthost"
+  - ip: "{{ baremetal_network_cidr_v6 | nthhost(5) }}"
+    hostnames:
+      - "api"
+  - ip: "{{ baremetal_network_cidr_v6 | nthhost(2) }}"
+    hostnames:
+      - "ns1"
+  - ip: "{{ baremetal_network_cidr_v6 | nthhost(1) }}"
+    hostnames:
       - "virthost"
+
 
 provisioning_network:
   - name: "{{ provisioning_network_name  }}"


### PR DESCRIPTION
* ensure that API_VIP and INGRESS_IP get v6 IPs when IP_STACK=v6
* add IPv6 DNS entries in dns_extrahosts

**Maybe don't ok-to-test yet**, ~~two~~ one thing seemed to go wrong:
~~The cluster pull secret only had the local registry creds, so I had to patch it with more stuff.~~ this was because of MIRROR_IMAGES
I  got this at the end:
```
21-04-19 15:11:35 +(./06_create_cluster.sh:55): main(): echo 'Cluster up, you can interact with it via oc --config /home/redhat/dev-scripts/ocp/ostest/auth/kubeconfig <command>'
2021-04-19 15:11:35 Cluster up, you can interact with it via oc --config /home/redhat/dev-scripts/ocp/ostest/auth/kubeconfig <command>
2021-04-19 15:11:35 +(./06_create_cluster.sh:1): main(): auth_template_and_removetmp
2021-04-19 15:11:35 +(utils.sh:504): auth_template_and_removetmp(): generate_auth_template
2021-04-19 15:11:35 +(utils.sh:238): generate_auth_template(): set +x
2021-04-19 15:11:39 PING fd2e:6f44:5dd8:c956::17(fd2e:6f44:5dd8:c956::17) 56 data bytes
2021-04-19 15:11:39 From fd2e:6f44:5dd8:c956::1: icmp_seq=1 Destination unreachable: Address unreachable
2021-04-19 15:11:39 
2021-04-19 15:11:39 --- fd2e:6f44:5dd8:c956::17 ping statistics ---
2021-04-19 15:11:39 1 packets transmitted, 0 received, +1 errors, 100% packet loss, time 0ms
2021-04-19 15:11:39 
2021-04-19 15:11:39 +(utils.sh:505): auth_template_and_removetmp(): removetmp
2021-04-19 15:11:39 +(utils.sh:500): removetmp(): '[' -n ' /tmp/test-token--0zwvJeaMcD' ']'
2021-04-19 15:11:39 +(utils.sh:500): removetmp(): rm -rf /tmp/test-token--0zwvJeaMcD
```


Signed-off-by: Rohan CJ <rohantmp@gmail.com>