### PR TITLE
Configure an NTP server for dev-scripts cluster

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -54,6 +54,11 @@ if [[ ! -z "${MIRROR_IMAGES}" || $(env | grep "_LOCAL_IMAGE=")  || ! -z "${ENABL
     setup_local_registry
 fi
 
+# Configure an NTP server for use by the cluster, this is especially
+# important on IPv6 where the cluster doesn't have outbound internet
+# access.
+configure_chronyd
+
 ansible-playbook \
     -e @vm_setup_vars.yml \
     -e "ironic_prefix=${CLUSTER_NAME}_" \

--- a/ocp_cleanup.sh
+++ b/ocp_cleanup.sh
@@ -64,3 +64,7 @@ done
 if [ -d assets/generated ]; then
   rm -rf assets/generated
 fi
+
+# Cleanup chrony configuration
+sudo sed -ie '/^allow /d' /etc/chrony.conf
+


### PR DESCRIPTION
Currently, IPv6 clusters do not synchronize their time with NTP because
there's no external internet access. This is causing a newly enabled
test to fail (`[sig-apps] [Feature:TTLAfterFinished] job should be deleted once it finishes after TTL seconds`).