### PR TITLE
Add support for "main" and "master" branches

### DIFF
--- a/utils.sh
+++ b/utils.sh
@@ -267,9 +267,9 @@ function sync_repo_and_patch {
     pushd $DEST
 
     git am --abort || true
-    git checkout master
+    git checkout master || git checkout main
     git fetch origin
-    git rebase origin/master
+    git rebase origin/master || git rebase origin/main
     if test "$#" -gt "2" ; then
         git branch -D metalkube || true
         git checkout -b metalkube


### PR DESCRIPTION
This PR fixes function responsible for synchronizing repositories so
that both "main" and "master" branches are supported. Current behaviour
assumes that there always exists a "master" branch what is no longer the
case given repositories follow a patern of using "main" instead.