### PR TITLE
Stop passing clusterOSImage

### DIFF
--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -162,29 +162,6 @@ if [ ! -f "${CACHED_MACHINE_OS_IMAGE}" ]; then
   pushd $(dirname ${CACHED_MACHINE_OS_IMAGE})
   sha256sum --strict --check ${CACHED_MACHINE_OS_IMAGE}.sha256sum || ( rm -f "${CACHED_MACHINE_OS_IMAGE}" ; exit 1 )
   popd
-  # If using the live images, fetch the kernel, rootfs and initramfs images also
-  if [ "${RHCOS_LIVE_IMAGES}"  == "true" ]; then
-     CACHED_MACHINE_OS_LIVE_KERNEL="${IRONIC_DATA_DIR}/html/images/${MACHINE_OS_LIVE_KERNEL}"
-     curl -g --insecure -L -o "${CACHED_MACHINE_OS_LIVE_KERNEL}" "${LIVE_KERNEL_IMAGE_URL}"
-     echo "${MACHINE_OS_LIVE_KERNEL_SHA256} $(basename ${CACHED_MACHINE_OS_LIVE_KERNEL})" | tee ${CACHED_MACHINE_OS_LIVE_KERNEL}.sha256sum
-     pushd $(dirname ${CACHED_MACHINE_OS_LIVE_KERNEL})
-     sha256sum --strict --check ${CACHED_MACHINE_OS_LIVE_KERNEL}.sha256sum || ( rm -f "${CACHED_MACHINE_OS_LIVE_KERNEL}" ; exit 1 )
-     popd
-     #
-     CACHED_MACHINE_OS_LIVE_ROOTFS="${IRONIC_DATA_DIR}/html/images/${MACHINE_OS_LIVE_ROOTFS}"
-     curl -g --insecure -L -o "${CACHED_MACHINE_OS_LIVE_ROOTFS}" "${LIVE_ROOTFS_IMAGE_URL}"
-     echo "${MACHINE_OS_LIVE_ROOTFS_SHA256} $(basename ${CACHED_MACHINE_OS_LIVE_ROOTFS})" | tee ${CACHED_MACHINE_OS_LIVE_ROOTFS}.sha256sum
-     pushd $(dirname ${CACHED_MACHINE_OS_LIVE_ROOTFS})
-     sha256sum --strict --check ${CACHED_MACHINE_OS_LIVE_ROOTFS}.sha256sum || ( rm -f "${CACHED_MACHINE_OS_LIVE_ROOTFS}" ; exit 1 )
-     popd
-     #
-     CACHED_MACHINE_OS_LIVE_INITRAMFS="${IRONIC_DATA_DIR}/html/images/${MACHINE_OS_LIVE_INITRAMFS}"
-     curl -g --insecure -L -o "${CACHED_MACHINE_OS_LIVE_INITRAMFS}" "${LIVE_INITRAMFS_IMAGE_URL}"
-     echo "${MACHINE_OS_LIVE_INITRAMFS_SHA256} $(basename ${CACHED_MACHINE_OS_LIVE_INITRAMFS})" | tee ${CACHED_MACHINE_OS_LIVE_INITRAMFS}.sha256sum
-     pushd $(dirname ${CACHED_MACHINE_OS_LIVE_INITRAMFS})
-     sha256sum --strict --check ${CACHED_MACHINE_OS_LIVE_INITRAMFS}.sha256sum || ( rm -f "${CACHED_MACHINE_OS_LIVE_INITRAMFS}" ; exit 1 )
-     popd
-  fi
 fi
 
 CACHED_MACHINE_OS_BOOTSTRAP_IMAGE="${IRONIC_DATA_DIR}/html/images/${MACHINE_OS_BOOTSTRAP_IMAGE_NAME}"

--- a/common.sh
+++ b/common.sh
@@ -328,6 +328,3 @@ fi
 
 # Defaults the variable to enable testing a custom machine-api-operator image
 export TEST_CUSTOM_MAO=${TEST_CUSTOM_MAO:-false}
