### PR TITLE
Clear spec.channel other than OPENSHIFT_RELEASE_TYPE ga

### DIFF
--- a/utils.sh
+++ b/utils.sh
@@ -99,9 +99,11 @@ function create_cluster() {
 
     $OPENSHIFT_INSTALLER --dir "${assets_dir}" --log-level=debug create manifests
 
-    # For CI and nightly releases we need to remove the channel property to
-    # prevent critical alerts.
-    sed -i '/^  channel:/d' "${assets_dir}/manifests/cvo-overrides.yaml"
+    if [[ "$OPENSHIFT_RELEASE_TYPE" != "ga" ]]; then
+      # For CI and nightly releases we need to remove the channel property to
+      # prevent critical alerts.
+      sed -i '/^  channel:/d' "${assets_dir}/manifests/cvo-overrides.yaml"
+    fi
 
     mkdir -p ${assets_dir}/openshift
     generate_assets


### PR DESCRIPTION
This PR adds condition to prevent spec.channel clear when
`OPENSHIFT_RELEASE_TYPE ` is `ga`. spec.channel is cleared for
only release types `ci` and `nightly`.