### PR TITLE
MetalLB: Use metallb-operator image from CI registry

### DIFF
--- a/metallb/deploy_operator.sh
+++ b/metallb/deploy_operator.sh
@@ -5,12 +5,7 @@ source ${metallb_dir}/metallb_common.sh
 
 METALLB_OPERATOR_REPO=${METALLB_OPERATOR_REPO:-"https://github.com/metallb/metallb-operator.git"}
 METALLB_OPERATOR_COMMIT=${METALLB_OPERATOR_COMMIT:-"4d52b86"}
-LOCAL_REGISTRY_DNS_NAME=${LOCAL_REGISTRY_DNS_NAME:-"virthost.ostest.test.metalkube.org"}
-LOCAL_REGISTRY_PORT=${LOCAL_REGISTRY_PORT:-"5000"}
-OPERATOR_IMAGE=${OPERATOR_IMAGE:-"${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/metallb-operator:ci"}
-METALLB_OPERATOR_DOCKER_FILE=${METALLB_OPERATOR_DOCKER_FILE:-"Dockerfile"}
-PERSONAL_PULL_SECRET=${PERSONAL_PULL_SECRET:-"/root/dev-scripts/pull_secret.json"}
-PULL_SECRET_FILE=${PULL_SECRET_FILE:-"/opt/dev-scripts/pull_secret.json"}
+METALLB_OPERATOR_IMAGE_TAG=${METALLB_OPERATOR_IMAGE_TAG:-"metallb-operator"}
 export NAMESPACE=${NAMESPACE:-"metallb-system"}
 
 if [ ! -d ./metallb-operator ]; then
@@ -21,9 +16,6 @@ if [ ! -d ./metallb-operator ]; then
 fi
 cd metallb-operator
 
-podman build . -f ${METALLB_OPERATOR_DOCKER_FILE} -t ${OPERATOR_IMAGE} --authfile ${PERSONAL_PULL_SECRET}
-podman push ${OPERATOR_IMAGE} --tls-verify=false --authfile ${PULL_SECRET_FILE}
-
 # install yq v4 for metallb deployment
 go install -mod='' github.com/mikefarah/yq/v4@v4.13.3
 
@@ -31,4 +23,4 @@ yq e --inplace '.spec.template.spec.containers[0].env[] |= select (.name=="SPEAK
 yq e --inplace '.spec.template.spec.containers[0].env[] |= select (.name=="CONTROLLER_IMAGE").value|="'${METALLB_IMAGE_BASE}':'${METALLB_IMAGE_TAG}'"' ${metallb_dir}/metallb-operator-deploy/controller_manager_patch.yaml
 yq e --inplace '.spec.template.spec.containers[0].env[] |= select (.name=="FRR_IMAGE").value|="'${METALLB_IMAGE_BASE}':'${FRR_IMAGE_TAG}'"' ${metallb_dir}/metallb-operator-deploy/controller_manager_patch.yaml
 
-PATH="${GOPATH}:${PATH}" ENABLE_OPERATOR_WEBHOOK=true KUSTOMIZE_DEPLOY_DIR="../metallb-operator-deploy" IMG=${OPERATOR_IMAGE} make deploy
+PATH="${GOPATH}:${PATH}" ENABLE_OPERATOR_WEBHOOK=true KUSTOMIZE_DEPLOY_DIR="../metallb-operator-deploy" IMG="${METALLB_IMAGE_BASE}:${METALLB_OPERATOR_IMAGE_TAG}" make deploy


### PR DESCRIPTION
Instead of building the operator image we can use the latest image in the CI registry.

Doing this so when running the CI in metallb-operator repo the deployment will be done with the committed changes instead of latest main.