### PR TITLE
Add support for additional networks

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -19,13 +19,13 @@ if [ -z "${METAL3_DEV_ENV}" ]; then
   # TODO -- come up with a plan for continuously updating this
   # Note we only do this in the case where METAL3_DEV_ENV is
   # unset, to enable developer testing of local checkouts
-  git reset 67afcb3315b44e2c68121493a819819966e588a2 --hard
+  git reset ee1b2fec44e22700c8d250d5e0e371e3fd0aba17 --hard
   popd
 fi
 
 # This must be aligned with the metal3-dev-env pinned version above, see
 # https://github.com/metal3-io/metal3-dev-env/blob/master/lib/common.sh
-export ANSIBLE_VERSION=${ANSIBLE_VERSION:-"4.6.0"}
+export ANSIBLE_VERSION=${ANSIBLE_VERSION:-"4.8.0"}
 
 # Update to latest packages first
 sudo dnf -y upgrade

--- a/vm_setup_vars.yml
+++ b/vm_setup_vars.yml
@@ -75,5 +75,3 @@ external_network:
       forwarders:
         - domain: "apps.{{ cluster_domain }}"
           addr: "127.0.0.1"
-
-networks: "{{ provisioning_network + external_network }}"


### PR DESCRIPTION
This allows additional networks to be defined e.g

```
export EXTRA_NETWORK_NAMES="nmstate1 nmstate2"
export NMSTATE1_NETWORK_SUBNET_V4='192.168.221.0/24'
export NMSTATE1_NETWORK_SUBNET_V6='fd2e:6f44:5dd8:ca56::/120'
export NMSTATE2_NETWORK_SUBNET_V4='192.168.222.0/24'
export NMSTATE2_NETWORK_SUBNET_V6='fd2e:6f44:5dd8:cc56::/120'
```

Requires ansible role changes added via

https://github.com/metal3-io/metal3-dev-env/pull/852