### PR TITLE
Don't reload firewalld during chronyd config

### DIFF
--- a/utils.sh
+++ b/utils.sh
@@ -54,10 +54,11 @@ function configure_chronyd() {
   if [ "$MANAGE_BR_BRIDGE" == "y" ];
   then
     sudo firewall-cmd --permanent --zone=libvirt --add-service=ntp
+    sudo firewall-cmd --zone=libvirt --add-service=ntp
   else
     sudo firewall-cmd --permanent --add-service=ntp
+    sudo firewall-cmd --add-service=ntp
   fi
-  sudo firewall-cmd --reload
 }
 
 function custom_ntp(){


### PR DESCRIPTION
This was added in #1274 but doing this drops all the libvirt chains,
which causes subsequent ansible libvirt setup tasks to fail.

(I'm not entirely sure why this didn't fail CI)