### PR TITLE
assisted-installer: do not set starting CSV

### DIFF
--- a/assisted_deployment.sh
+++ b/assisted_deployment.sh
@@ -182,7 +182,6 @@ $(subscription_config)
   name: assisted-service-operator
   source: assisted-service-catalog
   sourceNamespace: openshift-marketplace
-  startingCSV: assisted-service-operator.v0.0.1
 EOF
 
   wait_for_crd "agentserviceconfigs.agent-install.openshift.io"


### PR DESCRIPTION
With there being multiple releases of the assisted-service-operator,
starting at v0.0.1 is only going to cause headaches. This removes it
entirely and leaves it up to OLM which version to install first...which
if we set up our manifests correctly should always be the latest.