### PR TITLE
MetalLB E2E tests: Add use-operator flag

### DIFF
--- a/metallb/run_e2e.sh
+++ b/metallb/run_e2e.sh
@@ -46,4 +46,4 @@ export RUN_FRR_CONTAINER_ON_HOST_NETWORK=true
 inv e2etest --kubeconfig=$(readlink -f ../../ocp/ostest/auth/kubeconfig) \
 	--service-pod-port=8080 --system-namespaces="metallb-system" --skip-docker \
 	--ipv4-service-range=192.168.10.0/24 --ipv6-service-range=fc00:f853:0ccd:e799::/124 \
-	--skip="${SKIP}" -e "${TESTS_REPORTS_PATH}"
+	--skip="${SKIP}" --use-operator -e "${TESTS_REPORTS_PATH}"


### PR DESCRIPTION
Adding the flag to support the last change in the operator, as we are deploying MetalLB here through the operator.

In the new operator configuration the operator takes control of the ConfigMap, meaning if an external thing (like the e2e tests) changes the ConfigMap the Operator will reconcile it to what it thinks it should be - making the e2e tests useless.