### PR TITLE
Ensure firewalld is running early enough

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -54,6 +54,8 @@ if [[ ! -z "${MIRROR_IMAGES}" || $(env | grep "_LOCAL_IMAGE=")  || ! -z "${ENABL
     setup_local_registry
 fi
 
+sudo systemctl enable --now firewalld
+
 # Configure an NTP server for use by the cluster, this is especially
 # important on IPv6 where the cluster doesn't have outbound internet
 # access.
@@ -91,7 +93,6 @@ if [ ${NUM_EXTRA_WORKERS} -ne 0 ]; then
 fi
 
 ZONE="\nZONE=libvirt"
-sudo systemctl enable --now firewalld
 
 # Allow local non-root-user access to libvirt
 # Restart libvirtd service to get the new group membership loaded


### PR DESCRIPTION
Trying to bring up a cluster on a fresh CentOS 8 host, it errors out trying to run `sudo firewall-cmd --permanent --zone=libvirt --add-service=ntp` because firewalld isn't running. The script ensures firewalld is running (#970) but that happens _after_ the new chronyd config stuff that tries to modify the firewall (#1274).

I don't know why this isn't breaking anyone else? Reusing existing hosts rather than creating fresh ones? Additional setup scripts that enable firewalld?