### PR TITLE
Improve script to install assisted-service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,3 +62,6 @@ bell:
 
 assisted_deployment:
 	./assisted_deployment.sh install_assisted_service
+
+assisted_deployment_requirements:
+	./assisted_deployment.sh install_prerequisites_assisted_service


### PR DESCRIPTION
This PR adds additional ways to use `assisted_deployment.sh` so that it
can not only perform a complete installation of the Assisted Service but
can also be used to install only its prerequisites, i.e. LSO and Hive.

This is a useful workflow for development where operator-sdk is used to
install the operator itself, but we don't want to handle the base
requirements manually.