### PR TITLE
rhcos: don't output fatal error when printing json

### DIFF
--- a/03_build_installer.sh
+++ b/03_build_installer.sh
@@ -23,7 +23,7 @@ save_release_info ${OPENSHIFT_RELEASE_IMAGE} ${OCP_DIR}
 if [ -z "$KNI_INSTALL_FROM_GIT" ]; then
   # Extract openshift-install from the release image
   extract_installer "${OPENSHIFT_RELEASE_IMAGE}" $OCP_DIR
-  ${OPENSHIFT_INSTALLER} coreos print-stream-json 1>/dev/null 2&1 || extract_rhcos_json "${OPENSHIFT_RELEASE_IMAGE}" $OCP_DIR
+  ${OPENSHIFT_INSTALLER} coreos print-stream-json 1>/dev/null 2>&1 || extract_rhcos_json "${OPENSHIFT_RELEASE_IMAGE}" $OCP_DIR
 else
   # Clone and build the installer from source
   clone_installer


### PR DESCRIPTION
There's a missing `>`, so currently `2&1` is treated as an argument to
openshift-install resulting in this error in the CI logs:

```
INFO[2021-04-28T12:40:02Z] time="2021-04-28T11:03:00Z" level=fatal msg="Error executing openshift-install: accepts 0 arg(s), received 1"
```

See: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_ovn-kubernetes/516/pull-ci-openshift-ovn-kubernetes-master-e2e-metal-ipi-ovn-dualstack/1387357685652918272