### PR TITLE
Stop if we fail to retrieve the ci image

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -118,6 +118,10 @@ if [ -z "${OPENSHIFT_RELEASE_IMAGE:-}" ]; then
     LATEST_CI_IMAGE=$(curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OPENSHIFT_VERSION}/release.txt  | grep -o 'quay.io/openshift-release-dev/ocp-release[^"]\+')
   else
     LATEST_CI_IMAGE=$(get_latest_ci_image)
+    if [ -z "$LATEST_CI_IMAGE" ]; then
+      error "No release image found."
+      exit 1
+    fi
   fi
 fi
 export OPENSHIFT_RELEASE_IMAGE="${OPENSHIFT_RELEASE_IMAGE:-$LATEST_CI_IMAGE}"


### PR DESCRIPTION
If we have no release image and retrieving the latest ci image fails,
we can't proceed. If we try to anyway then confusing errors happen.
It's better if we bail out as soon as we know something is wrong so
we can log a message that explains what happened.