### PR TITLE
Bump go_version to 1.17.1

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -47,7 +47,7 @@ ansible-galaxy collection install ansible.netcommon ansible.posix community.gene
 ANSIBLE_FORCE_COLOR=true ansible-playbook \
   -e "working_dir=$WORKING_DIR" \
   -e "virthost=$HOSTNAME" \
-  -e "go_version=1.14.4" \
+  -e "go_version=1.17.1" \
   -i vm-setup/inventory.ini \
   -b -vvv vm-setup/install-package-playbook.yml
 popd

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/openshift-metal3/dev-scripts/metal3-templater
+
+go 1.17
+
+require (
+	github.com/apparentlymart/go-cidr v1.1.0
+	github.com/openshift/installer v0.16.1
+)
+
+require github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/apparentlymart/go-cidr v1.1.0 h1:2mAhrMoF+nhXqxTzSZMUzDHkLjmIHC+Zzn4tdgBZjnU=
+github.com/apparentlymart/go-cidr v1.1.0/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=
+github.com/openshift/installer v0.16.1 h1:PmjALN9x1NVNVi3SCqfz0ZwVCgOkQLQWo2nHYXREq/A=
+github.com/openshift/installer v0.16.1/go.mod h1:VWGgpJgF8DGCKQjbccnigglhZnHtRLCZ6cxqkXN4Ck0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
baremetal-operator depends on 1.16, and there is no reason to not use
the latest