### PR TITLE
retry downloading of oc client from mirror.openshift.com

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -63,6 +63,6 @@ if sudo systemctl is-active docker-distribution.service; then
   sudo systemctl disable --now docker-distribution.service
 fi
 
-curl --retry 5 "$OPENSHIFT_CLIENT_TOOLS_URL" | sudo tar -U -C /usr/local/bin -xzf -
+retry_with_timeout 5 60 "curl $OPENSHIFT_CLIENT_TOOLS_URL | sudo tar -U -C /usr/local/bin -xzf -"
 sudo chmod +x /usr/local/bin/oc
 oc version --client -o json

--- a/utils.sh
+++ b/utils.sh
@@ -5,12 +5,12 @@ set -o pipefail
 function retry_with_timeout() {
   retries=$1
   timeout_duration=$2
-  command=${@:3}
+  command=${*:3}
 
-  for i in $(seq $retries); do
+  for _ in $(seq "$retries"); do
     exit_code=0
-    timeout $timeout_duration bash -c "$command" || exit_code=$?
-    if (( $exit_code == 0 )); then
+    timeout "$timeout_duration" bash -c "$command" || exit_code=$?
+    if (( exit_code == 0 )); then
       return 0
     fi
   done

--- a/utils.sh
+++ b/utils.sh
@@ -2,6 +2,22 @@
 
 set -o pipefail
 
+function retry_with_timeout() {
+  retries=$1
+  timeout_duration=$2
+  command=${@:3}
+
+  for i in $(seq $retries); do
+    exit_code=0
+    timeout $timeout_duration bash -c "$command" || exit_code=$?
+    if (( $exit_code == 0 )); then
+      return 0
+    fi
+  done
+
+  return $(( exit_code ))
+}
+
 function generate_assets() {
   rm -rf assets/generated && mkdir assets/generated
   for file in $(find assets/templates/ -iname '*.yaml' -type f -printf "%P\n"); do


### PR DESCRIPTION
We're having those kind of errors in all kinds of jobs:
https://search.ci.openshift.org/?search=OpenSSL+SSL_connect%3A+SSL_ERROR_SYSCALL+in+connection+to+mirror.openshift.com%3A443&maxAge=48h&context=1&type=all&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

I think it will help us deal with those kind of flakes on other places as well, but let's start with the oc installation.