### PR TITLE
Add Alma and Rocky Linux as supported host OSes

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -51,6 +51,8 @@ case $DISTRO in
     sudo dnf install -y network-scripts
     if [[ $DISTRO == "centos8" ]]; then
       echo "CentOS is not supported anymore. Please switch to CentOS Stream / RHEL / Rocky Linux"
+    fi
+    if [[ $DISTRO == "centos8" || $DISTRO == "almalinux8" || $DISTRO == "rocky8" ]]; then
       sudo dnf -y install epel-release dnf --enablerepo=extras
     elif [[ $DISTRO == "rhel8" ]]; then
       # Enable EPEL for python3-passlib and python3-bcrypt required by metal3-dev-env
@@ -104,6 +106,7 @@ ANSIBLE_FORCE_COLOR=true ansible-playbook \
   -e "virthost=$HOSTNAME" \
   -e "go_version=1.18.3" \
   -e "GOARCH=$GOARCH" \
+  $ALMA_PYTHON_OVERRIDE \
   -i vm-setup/inventory.ini \
   -b -vvv vm-setup/install-package-playbook.yml
 popd

--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -119,6 +119,7 @@ ansible-playbook \
     -e "worker_hostname_format=$WORKER_HOSTNAME_FORMAT" \
     -e "libvirt_arch=$(uname -m)" \
     -e "enable_vnc_console=$VNC_CONSOLE" \
+    $ALMA_PYTHON_OVERRIDE \
     -i ${VM_SETUP_PATH}/inventory.ini \
     -b -vvv ${VM_SETUP_PATH}/setup-playbook.yml
 
@@ -249,6 +250,7 @@ ANSIBLE_FORCE_COLOR=true ansible-playbook \
     -e "baremetal_interface=$BAREMETAL_NETWORK_NAME" \
     -e "{provisioning_host_ports: [80, ${LOCAL_REGISTRY_PORT}, 8000, ${INSTALLER_PROXY_PORT}]}" \
     -e "vbmc_port_range=$VBMC_BASE_PORT:$VBMC_MAX_PORT" \
+    $ALMA_PYTHON_OVERRIDE \
     -i ${VM_SETUP_PATH}/inventory.ini \
     -b -vvv ${VM_SETUP_PATH}/firewall.yml
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ other components of OpenShift via support for a baremetal platform type.
 # Pre-requisites
 
 - CentOS 8 or RHEL 8 host
+  - Alma and Rocky Linux 8 are also supported on a best effort basis
 - file system that supports d_type (see [Troubleshooting](#Troubleshooting) section for more information)
 - ideally on a bare metal host with at least 64G of RAM
 - run as a user with passwordless sudo access

--- a/common.sh
+++ b/common.sh
@@ -379,3 +379,12 @@ export TEST_CUSTOM_MAO=${TEST_CUSTOM_MAO:-false}
 # Set to configure bootstrap VM baremetal network with static IP
 # (Currently this just expects a non-empty value, the IP is fixed to .9)
 export ENABLE_BOOTSTRAP_STATIC_IP=${ENABLE_BOOTSTRAP_STATIC_IP:-}
+
+# TODO(bnemec): Once https://github.com/ansible/ansible/pull/75537 merges this
+# can be removed.
+ALMA_PYTHON_OVERRIDE=
+source /etc/os-release
+export DISTRO="${ID}${VERSION_ID%.*}"
+if [[ $DISTRO == "almalinux8" || $DISTRO == "rocky8" ]]; then
+    ALMA_PYTHON_OVERRIDE="-e ansible_python_interpreter=/usr/libexec/platform-python"
+fi

--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -28,6 +28,7 @@ ansible-playbook \
     -e "virthost=$HOSTNAME" \
     -e "manage_baremetal=$MANAGE_BR_BRIDGE" \
     -e "nodes_file=$NODES_FILE" \
+    $ALMA_PYTHON_OVERRIDE \
     -i ${VM_SETUP_PATH}/inventory.ini \
     -b -vvv ${VM_SETUP_PATH}/teardown-playbook.yml
 

--- a/validation.sh
+++ b/validation.sh
@@ -16,7 +16,7 @@ function early_either_validation() {
     fi
 
     # Check OS
-    if [[ ! $(awk -F= '/^ID=/ { print $2 }' /etc/os-release | tr -d '"') =~ ^(centos|rhel)$ ]]; then
+    if [[ ! $(awk -F= '/^ID=/ { print $2 }' /etc/os-release | tr -d '"') =~ ^(centos|rhel|almalinux|rocky)$ ]]; then
         error "Unsupported OS"
         exit 1
     fi


### PR DESCRIPTION
These two distributions are essentially what CentOS was pre-Stream,
so they should generally be compatible as well. They are documented
as "best effort" support though since I don't think we'll be running
them in CI.