### PR TITLE
Update base-image logic

### DIFF
--- a/config_example.sh
+++ b/config_example.sh
@@ -29,6 +29,9 @@ set -x
 # For example:
 # export IRONIC_EXTRA_PACKAGES=ironic-extra-pkgs.txt
 
+# Uncomment this to build a custom base image for ironic images
+# export CUSTOM_BASE_IMAGE=true
+
 # Set this variable to point the custom base image to a different location
 # It can be an absolute path or a local path under the dev-scripts dir
 # export BASE_IMAGE_DIR=base-image


### PR DESCRIPTION
Introduce a variable to explicitly trigger the build of a custom base
image for the ironic images.
Do not make that depends from the CUSTOM_REPO_FILE variable anymore.
The CUSTOM_REPO_FILE is not mandatory anymore to build a custom base
image.
Also a custom base image is not required anymore to build local images as
the openshift base images are pullable from the openshift registry.