### PR TITLE
MetalLB: open BFD ports

### DIFF
--- a/metallb/run_e2e.sh
+++ b/metallb/run_e2e.sh
@@ -20,6 +20,15 @@ sudo firewall-cmd --zone=libvirt --permanent --add-port=179/tcp
 sudo firewall-cmd --zone=libvirt --add-port=179/tcp
 sudo firewall-cmd --zone=libvirt --permanent --add-port=180/tcp
 sudo firewall-cmd --zone=libvirt --add-port=180/tcp
+# BFD control packets
+sudo firewall-cmd --zone=libvirt --permanent --add-port=3784/udp
+sudo firewall-cmd --zone=libvirt --add-port=3784/udp
+# BFD echo packets
+sudo firewall-cmd --zone=libvirt --permanent --add-port=3785/udp
+sudo firewall-cmd --zone=libvirt --add-port=3785/udp
+# BFD multihop packets
+sudo firewall-cmd --zone=libvirt --permanent --add-port=4784/udp
+sudo firewall-cmd --zone=libvirt --add-port=4784/udp
 
 # need to skip L2 metrics test because the pod that's running the tests is not in the
 # same subnet of the cluster nodes, so the arp request that's done in the test won't work.


### PR DESCRIPTION
In order to make bfd work, we need to open the ports in the same way we did for bgp.

