### PR TITLE
Skip clouds.yaml generation if cluster deployment wasn't fine

### DIFF
--- a/utils.sh
+++ b/utils.sh
@@ -236,6 +236,13 @@ function sync_repo_and_patch {
 
 function generate_auth_template {
     set +x
+
+    numPods=$(oc get pods -n openshift-machine-api -l baremetal.openshift.io/cluster-baremetal-operator=metal3-state -o json | jq '.items | length')
+    if [ "$numPods" -eq '0' ]; then 
+      echo "Metal3 pod not found, skipping clouds.yaml generation"
+      return
+    fi
+
     # clouds.yaml
     OCP_VERSIONS_NOAUTH="4.3 4.4 4.5"
 


### PR DESCRIPTION
`generate_auth_template` is invoked always, also when the cluster deployment didn't work for some reason, thus logging more errors.
This is somehow annoying especially when troubleshooting CI jobs, as the log output becomes more complex to read.