### PR TITLE
Bump go version to 1.16

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -47,7 +47,7 @@ ansible-galaxy collection install ansible.netcommon ansible.posix
 ANSIBLE_FORCE_COLOR=true ansible-playbook \
   -e "working_dir=$WORKING_DIR" \
   -e "virthost=$HOSTNAME" \
-  -e "go_version=1.14.4" \
+  -e "go_version=1.16.7" \
   -i vm-setup/inventory.ini \
   -b -vvv vm-setup/install-package-playbook.yml
 popd


### PR DESCRIPTION
Since https://github.com/openshift/installer/pull/5120
we need >=1.16 to build the installer from source