### PR TITLE
Bug 1966602: Only do the feature-gate override for dual-stack on 4.6 and 4.7

### DIFF
--- a/utils.sh
+++ b/utils.sh
@@ -67,11 +67,9 @@ function create_cluster() {
 
     find assets/generated -name '*.yaml' -exec cp -f {} ${assets_dir}/openshift \;
 
-    if [[ "${IP_STACK}" == "v4v6" ]]; then
-        # The IPv6DualStack feature is not on by default, because it doesn't
-        # fully work yet.  If we're running a dual-stack test environment,
-        # we will turn on the IPv6DualStackNoUpgrade feature set for testing
-        # purposes.
+    if [[ "${IP_STACK}" == "v4v6" && "$OPENSHIFT_VERSION" =~ 4.[67] ]]; then
+        # The IPv6DualStack feature is not on by default in 4.6 and 4.7 and needs
+        # to be manually enabled
         cp assets/ipv6-dual-stack-no-upgrade.yaml ${assets_dir}/openshift/.
     fi
 


### PR DESCRIPTION
On 4.8 and later we don't need to override the default feature gates, and so we shouldn't.

(Currently MCO is assuming that we will, and so it hacks the bootstrap-time kubelet config to include the feature gate, which will then cause problems if you _didn't_ manually set the feature gate, so effectively 4.8 still requires people to manually override the feature gate.)

MCO fix: https://github.com/openshift/machine-config-operator/pull/2580
Whichever one merges first will break dual-stack CI. There is no good way to avoid this.