### PR TITLE
Store extraworkers info in a secret

### DIFF
--- a/06_create_cluster.sh
+++ b/06_create_cluster.sh
@@ -58,6 +58,11 @@ if [[ -n "${APPLY_EXTRA_WORKERS}" ]]; then
     fi
 fi
 
+# Create a secret containing extraworkers info for the e2e tests
+if [[ ${NUM_EXTRA_WORKERS} -ne 0 && -d "${OCP_DIR}/extras" ]]; then
+    oc create secret generic extraworkers-secret --from-file="${OCP_DIR}/extras/" -n openshift-machine-api
+fi
+
 if [[ ! -z "${ENABLE_METALLB}" ]]; then
 
 	if [[ -z ${METALLB_IMAGE_BASE} ]]; then


### PR DESCRIPTION
This patch stores the yaml generated for the extra workers in a secret, so that [e2e baremetal tests](https://github.com/openshift/origin/tree/master/test/extended/baremetal) could use it to dynamically add/delete extra workers when required