### PR TITLE
remove workaround of unset XDG_RUNTIME_DIR

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -9,9 +9,6 @@ eval "$(go env)"
 
 export PATH="${GOPATH}/bin:$PATH"
 
-# Workaround for https://github.com/containers/libpod/issues/3463
-unset XDG_RUNTIME_DIR
-
 # Ensure if a go program crashes we get a coredump
 #
 # To get the dump, use coredumpctl:


### PR DESCRIPTION
RHEL 8.2 already having podman >= 1.4.4, so this workaround shouldn't be needed anymore.
/cc @stbenjam 
/hold