### PR TITLE
Add ENABLE_VIRTUAL_MEDIA_VIA_EXTERNAL_NETWORK environment variable

### DIFF
--- a/06_create_cluster.sh
+++ b/06_create_cluster.sh
@@ -83,4 +83,8 @@ if [[ ! -z "${ENABLE_METALLB}" ]]; then
 	popd
 fi
 
+if [[ ! -z "${ENABLE_VIRTUAL_MEDIA_VIA_EXTERNAL_NETWORK}" ]]; then
+    oc patch provisioning provisioning-configuration --type merge -p "{\"spec\":{\"virtualMediaViaExternalNetwork\":true}}"
+fi
+
 echo "Cluster up, you can interact with it via oc --config ${KUBECONFIG} <command>"

--- a/config_example.sh
+++ b/config_example.sh
@@ -169,6 +169,11 @@ set -x
 #export SERVICE_SUBNET_V4="172.30.0.0/16"
 #export SERVICE_SUBNET_V6="fd02::/112"
 
+# Enable virtualMediaViaExternalNetwork in provisioning
+# configuration.
+# More info: https://github.com/openshift/cluster-baremetal-operator/blob/master/api/v1alpha1/provisioning_types.go#L163-L171
+#export ENABLE_VIRTUAL_MEDIA_VIA_EXTERNAL_NETWORK=true
+
 # Enable testing of custom machine-api-operator-image
 #export TEST_CUSTOM_MAO=true
 


### PR DESCRIPTION
This new ENABLE_VIRTUAL_MEDIA_VIA_EXTERNAL_NETWORK will be used to pass
virtualMediaViaExternalNetwork as true in provisioning configs.

virtualMediaViaExternalNetwork, when it is set to true, allows for worker
to boot via Virtual Media and contact metal3 over the External Network.

With this PR, we will be able to test this functionality in our CI
jobs to assure that it is working as expected or not. Moreover,
users also can use that environment variable if they want to boot workers
via Virtual Media and contact metal3 over the External Network.