### PR TITLE
NO-ISSUE Store artifacts in saved-assets/assisted-installer-manifests

### DIFF
--- a/assisted_deployment.sh
+++ b/assisted_deployment.sh
@@ -19,13 +19,11 @@ ASSISTED_OPENSHIFT_VERSIONS="${ASSISTED_OPENSHIFT_VERSIONS:-}"
 ASSISTED_NAMESPACE="${ASSISTED_NAMESPACE:-assisted-installer}"
 ASSISTED_OPERATOR_INDEX="${ASSISTED_OPERATOR_INDEX:-quay.io/ocpmetal/assisted-service-index:latest}"
 
+ASSETS_DIR="${OCP_DIR}/saved-assets/assisted-installer-manifests"
 
-function deploy_local_storage() {
-  oc adm new-project openshift-local-storage || true
 
-  oc annotate project openshift-local-storage openshift.io/node-selector=''
-
-  cat <<EOF | oc apply -f -
+function generate_local_storage() {
+  cat >"${ASSETS_DIR}/01-local-storage-operator.yaml" <<EOF
 apiVersion: operators.coreos.com/v1alpha2
 kind: OperatorGroup
 metadata:
@@ -47,10 +45,7 @@ spec:
   sourceNamespace: openshift-marketplace
 EOF
 
-  wait_for_crd "localvolumes.local.storage.openshift.io"
-
-  echo "Creating local volume and storage class..."
-  cat <<EOCR | oc apply -f -
+  cat >"${ASSETS_DIR}/02-local-volume.yaml" <<EOCR
 apiVersion: local.storage.openshift.io/v1
 kind: LocalVolume
 metadata:
@@ -82,10 +77,24 @@ EOF
 }
 
 
-function deploy_hive() {
-  echo "Installing Hive..."
+function deploy_local_storage() {
+  oc adm new-project openshift-local-storage || true
 
-  cat <<EOCR | oc apply -f -
+  oc annotate project openshift-local-storage openshift.io/node-selector=''
+
+  generate_local_storage
+
+  echo "Creating local storage operator group and subscription..."
+  oc apply -f "${ASSETS_DIR}/01-local-storage-operator.yaml"
+  wait_for_crd "localvolumes.local.storage.openshift.io"
+
+  echo "Creating local volume and storage class..."
+  oc apply -f "${ASSETS_DIR}/02-local-volume.yaml"
+}
+
+
+function generate_hive() {
+  cat >"${ASSETS_DIR}/03-hive.yaml" <<EOCR
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
@@ -97,6 +106,14 @@ spec:
   source: community-operators
   sourceNamespace: openshift-marketplace
 EOCR
+}
+
+
+function deploy_hive() {
+  echo "Installing Hive..."
+
+  generate_hive
+  oc apply -f "${ASSETS_DIR}/03-hive.yaml"
 
   wait_for_crd "clusterdeployments.hive.openshift.io"
 }
@@ -147,19 +164,15 @@ EOF
 }
 
 
-function deploy_assisted_operator() {
-  echo "Installing assisted-installer operator..."
-
-  cat <<EOF | oc apply -f -
+function generate_assisted_operator() {
+  cat >"${ASSETS_DIR}/04-assisted-service.yaml" <<EOF
 apiVersion: v1
 kind: Namespace
 metadata:
   name: $ASSISTED_NAMESPACE
   labels:
     name: $ASSISTED_NAMESPACE
-EOF
-
-  cat <<EOF | oc apply -f -
+---
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
@@ -168,9 +181,7 @@ metadata:
 spec:
   sourceType: grpc
   image: $ASSISTED_OPERATOR_INDEX
-EOF
-
-  cat <<EOF | oc apply -f -
+---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
@@ -179,9 +190,7 @@ metadata:
 spec:
   targetNamespaces:
     - $ASSISTED_NAMESPACE
-EOF
-
-  cat <<EOF | oc apply -f -
+---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
@@ -197,9 +206,7 @@ $(subscription_config)
   sourceNamespace: openshift-marketplace
 EOF
 
-  wait_for_crd "agentserviceconfigs.agent-install.openshift.io"
-
-  cat <<EOF | oc apply -f -
+  cat >"${ASSETS_DIR}/05-assisted-service-config.yaml" <<EOF
 apiVersion: agent-install.openshift.io/v1beta1
 kind: AgentServiceConfig
 metadata:
@@ -221,16 +228,40 @@ spec:
    requests:
     storage: 8Gi
 EOF
+}
 
+
+function deploy_assisted_operator() {
+  echo "Installing assisted-installer operator..."
+
+  generate_assisted_operator
+
+  oc apply -f "${ASSETS_DIR}/04-assisted-service.yaml"
+  wait_for_crd "agentserviceconfigs.agent-install.openshift.io"
+
+  oc apply -f "${ASSETS_DIR}/05-assisted-service-config.yaml"
+}
+
+
+function patch_extra_host_manifests() {
+  if [ -f "${OCP_DIR}/extra_host_manifests.yaml" ]; then
+    cp "${OCP_DIR}/extra_host_manifests.yaml" "${ASSETS_DIR}/06-extra-host-manifests.yaml"
+    sed -i s/"namespace: openshift-machine-api"/"namespace: ${ASSISTED_NAMESPACE}"/ "${ASSETS_DIR}/06-extra-host-manifests.yaml"
+  fi
 }
 
 function install_assisted_service() {
- # Verify extra disks were created for the nodes
+ mkdir -p "${ASSETS_DIR}"
+ patch_extra_host_manifests
  deploy_local_storage
  deploy_hive
  deploy_assisted_operator
 
  oc wait -n "$ASSISTED_NAMESPACE" --for=condition=Ready pod -l app=assisted-service --timeout=90s
+
+ echo "Installation finished..."
+ echo "For debugging purposes all the manifests have been saved in ${OCP_DIR}/saved-assets/assisted-installer-manifests"
+ echo "Please remember to manually apply BareMetalHost manifest available in the directory above."
 }
 
 function delete_assisted() {


### PR DESCRIPTION
This PR makes the `assisted_deployment.sh` script save all the manifests
into `saved-assets/` so that operators have an ability to inspect them
after (un)successful installation.

The previous behavior was to generate the manifest on fly and pass it
directly to `oc apply`. From now on the manifest will be saved on a
local filesystem and only afterwards applied from the file that has been
created.

This PR creates as well a patched copy of `extra_host_manifests.yaml`
given that the namespace of the created resource must match the
namespace of all the other resources we are creating.