### PR TITLE
Fix image_mirror_config test condition bug

### DIFF
--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -132,8 +132,8 @@ EOF
 }
 
 function additional_trust_bundle() {
-  if [ ! -z "$ADDITIONAL_TRUST_BUNDLE" ]; then
-    if [ -z "${MIRROR_IMAGES}" && -z "${ENABLE_LOCAL_REGISTRY}" ]; then
+  if [[ ! -z "$ADDITIONAL_TRUST_BUNDLE" ]]; then
+    if [[ -z "${MIRROR_IMAGES}" && -z "${ENABLE_LOCAL_REGISTRY}" ]]; then
       echo "additionalTrustBundle: |"
     fi
     awk '{ print " ", $0 }' "${ADDITIONAL_TRUST_BUNDLE}"

--- a/utils.sh
+++ b/utils.sh
@@ -334,9 +334,9 @@ function generate_metal3_config {
 }
 
 function image_mirror_config {
-    if [ ! -z "${MIRROR_IMAGES}" || ! -z "${ENABLE_LOCAL_REGISTRY}" ]; then
+    if [[ ! -z "${MIRROR_IMAGES}" || ! -z "${ENABLE_LOCAL_REGISTRY}" ]]; then
         INDENTED_CERT=$( cat $REGISTRY_DIR/certs/$REGISTRY_CRT | awk '{ print " ", $0 }' )
-        if [ ! -z "${MIRROR_IMAGES}" && ! -s ${MIRROR_LOG_FILE} ]; then
+        if [[ ! -z "${MIRROR_IMAGES}" && ! -s ${MIRROR_LOG_FILE} ]]; then
             . /tmp/mirrored_release_image
             TAGGED=$(echo $MIRRORED_RELEASE_IMAGE | sed -e 's/release://')
             RELEASE=$(echo $MIRRORED_RELEASE_IMAGE | grep -o 'registry.ci.openshift.org[^":\@]\+')


### PR DESCRIPTION
When there is no `MIRROR_IMAGES` or `ENABLE_LOCAL_REGISTRY` environment variables, image_mirror_config function gets an `-z: command not found` error and https://github.com/openshift-metal3/dev-scripts/blob/d3249ae3e97d7a9cb473b17b3e0fab43f27ab6ff/utils.sh#L340 is never executed.

This PR fixes by adding extra brackets to test condition.