### PR TITLE
Set watchAllNamespaces when deploying assisted service

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -207,6 +207,7 @@ export EXTRA_NODES_FILE=${EXTRA_NODES_FILE:-"${WORKING_DIR}/${CLUSTER_NAME}/extr
 NODES_PLATFORM=${NODES_PLATFORM:-"libvirt"}
 BAREMETALHOSTS_FILE=${BAREMETALHOSTS_FILE:-"${OCP_DIR}/baremetalhosts.json"}
 EXTRA_BAREMETALHOSTS_FILE=${EXTRA_BAREMETALHOSTS_FILE:-"${OCP_DIR}/extra_baremetalhosts.json"}
+export BMO_WATCH_ALL_NAMESPACES=${BMO_WATCH_ALL_NAMESPACES:-"false"}
 
 # Optionally set this to a path to use a local dev copy of
 # metal3-dev-env, otherwise it's cloned to $WORKING_DIR

--- a/config_example.sh
+++ b/config_example.sh
@@ -262,3 +262,9 @@ set -x
 # and the Local Storage oeprator. Hive's subscription will be deployed on the `openshift-operators`
 # namespace and the Local Storage in the `openshift-local-storage` one.
 # export ASSISTED_NAMESPACE="assisted-installer"
+
+# Uncomment the following line to have BareMetal Operator
+# watch the BareMetalHosts on all namespaces. Note that
+# setting this variable to true will require more RAM
+# More info here: https://github.com/openshift-metal3/dev-scripts/pull/1241#issuecomment-846067822
+# export BMO_WATCH_ALL_NAMESPACES="true"

--- a/utils.sh
+++ b/utils.sh
@@ -88,6 +88,10 @@ function create_cluster() {
       cp -rf ${ASSETS_EXTRA_FOLDER}/*.yaml ${assets_dir}/openshift/
     fi
 
+    if [[ "$BMO_WATCH_ALL_NAMESPACES" == "true" ]]; then
+        sed -i s/"watchAllNamespaces: false"/"watchAllNamespaces: true"/ "${assets_dir}/openshift/99_baremetal-provisioning-config.yaml"
+    fi
+
     # Preserve the assets for debugging
     mkdir -p "${assets_dir}/saved-assets"
     cp -av "${assets_dir}/openshift" "${assets_dir}/saved-assets"
@@ -246,7 +250,7 @@ function generate_auth_template {
     set +x
 
     numPods=$(oc get pods -n openshift-machine-api -l baremetal.openshift.io/cluster-baremetal-operator=metal3-state -o json | jq '.items | length')
-    if [ "$numPods" -eq '0' ]; then 
+    if [ "$numPods" -eq '0' ]; then
       echo "Metal3 pod not found, skipping clouds.yaml generation"
       return
     fi


### PR DESCRIPTION
I was trying to find a better place for this as I think, for dev-script, it may be beneficial to always set this. I put it in the assisted_deployment script for now as that's the workflow I'm after right now. 

I'd be happy to move this to a more generic place if people think it is worth it.

```
[dev@edge-10 dev-scripts]$ cat config_dev.sh | grep BMO
export BMO_WATCH_ALL_NAMESPACES=true
[dev@edge-10 dev-scripts]$ cat ocp/ostest/saved-assets/openshift/99_baremetal-provisioning-config.yaml | grep watchAll
  watchAllNamespaces: true
[dev@edge-10 dev-scripts]$ oc get provisioning provisioning-configuration -o yaml | grep watchAll
  watchAllNamespaces: true
[dev@edge-10 dev-scripts]$
```

Signed-off-by: Flavio Percoco <flavio@redhat.com>