### PR TITLE
Revert "Get Centos packages from Vault"

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -35,13 +35,7 @@ sudo dnf -y upgrade
 source /etc/os-release
 export DISTRO="${ID}${VERSION_ID%.*}"
 if [[ $DISTRO == "centos8" ]]; then
-    if [ "$NAME" != "CentOS Stream" -a ! -e /etc/yum.repos.d/centos-vault.repo ] ; then
-        # Centos8 is EOL
-        mv /etc/yum.repos.d /etc/yum.repos.d_$(date +%s)
-        mkdir /etc/yum.repos.d
-        echo -e '[base]\nname=base\nbaseurl=https://vault.centos.org/8.4.2105/BaseOS/x86_64/os/\ngpgcheck=0\nenabled=1\n[apps]\nname=apps\nbaseurl=https://vault.centos.org/8.4.2105/AppStream/x86_64/os/\ngpgcheck=0\nenabled=1\n[extras]\nname=extras\nbaseurl=https://vault.centos.org/8.4.2105/extras/x86_64/os/\ngpgcheck=0\nenabled=1' > /etc/yum.repos.d/centos-vault.repo
-    fi
-
+    echo "CentOS is not supported anymore. Please switch to CentOS Stream / RHEL / Rocky Linux"
     sudo dnf -y install epel-release dnf --enablerepo=extras
 elif [[ $DISTRO == "rhel8" ]]; then
     # Enable EPEL for python3-passlib and python3-bcrypt required by metal3-dev-env


### PR DESCRIPTION
Reverts openshift-metal3/dev-scripts#1343

Since moving to Rocky Linux, this code changes package repositories back to using vault mirror even in Rocky Linux.
Regular repositories are good enough for us, so this change no longer needed.

/cc @derekhiggins 
/hold
(waiting to manually investigate CI logs)