### PR TITLE
WIP: Disable chrony for connected jobs to test

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -57,7 +57,9 @@ fi
 # Configure an NTP server for use by the cluster, this is especially
 # important on IPv6 where the cluster doesn't have outbound internet
 # access.
-configure_chronyd
+if [[ ! -z "${MIRROR_IMAGES}" ]]; then
+  configure_chronyd
+fi
 
 ansible-playbook \
     -e @vm_setup_vars.yml \

--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -57,7 +57,7 @@ fi
 # Configure an NTP server for use by the cluster, this is especially
 # important on IPv6 where the cluster doesn't have outbound internet
 # access.
-if [[ ! -z "${MIRROR_IMAGES}" ]]; then
+if [[ -n "${MIRROR_IMAGES}" ]]; then
   configure_chronyd
 fi
 

--- a/ocp_cleanup.sh
+++ b/ocp_cleanup.sh
@@ -65,7 +65,7 @@ if [ -d assets/generated ]; then
   rm -rf assets/generated
 fi
 
-if [[ ! -z "${MIRROR_IMAGES}" ]]; then
+if [[ -n "${MIRROR_IMAGES}" ]]; then
   # Cleanup chrony configuration
   sudo sed -ie '/^allow /d' /etc/chrony.conf
 fi

--- a/ocp_cleanup.sh
+++ b/ocp_cleanup.sh
@@ -65,6 +65,8 @@ if [ -d assets/generated ]; then
   rm -rf assets/generated
 fi
 
-# Cleanup chrony configuration
-sudo sed -ie '/^allow /d' /etc/chrony.conf
+if [[ ! -z "${MIRROR_IMAGES}" ]]; then
+  # Cleanup chrony configuration
+  sudo sed -ie '/^allow /d' /etc/chrony.conf
+fi
 

--- a/utils.sh
+++ b/utils.sh
@@ -102,7 +102,7 @@ function create_cluster() {
     mkdir -p ${assets_dir}/openshift
     generate_assets
 
-    if [ -z "${NTP_SERVERS}" ];
+    if [[ ! -z "${MIRROR_IMAGES}" && -z "${NTP_SERVERS}" ]];
     then
       export NTP_SERVERS="$PROVISIONING_HOST_EXTERNAL_IP"
     fi

--- a/utils.sh
+++ b/utils.sh
@@ -102,7 +102,7 @@ function create_cluster() {
     mkdir -p ${assets_dir}/openshift
     generate_assets
 
-    if [[ ! -z "${MIRROR_IMAGES}" && -z "${NTP_SERVERS}" ]];
+    if [[ -n "${MIRROR_IMAGES}" && -z "${NTP_SERVERS}" ]];
     then
       export NTP_SERVERS="$PROVISIONING_HOST_EXTERNAL_IP"
     fi


### PR DESCRIPTION
e2e-metal-ipi jobs are failing in waterfall pattern. In logs, there are apiserver restarts, handshake failures, etcd connection errors, just a hypothesis triggering e2e-metal-ipi jobs after disabling chrony.