### PR TITLE
Install dualstack connected

### DIFF
--- a/network.sh
+++ b/network.sh
@@ -113,8 +113,6 @@ elif [[ "$IP_STACK" = "v4v6" ]]; then
   export SERVICE_SUBNET_V4=${SERVICE_SUBNET_V4:-"172.30.0.0/16"}
   export SERVICE_SUBNET_V6=${SERVICE_SUBNET_V6:-"fd02::/112"}
   export NETWORK_TYPE=${NETWORK_TYPE:-"OVNKubernetes"}
-  export MIRROR_IMAGES=true
-  export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/local-release-image:latest"
 else
   echo "Unexpected setting for IP_STACK: '${IP_STACK}'"
   exit 1


### PR DESCRIPTION
Dualstack doesn't need to be installed disconnected. This expands the tests that will run on dualstack since we'll run the connected ones too, and it also makes the test a little bit shorter.