### PR TITLE
Fix metallb script that's running E2E tests

### DIFF
--- a/metallb/run_e2e.sh
+++ b/metallb/run_e2e.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/bash
 
+metallb_dir="$(dirname $(readlink -f $0))"
+source ${metallb_dir}/metallb_common.sh
+
 export METALLB_REPO=${METALLB_REPO:-https://github.com/metallb/metallb.git}
 [[ -d /usr/local/go ]] && export PATH=${PATH}:/usr/local/go/bin
 
@@ -15,16 +18,25 @@ sudo firewall-cmd --zone=libvirt --permanent --add-port=180/tcp
 sudo firewall-cmd --zone=libvirt --add-port=180/tcp
 
 SKIP="none"
-if [ "${IP_STACK}" = "v4" ]; then SKIP="${SKIP}\|IPV6"; fi
-if [ "${IP_STACK}" = "dual" ]; then SKIP="${SKIP}\|IPV6"; fi
-if [ "${IP_STACK}" = "v6" ]; then SKIP="${SKIP}\|IPV4\|BGP"; fi
+if [ "${IP_STACK}" = "v4" ]; then
+	SKIP="$SKIP\|IPV6\|DUALSTACK"
+	export PROVISIONING_HOST_EXTERNAL_IPV4=${PROVISIONING_HOST_EXTERNAL_IP}
+	export PROVISIONING_HOST_EXTERNAL_IPV6=1111:1:1::1
+elif [ "${IP_STACK}" = "v6" ]; then
+	SKIP="$SKIP\|IPV4\|DUALSTACK"
+	export PROVISIONING_HOST_EXTERNAL_IPV6=${PROVISIONING_HOST_EXTERNAL_IP}
+	export PROVISIONING_HOST_EXTERNAL_IPV4=1.1.1.1
+elif [ "${IP_STACK}" = "v4v6" ]; then
+	SKIP="$SKIP\|IPV6"
+	export PROVISIONING_HOST_EXTERNAL_IPV4=${PROVISIONING_HOST_EXTERNAL_IP}
+	export PROVISIONING_HOST_EXTERNAL_IPV6=1111:1:1::1
+fi
 echo "Skipping ${SKIP}"
 
 pip3 install --user -r ./dev-env/requirements.txt
 export PATH=${PATH}:${HOME}/.local/bin
 export CONTAINER_RUNTIME=podman
 export RUN_FRR_CONTAINER_ON_HOST_NETWORK=true
-export PROVISIONING_HOST_EXTERNAL_IPV4=${PROVISIONING_HOST_EXTERNAL_IP}
 inv e2etest --kubeconfig=$(readlink -f ../../ocp/ostest/auth/kubeconfig) \
 	--service-pod-port=8080 --system-namespaces="metallb-system" --skip-docker \
 	--ipv4-service-range=192.168.10.0/24 --ipv6-service-range=fc00:f853:0ccd:e799::/124 \


### PR DESCRIPTION
1. We need to source the metallb common.sh file to get the
network settings of the cluster to set the provisioning
host IP variable passed to the E2E tests.

2. Setting the dual stack name to 'v4v6' as this is the
setup in the dev-scripts, and not 'dual'.

3. Set the provisioning host IP according to the cluster IP family.

4. Skip dual stack tests according to the cluster IP family.

5. Set dummy IP for the unsued host IP, the host IPV4 or IPV6
according to the cluster IP family.