### PR TITLE
MetalLB E2E tests: Fix skip flag

### DIFF
--- a/metallb/run_e2e.sh
+++ b/metallb/run_e2e.sh
@@ -42,4 +42,4 @@ export RUN_FRR_CONTAINER_ON_HOST_NETWORK=true
 inv e2etest --kubeconfig=$(readlink -f ../../ocp/ostest/auth/kubeconfig) \
 	--service-pod-port=8080 --system-namespaces="metallb-system" --skip-docker \
 	--ipv4-service-range=192.168.10.0/24 --ipv6-service-range=fc00:f853:0ccd:e799::/124 \
-	--skip=${SKIP}
+	--skip="${SKIP}"


### PR DESCRIPTION
This is done to fix the following error:

```
skip="L2' 'metrics"\|IPV6\|DUALSTACK'
No idea what 'metrics"\\|IPV6\\|DUALSTACK' is!
make: Leaving directory '/root/dev-scripts/metallb'
make: *** [Makefile:19: run_e2e] Error 1

```
As there are spaces in the skip string variable we need to put double quotes on it.