### PR TITLE
Make assisted_deployment.sh generate useful BMH definition

### DIFF
--- a/assisted_deployment.sh
+++ b/assisted_deployment.sh
@@ -246,7 +246,13 @@ function deploy_assisted_operator() {
 function patch_extra_host_manifests() {
   if [ -f "${OCP_DIR}/extra_host_manifests.yaml" ]; then
     cp "${OCP_DIR}/extra_host_manifests.yaml" "${ASSETS_DIR}/06-extra-host-manifests.yaml"
-    sed -i s/"namespace: openshift-machine-api"/"namespace: ${ASSISTED_NAMESPACE}"/ "${ASSETS_DIR}/06-extra-host-manifests.yaml"
+
+    yq -i -Y '. | select(."kind" == "BareMetalHost") | .metadata += {"namespace":'\"${ASSISTED_NAMESPACE}\"'}' "${ASSETS_DIR}/06-extra-host-manifests.yaml"
+    yq -i -Y '. | select(."kind" == "BareMetalHost") | .metadata.labels += {"infraenvs.agent-install.openshift.io":"myinfraenv"}' "${ASSETS_DIR}/06-extra-host-manifests.yaml"
+    yq -i -Y '. | select(."kind" == "BareMetalHost") | .metadata.annotations += {"inspect.metal3.io":"disabled"}' "${ASSETS_DIR}/06-extra-host-manifests.yaml"
+    yq -i -Y '. | select(."kind" == "BareMetalHost") | .spec += {"automatedCleaningMode":"disabled"}' "${ASSETS_DIR}/06-extra-host-manifests.yaml"
+    echo "---" >> "${ASSETS_DIR}/06-extra-host-manifests.yaml"
+    yq -Y '. | select(."kind" == "Secret") | .metadata += {"namespace":'\"${ASSISTED_NAMESPACE}\"'}' "${OCP_DIR}/extra_host_manifests.yaml" >> "${ASSETS_DIR}/06-extra-host-manifests.yaml"
   fi
 }
 


### PR DESCRIPTION
# Description

This PR makes `assisted_deployment.sh` script generate more useful BMH
definition, i.e. by adding additional labels and annotations which
otherwise would need to be added manually by the operator.

Please note that while the namespace will be configured according to the
namespace where assisted-service is installed (defined in
`config_*.sh`), the `infraenvs.agent-install.openshift.io` labels gets a
sample value of `myinfraenv`. This is because we do not provide an
automatically generated InfraEnv definition, but at the same time we
want the BMH to contain all the fields an operator may need to add
manualy at the later stage.

# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Manual test

assisted_deployment.sh generates now the following file

```
# cat /root/dev-scripts/ocp/ostest/saved-assets/assisted-installer-manifests/06-extra-host-manifests.yaml                                                                                                     
apiVersion: metal3.io/v1alpha1
kind: BareMetalHost
metadata:
  name: ostest-worker-0
  namespace: assisted-installer
  labels:
    infraenvs.agent-install.openshift.io: myinfraenv
  annotations:
    inspect.metal3.io: disabled
spec:
  online: true
  bootMACAddress: 00:44:a7:be:43:c7
  bmc:
    address: red[...]9367                                                                                                                   
    credentialsName: ostest-worker-0-bmc-secret
  automatedCleaningMode: disabled
---
apiVersion: v1
kind: Secret
metadata:
  name: ostest-worker-0-bmc-secret
  namespace: assisted-installer
type: Opaque
data:
  username: Y[...]4=
  password: c[...]Q=
```

# Assignees

/assign @flaper87

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change includes unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
