### PR TITLE
Remove ClusterVersion channel

### DIFF
--- a/utils.sh
+++ b/utils.sh
@@ -57,6 +57,10 @@ function create_cluster() {
 
     $OPENSHIFT_INSTALLER --dir "${assets_dir}" --log-level=debug create manifests
 
+    # For CI and nightly releases we need to remove the channel property to
+    # prevent critical alerts.
+    sed -i '/^  channel:/d' "${assets_dir}/manifests/cvo-overrides.yaml"
+
     mkdir -p ${assets_dir}/openshift
     generate_assets
     custom_ntp ${assets_dir}/openshift


### PR DESCRIPTION
CI and nightly releases are not part of the official Red Hat
Cincinnati graphs.  This commit removes the channel property [1],
which will result in the NoChannel condition [2], but will keep the
CVO from attempting to find its current version in the official
Cincinnati [3].  That in turn should keep the CVO from throwing a new,
critical alert [4], which will keep it from running afoul of recent
update e2e logic that forbids critical alerts [5].

See this related PR [6] which does this for other platforms IPI
install step.

[1]: https://github.com/openshift/installer/blob/4eca2efd615f8abd65f576721e2410b19f0d40d0/data/data/manifests/bootkube/cvo-overrides.yaml.template#L8
[2]: https://github.com/openshift/cluster-version-operator/blob/fa452c2d270f1f989f3868ef97ae8cf825713583/docs/user/status.md#nochannel
[3]: https://bugzilla.redhat.com/show_bug.cgi?id=1827378#c4
[4]: openshift/cluster-version-operator#357
[5]: openshift/origin#24786
[6]: https://github.com/openshift/release/pull/8631

Co-authored-by: W. Trevor King <wking@tremily.us>