-
-# Set to true to enable RHCOS Live Image based installs
-export RHCOS_LIVE_IMAGES=${RHCOS_LIVE_IMAGES:-false}

--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -188,6 +188,14 @@ EOF
   fi
 }
 
+function cluster_os_image() {
+  if is_lower_version $OPENSHIFT_VERSION 4.10; then
+cat <<EOF
+    clusterOSImage: http://$(wrap_if_ipv6 $MIRROR_IP)/images/${MACHINE_OS_IMAGE_NAME}?sha256=${MACHINE_OS_IMAGE_SHA256}
+EOF
+  fi
+}
+
 function generate_ocp_install_config() {
     local outdir
 
@@ -233,7 +241,7 @@ $(libvirturi)
 $(baremetal_network_configuration)
     externalBridge: ${BAREMETAL_NETWORK_NAME}
     bootstrapOSImage: http://$(wrap_if_ipv6 $MIRROR_IP)/images/${MACHINE_OS_BOOTSTRAP_IMAGE_NAME}?sha256=${MACHINE_OS_BOOTSTRAP_IMAGE_UNCOMPRESSED_SHA256}
-    clusterOSImage: http://$(wrap_if_ipv6 $MIRROR_IP)/images/${MACHINE_OS_IMAGE_NAME}?sha256=${MACHINE_OS_IMAGE_SHA256}
+$(cluster_os_image)
     apiVIP: ${API_VIP}
     ingressVIP: ${INGRESS_VIP}
 $(dnsvip)

--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -188,21 +188,6 @@ EOF
   fi
 }
 
