### PR TITLE
Enable alternative CI_SERVER login

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ other components of OpenShift via support for a baremetal platform type.
 - ideally on a bare metal host with at least 64G of RAM
 - run as a user with passwordless sudo access
 - get a valid pull secret (json string) from https://cloud.redhat.com/openshift/install/pull-secret
-- get a login token from https://api.ci.openshift.org
+- get a login token from console-openshift-console.apps.ci.l2s4.p1.openshiftapps.com
 
 # Instructions
 

--- a/common.sh
+++ b/common.sh
@@ -277,6 +277,7 @@ export PULL_SECRET_FILE=${PULL_SECRET_FILE:-$WORKING_DIR/pull_secret.json}
 set +x
 export CI_TOKEN=${CI_TOKEN:-}
 set -x
+export CI_SERVER=${CI_SERVER:-api.ci.l2s4.p1.openshiftapps.com}
 export PERSONAL_PULL_SECRET=${PERSONAL_PULL_SECRET:-$SCRIPTDIR/pull_secret.json}
 
 # Ensure working dir is always different than script dir. If not, some

--- a/config_example.sh
+++ b/config_example.sh
@@ -7,6 +7,10 @@ set +x
 export CI_TOKEN=''
 set -x
 
+# When testing e.g cluster-bot builds, you must change CI_TOKEN to one
+# from a different cluster, in which case this should be updated
+#export CI_SERVER=api.ci.l2s4.p1.openshiftapps.com
+
 # Select a different release stream from which to pull the latest image, if the
 # image name is not specified
 #export OPENSHIFT_RELEASE_STREAM=4.8

--- a/utils.sh
+++ b/utils.sh
@@ -518,7 +518,7 @@ function write_pull_secret() {
     # Get a current pull secret for registry.ci.openshift.org using the token
     tmpkubeconfig=$(mktemp --tmpdir "kubeconfig--XXXXXXXXXX")
     _tmpfiles="$_tmpfiles $tmpkubeconfig"
-    oc login https://api.ci.l2s4.p1.openshiftapps.com:6443 --kubeconfig=$tmpkubeconfig --token=${CI_TOKEN}
+    oc login https://${CI_SERVER}:6443 --kubeconfig=$tmpkubeconfig --token=${CI_TOKEN}
     tmppullsecret=$(mktemp --tmpdir "pullsecret--XXXXXXXXXX")
     _tmpfiles="$_tmpfiles $tmppullsecret"
     oc registry login --kubeconfig=$tmpkubeconfig --to=$tmppullsecret

--- a/validation.sh
+++ b/validation.sh
@@ -85,7 +85,7 @@ function early_deploy_validation() {
     if [ ${#CI_TOKEN} != 0 -a ${LOGIN_CHECK} == "true" ]; then
         _test_token=$(mktemp --tmpdir "test-token--XXXXXXXXXX")
         _tmpfiles="$_tmpfiles $_test_token"
-        if ! oc login https://api.ci.l2s4.p1.openshiftapps.com:6443 --kubeconfig=$_test_token --token=${CI_TOKEN}; then
+        if ! oc login https://${CI_SERVER}:6443 --kubeconfig=$_test_token --token=${CI_TOKEN}; then
             error "Please login to https://console-openshift-console.apps.ci.l2s4.p1.openshiftapps.com/ and copy the token from the login command from the menu in the top right corner to set CI_TOKEN."
             error "Refer to https://github.com/openshift-metal3/dev-scripts#configuration for details."
             exit 1


### PR DESCRIPTION
When testing cluster-bot builds, the server (and CI_TOKEN) is
different, so it's necessary to modify the server login URL from
that used for regular CI builds.