### PR TITLE
Fix make target for Assisted Installer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ default: requirements configure build_installer ironic install_config ocp_run be
 all: default
 
 # Deploy cluster with assisted deployment flow
-assisted: requirements configure assisted_deployment bell
+assisted: assisted_deployment bell
 
 redeploy: ocp_cleanup ironic_cleanup build_installer ironic install_config ocp_run bell
 


### PR DESCRIPTION
`make configure` is not an idempotent action and in the current form
makes it impossible to use `make assisted` without breaking a
deployment, i.e.

```
make
make assisted
```

leaves the environment in a broken state. This PR changes the `assisted`
target so it only executes the installation script for the assisted
service.

Please note it implicitly assumes that the user previously executed
`make all`, however this is not a change in the behaviour as currently
this is also required.