### PR TITLE
Enable EPEL repo on RHEL8

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -37,6 +37,9 @@ export DISTRO="${ID}${VERSION_ID%.*}"
 if [[ $DISTRO == "centos8" ]]; then
     sudo dnf -y install epel-release dnf --enablerepo=extras
 elif [[ $DISTRO == "rhel8" ]]; then
+    # Enable EPEL for python3-passlib and python3-bcrypt required by metal3-dev-env
+    sudo dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+
     # The packaged 2.x ansible is too old for compatibility with metal3-dev-env
     sudo dnf erase -y ansible
     sudo subscription-manager repos --disable=ansible-2-for-rhel-8-x86_64-rpms


### PR DESCRIPTION
A metal3-dev-env change ([Enable authentication in sushy-tools](https://github.com/metal3-io/metal3-dev-env/pull/798)) added a requirement for python3-passlib and python3-bcrypt.

Apparently these aren't available in RHEL and some folks on slack have been workinga around this by using EPEL. They are also available in OSP 16 repos.