### PR TITLE
Add support for mirroring OLM operators

### DIFF
--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -136,11 +136,18 @@ if [ ! -z "${MIRROR_IMAGES}" ]; then
     IRONIC_LOCAL_IMAGE=${IRONIC_LOCAL_IMAGE:-"${LOCAL_REGISTRY_PREFIX}@${IRONIC_RELEASE_IMAGE}"}
 
     if [ -n "${MIRROR_OLM:-}" ]; then
-        echo "Mirroring OLM operator(s): ${MIRROR_OLM}"
+        echo "Installing OPM client"
         VERSION="$(openshift_version ${OCP_DIR})"
         OLM_DIR=$(mktemp --tmpdir -d "mirror-olm--XXXXXXXXXX")
         _tmpfiles="$_tmpfiles $OLM_DIR"
 
+        pushd $OLM_DIR
+        curl -O https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/${VERSION}.0/opm-linux.tar.gz
+        tar xf opm-linux.tar.gz
+        sudo mv -f opm /usr/local/bin
+        popd
+
+        echo "Mirroring OLM operator(s): ${MIRROR_OLM}"
         REGISTRY_AUTH_FILE=${PULL_SECRET_FILE} opm index prune -f registry.redhat.io/redhat/redhat-operator-index:v${VERSION} -p ${MIRROR_OLM} -t ${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/redhat-operator-index:v${VERSION}
 
         podman push --authfile ${PULL_SECRET_FILE} ${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/redhat-operator-index:v${VERSION}

--- a/config_example.sh
+++ b/config_example.sh
@@ -76,6 +76,12 @@ set -x
 # for an IPv4 install.
 #export MIRROR_IMAGES=true
 
+# Comma-separated list of OLM operators to mirror into the local registry. This
+# has no effect if MIRROR_IMAGES is false.
+# This will not work for releases that have not yet shipped. The content for
+# the release must have been published in order for mirroring to work.
+#export MIRROR_OLM=kubernetes-nmstate-operator
+
 # Ensure that the local registry will be available
 #export ENABLE_LOCAL_REGISTRY=true
 


### PR DESCRIPTION
In disconnected deployments (like ipv6) we need to mirror any OLM
operators that we want to install because the OLM images aren't
otherwise available. This patch adds a MIRROR_OLM configuration
variable that will create a pruned index containing only the
relevant operators in the local registry.

The mirroring process generates a couple of manifests needed to use
the mirrored index, and these files are added to the deployment
manifests directory so it will be usable immediately.