### PR TITLE
Reinstate check for NODES_PLATFORM in assisted cleanup

### DIFF
--- a/assisted_deployment.sh
+++ b/assisted_deployment.sh
@@ -235,8 +235,10 @@ function delete_hive() {
 }
 
 function delete_all() {
-    delete_assisted
-    delete_hive
+    if  [ "$NODES_PLATFORM" = "assisted" ]; then
+        delete_assisted
+        delete_hive
+    fi
 
     # Skipping LocalVolume cleanup on purpose.
 }


### PR DESCRIPTION
This got dropped in a recent change to the assisted scripts and it
causes make clean to always fail on non-assisted deployments.