### PR TITLE
Add VM_EXTRADISKS_LIST

### DIFF
--- a/config_example.sh
+++ b/config_example.sh
@@ -197,6 +197,13 @@ set -x
 #export WORKER_DISK=20
 #export WORKER_VCPU=4
 
+# Add extradisks to VMs
+# export VM_EXTRADISKS=true
+
+# Configure how many extra disks to add to VMs. Takes a string of disk
+# names delimited by spaces. Example "vdb vde"
+# export VM_EXTRADISKS_LIST="vdb vde"
+
 # Provide additional master/worker ignition configuration, will be
 # merged with the installer provided config, can be used to modify
 # the default nic configuration etc

--- a/vm_setup_vars.yml
+++ b/vm_setup_vars.yml
@@ -9,6 +9,7 @@ ironic_prefix: "{{ ironic_prefix }}"
 # in metal3-dev-env
 num_masters: 3
 num_workers: 1
+extradisks_list: "{{ lookup('env', 'VM_EXTRADISKS_LIST').split(' ') | default(['vdb']) }}"
 flavors:
   master:
     memory: "{{ lookup('env', 'MASTER_MEMORY') | default('16384', true) }}"


### PR DESCRIPTION
Adding VM_EXTRADISKS_LIST to be able to control the names and number of disks created using this option.

- [X] Add VM_EXTRADISKS_LIST as a variable
- [ ] Test adding VM_EXTRADISKS_SIZE as a variable
- [ ] Work through ci test errors