### PR TITLE
Add ability to inject static ips into install-config

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -19,7 +19,7 @@ if [ -z "${METAL3_DEV_ENV}" ]; then
   # TODO -- come up with a plan for continuously updating this
   # Note we only do this in the case where METAL3_DEV_ENV is
   # unset, to enable developer testing of local checkouts
-  git reset ee1b2fec44e22700c8d250d5e0e371e3fd0aba17 --hard
+  #git reset 67afcb3315b44e2c68121493a819819966e588a2 --hard
   popd
 fi
 

--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -81,6 +81,7 @@ ansible-playbook \
     -e "virtualbmc_base_port=$VBMC_BASE_PORT" \
     -e "master_hostname_format=$MASTER_HOSTNAME_FORMAT" \
     -e "worker_hostname_format=$WORKER_HOSTNAME_FORMAT" \
+    -e "virsh_dhcp_enabled=$DHCP_ENABLED" \
     -i ${VM_SETUP_PATH}/inventory.ini \
     -b -vvv ${VM_SETUP_PATH}/setup-playbook.yml
 

--- a/common.sh
+++ b/common.sh
@@ -56,11 +56,22 @@ export CLUSTER_NAME=${CLUSTER_NAME:-ostest}
 
 export PROVISIONING_NETWORK_PROFILE=${PROVISIONING_NETWORK_PROFILE:-"Managed"}
 
+# Set to 1 if you want dev scripts to configure static IPs for your deployment.
+export STATIC_IPS=${STATIC_IPS:-""}
+# Set to false to disable DHCP on all networks.
+export DHCP_ENABLED=${DHCP_ENABLED:-"true"}
+
 # Network interface names can only be 15 characters long, so
 # abbreviate provisioning and baremetal and add them as suffixes to
 # the cluster name.
 export PROVISIONING_NETWORK_NAME=${PROVISIONING_NETWORK_NAME:-${CLUSTER_NAME}pr}
 export BAREMETAL_NETWORK_NAME=${BAREMETAL_NETWORK_NAME:-${CLUSTER_NAME}bm}
+
+if [[ "$PROVISIONING_NETWORK_PROFILE" == "Disabled" ]]; then
+    export PROVISIONING_NETWORK_INTERFACE="enp2s1"
+else
+    export PROVISIONING_NETWORK_INTERFACE="enp2s0"
+fi
 
 export BASE_DOMAIN=${BASE_DOMAIN:-test.metalkube.org}
 export CLUSTER_DOMAIN="${CLUSTER_NAME}.${BASE_DOMAIN}"
@@ -157,7 +168,7 @@ else
   export BMC_DRIVER=${BMC_DRIVER:-mixed}
 fi
 
-if [[ "$PROVISIONING_NETWORK_PROFILE" == "Disabled" ]]; then
+if [[ "$PROVISIONING_NETWORK_PROFILE" == "Disabled" || -n "$STATIC_IPS" ]]; then
   export BMC_DRIVER="redfish-virtualmedia"
 fi
 

--- a/utils.sh
+++ b/utils.sh
@@ -241,7 +241,41 @@ function node_map_to_install_config_hosts() {
           disableCertificateVerification: ${disable_certificate_verification}
         bootMACAddress: ${mac}
         bootMode: ${boot_mode}
+        networkConfig:
+          routes:
+            config:
+            - destination: 0.0.0.0/0
+              next-hop-address: ${PROVISIONING_HOST_EXTERNAL_IP}
+              next-hop-interface: ${PROVISIONING_NETWORK_INTERFACE}
+          dns-resolver:
+            config:
+              search:
+              - ostest.test.metalkube.org
+              server:
+              - ${PROVISIONING_HOST_EXTERNAL_IP}
+          interfaces:
+          - name: ${PROVISIONING_NETWORK_INTERFACE}
+            type: ethernet
+            state: up
 EOF
+      if [[ "$IP_STACK" = "v4" || "$IP_STACK" = "v4v6" ]]; then
+      cat << EOF
+            ipv4:
+              address:
+              - ip: $(nth_ip $EXTERNAL_SUBNET_V4 $((idx + 10)))
+                prefix-length: $(ipcalc --prefix $EXTERNAL_SUBNET_V4 | cut -d= -f2)
+              enabled: true
+EOF
+      fi
+      if [[ "$IP_STACK" = "v6" || "$IP_STACK" = "v4v6" ]]; then
+      cat << EOF
+            ipv6:
+              address:
+              - ip: $(nth_ip $EXTERNAL_SUBNET_V6 $((idx + 10)))
+                prefix-length: $(ipcalc --prefix $EXTERNAL_SUBNET_V6 | cut -d= -f2)
+              enabled: true
+EOF
+      fi
 
         # FIXME(stbenjam) Worker code in installer should accept
         # "default" as well -- currently the mapping doesn't work,

--- a/vm_setup_vars.yml
+++ b/vm_setup_vars.yml
@@ -51,6 +51,8 @@ provisioning_network:
     bridge: "{{ provisioning_network_name  }}"
     forward_mode: bridge
 
+virsh_dhcp_enabled: "{{ lookup('env', 'DHCP_ENABLED')|default('', true) }}"
+
 external_network:
   - name: "{{ baremetal_network_name }}"
     bridge: "{{ baremetal_network_name }}"
@@ -59,6 +61,7 @@ external_network:
     netmask_v4: "{{ baremetal_network_cidr_v4|ipaddr('netmask') }}"
     address_v6: "{{ baremetal_network_cidr_v6|nthhost(1)|default('', true) }}"
     prefix_v6: "{{ baremetal_network_cidr_v6|ipaddr('prefix') }}"
+    dhcp_enabled: "{{ virsh_dhcp_enabled|bool }}"
     dhcp_range_v4:
       - "{{ baremetal_network_cidr_v4|nthhost(20) }}"
       - "{{ baremetal_network_cidr_v4|nthhost(60) }}"


### PR DESCRIPTION
Set up a STATIC_IPS configuration flag that configures dev-scripts
to use static IPs (v4 and/or v6) for the baremetal network.

Co-Authored-By: Caleb Boylan <cboylan@redhat.com>