-function os_images() {
-	# If using the live images, fetch the kernel, rootfs and initramfs images also
-	if [ "${RHCOS_LIVE_IMAGES}"  == "true" ]; then
-cat <<EOF
-    bootstrapOSImage: http://$(wrap_if_ipv6 $MIRROR_IP)/images/${MACHINE_OS_BOOTSTRAP_IMAGE_NAME}?sha256=${MACHINE_OS_BOOTSTRAP_IMAGE_UNCOMPRESSED_SHA256}
-    clusterOSImage: http://$(wrap_if_ipv6 $MIRROR_IP)/images/${MACHINE_OS_IMAGE_NAME}?sha256=${MACHINE_OS_IMAGE_SHA256},http://$(wrap_if_ipv6 $MIRROR_IP)/images/${MACHINE_OS_LIVE_KERNEL}?sha256=${MACHINE_OS_LIVE_KERNEL_SHA256},http://$(wrap_if_ipv6 $MIRROR_IP)/images/${MACHINE_OS_LIVE_ROOTFS}?sha256=${MACHINE_OS_LIVE_ROOTFS_SHA256},http://$(wrap_if_ipv6 $MIRROR_IP)/images/${MACHINE_OS_LIVE_INITRAMFS}?sha256=${MACHINE_OS_LIVE_INITRAMFS_SHA256}
-EOF
-	else
-cat <<EOF
-    bootstrapOSImage: http://$(wrap_if_ipv6 $MIRROR_IP)/images/${MACHINE_OS_BOOTSTRAP_IMAGE_NAME}?sha256=${MACHINE_OS_BOOTSTRAP_IMAGE_UNCOMPRESSED_SHA256}
-    clusterOSImage: http://$(wrap_if_ipv6 $MIRROR_IP)/images/${MACHINE_OS_IMAGE_NAME}?sha256=${MACHINE_OS_IMAGE_SHA256}
-EOF
-	fi
-}
-
 function generate_ocp_install_config() {
     local outdir
 
@@ -247,7 +232,8 @@ platform:
 $(libvirturi)
 $(baremetal_network_configuration)
     externalBridge: ${BAREMETAL_NETWORK_NAME}
-$(os_images)
+    bootstrapOSImage: http://$(wrap_if_ipv6 $MIRROR_IP)/images/${MACHINE_OS_BOOTSTRAP_IMAGE_NAME}?sha256=${MACHINE_OS_BOOTSTRAP_IMAGE_UNCOMPRESSED_SHA256}
+    clusterOSImage: http://$(wrap_if_ipv6 $MIRROR_IP)/images/${MACHINE_OS_IMAGE_NAME}?sha256=${MACHINE_OS_IMAGE_SHA256}
     apiVIP: ${API_VIP}
     ingressVIP: ${INGRESS_VIP}
 $(dnsvip)

--- a/rhcos.sh
+++ b/rhcos.sh
@@ -52,30 +52,3 @@ else
   export MACHINE_OS_INSTALLER_BOOTSTRAP_IMAGE_UNCOMPRESSED_SHA256=$(jq -r '.images.qemu["uncompressed-sha256"]' $OCP_DIR/rhcos.json)
   export MACHINE_OS_BOOTSTRAP_IMAGE_UNCOMPRESSED_SHA256=${MACHINE_OS_BOOTSTRAP_IMAGE_UNCOMPRESSED_SHA256:-${MACHINE_OS_INSTALLER_BOOTSTRAP_IMAGE_UNCOMPRESSED_SHA256}}
 fi
-
-if [ "${RHCOS_LIVE_IMAGES}"  == "true" ]; then
-	export LIVE_ISO_IMAGE_URL=$(jq -r '.architectures.x86_64.artifacts.metal.formats["iso"].disk.location' $OCP_DIR/rhcos.json)
-	export LIVE_KERNEL_IMAGE_URL=$(jq -r '.architectures.x86_64.artifacts.metal.formats["pxe"].kernel.location' $OCP_DIR/rhcos.json)
-	export LIVE_ROOTFS_IMAGE_URL=$(jq -r '.architectures.x86_64.artifacts.metal.formats["pxe"].rootfs.location' $OCP_DIR/rhcos.json)
-	export LIVE_INITRAMFS_IMAGE_URL=$(jq -r '.architectures.x86_64.artifacts.metal.formats["pxe"].initramfs.location' $OCP_DIR/rhcos.json)
-
-	MACHINE_OS_INSTALLER_LIVE_URLS=""
-	for URL in $LIVE_ISO_IMAGE_URL \
-		   $LIVE_KERNEL_IMAGE_URL \
-		   $LIVE_ROOTFS_IMAGE_URL \
-		   $LIVE_INITRAMFS_IMAGE_URL; do
-		MACHINE_OS_INSTALLER_LIVE_URLS+="${URL},"
-	done
-	# Trim tailing ','
-	MACHINE_OS_INSTALLER_LIVE_URLS=$(echo $MACHINE_OS_INSTALLER_LIVE_URLS | sed 's/,*$//')
-
-	export MACHINE_OS_IMAGE_URL=${LIVE_ISO_IMAGE_URL}
-	export MACHINE_OS_IMAGE_NAME=$(basename ${MACHINE_OS_IMAGE_URL})
-	export MACHINE_OS_IMAGE_SHA256=$(jq -r '.architectures.x86_64.artifacts.metal.formats["iso"].disk.sha256' $OCP_DIR/rhcos.json)
-	export MACHINE_OS_LIVE_KERNEL=$(basename ${LIVE_KERNEL_IMAGE_URL})
-	export MACHINE_OS_LIVE_KERNEL_SHA256=$(jq -r '.architectures.x86_64.artifacts.metal.formats["pxe"].kernel.sha256' $OCP_DIR/rhcos.json)
-	export MACHINE_OS_LIVE_ROOTFS=$(basename ${LIVE_ROOTFS_IMAGE_URL})
-	export MACHINE_OS_LIVE_ROOTFS_SHA256=$(jq -r '.architectures.x86_64.artifacts.metal.formats["pxe"].rootfs.sha256' $OCP_DIR/rhcos.json)
-	export MACHINE_OS_LIVE_INITRAMFS=$(basename ${LIVE_INITRAMFS_IMAGE_URL})
-	export MACHINE_OS_LIVE_INITRAMFS_SHA256=$(jq -r '.architectures.x86_64.artifacts.metal.formats["pxe"].initramfs.sha256' $OCP_DIR/rhcos.json)
-fi


### PR DESCRIPTION
In 4.10 we don't need to pass a clusterOSImage in the install config, so don't.