### PR TITLE
Update metal3-dev-env pin, and ansible/python version

### DIFF
--- a/network.sh
+++ b/network.sh
@@ -4,7 +4,7 @@ function nth_ip() {
   network=$1
   idx=$2
 
-  python -c "from ansible.plugins.filter import ipaddr; print(ipaddr.nthhost('"$network"', $idx))"
+  python -c "from ansible_collections.ansible.netcommon.plugins.filter import ipaddr; print(ipaddr.nthhost('"$network"', $idx))"
 }
 
 


### PR DESCRIPTION
Currently switching between dev-scripts and metal3-dev-env is inconvenient
because metal3-dev-env requires a much newer ansible version than we have
packaged (at least in the RHEL case)

Newer ansible also requires python 3.8+ (which is available along with 3.9,
but the default is 3.6)

So, update to install ansible pinned to the same version as metal3-dev-env
via pip, also upgrade python and set alternatives to use the newer version.