### PR TITLE
Get CoreOS data from stream

### DIFF
--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -87,7 +87,7 @@ function build_installer() {
   cd $OPENSHIFT_INSTALL_PATH
   TAGS="libvirt baremetal" hack/build.sh
   popd
-  cp "$OPENSHIFT_INSTALL_PATH/data/data/rhcos.json" "$OCP_DIR"
+  "$OPENSHIFT_INSTALL_PATH/bin/openshift-install" coreos print-stream-json >"$OCP_DIR/rhcos.json" || cp "$OPENSHIFT_INSTALL_PATH/data/data/rhcos.json" "$OCP_DIR"
 }
 
 function baremetal_network_configuration() {


### PR DESCRIPTION
The file `data/data/rhcos.json` [no longer exists](https://github.com/openshift/installer/pull/5252) (replaced by
`data/data/coreos/rhcos.json`). If the installer binary is able to output
the new (stream) file, use that. Only fall back to using the old file
for older releases.