### PR TITLE
utils: Use registry-scoped sources in imageContentSources

### DIFF
--- a/utils.sh
+++ b/utils.sh
@@ -384,6 +384,7 @@ function image_mirror_config {
             TAGGED=$(echo $MIRRORED_RELEASE_IMAGE | sed -e 's/release://')
             RELEASE=$(echo $MIRRORED_RELEASE_IMAGE | grep -o 'registry.ci.openshift.org[^":\@]\+')
             CANONICAL_REGISTRIES="$(printf "%s\n%s\n" "${RELEASE}" "${TAGGED}" | while read PULLSPEC; do pullspec_registry "${PULLSPEC}"; done | sort | uniq)"
+            echo "setting up imageContentSources for ${CANONICAL_REGISTRIES}" >&2
             echo imageContentSources:
             echo "${CANONICAL_REGISTRIES}" | while read REGISTRY; do
                 printf -- "- mirrors:\n  - %s:\n  source: %s\n" "${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/local-release-image" "${REGISTRY}"


### PR DESCRIPTION
The previous configuration created entries which included the full repository path within the registry.  The installer creates `ImageContentSourcePolicies` from the install-config entries, and they end up in the cluster [like][1]:

```console
$ curl -s https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/openshift-kubernetes-1087-nightly-4.10-e2e-metal-ipi-upgrade-ovn-ipv6/1479101028317007872/artifacts/e2e-metal-ipi-upgrade-ovn-ipv6/gather-must-gather/artifacts/must-gather.tar | tar xOz quay-io-openshift-release-dev-ocp-v4-0-art-dev-sha256-6da7281285800ef1fca3ae4da6fad9f321ff757145212b74c94c4fe08fc3f055/cluster-scoped-resources/operator.openshift.io/imagecontentsourcepolicies/image-policy-0.yaml
---
apiVersion: operator.openshift.io/v1alpha1
kind: ImageContentSourcePolicy
metadata:
  creationTimestamp: "2022-01-06T15:52:21Z"
  generation: 1
  name: image-policy-0
  resourceVersion: "1567"
  uid: eb48e7b9-5768-42d9-b7a1-9bcec6800197
spec:
  repositoryDigestMirrors:
  - mirrors:
    - virthost.ostest.test.metalkube.org:5000/localimages/local-release-image
    source: registry.build01.ci.openshift.org/ci-op-1yt550tk/release
```

That repository path causes trouble when the referenced images use a different repository, like:

```console
$ curl -s https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/openshift-kubernetes-1087-nightly-4.10-e2e-metal-ipi-upgrade-ovn-ipv6/1479101028317007872/artifacts/e2e-metal-ipi-upgrade-ovn-ipv6/gather-extra/artifacts/pods.json | jq -r '.items[] | select(.metadata.namespace == "openshift-etcd-operator").status.containerStatuses[].state'
{
  "waiting": {
    "message": "Back-off pulling image \"registry.build01.ci.openshift.org/ci-op-1yt550tk/stable@sha256:b39240d76f42457511234d22b7d1dad72fe7917e7b55a25f520b41fd9dbbea53\"",
    "reason": "ImagePullBackOff"
  }
}
```

Compare `ci-op-1yt550tk/stable` with the ImageContentSourcePolicy's `ci-op-1yt550tk/release`.

With this commit, we'll move to having entries like:

```yaml
source: registry.build01.ci.openshift.org
````

From [the OpenShift docs][2]:

```
  source: registry.redhat.io/openshift4 [3]
  ...
  [3]: You can configure a namespace inside a registry to use any
    image in that namespace. If you use a registry domain as a source,
    the ImageContentSourcePolicy resource is applied to all
    repositories from the registry.
```

The `%%` business is [POSIX parameter expansion][3]:

```
  ${parameter%%[word]}
    Remove Largest Suffix Pattern. The word shall be expanded to
    produce a pattern. The parameter expansion shall then result in
    parameter, with the largest portion of the suffix matched by the
    pattern deleted.
```

stripping the first slash in the pullspec and everything after it.

[1]: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/openshift-kubernetes-1087-nightly-4.10-e2e-metal-ipi-upgrade-ovn-ipv6/1479101028317007872#1:build-log.txt%3A54
[2]: https://docs.openshift.com/container-platform/4.9/openshift_images/image-configuration.html#images-configuration-registry-mirror_image-configuration
[3]: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_02