### PR TITLE
Update assisted operator index image

### DIFF
--- a/assisted_deployment.sh
+++ b/assisted_deployment.sh
@@ -17,7 +17,7 @@ ASSISTED_CONTROLLER_IMAGE="${ASSISTED_CONTROLLER_IMAGE:-}"
 ASSISTED_OPENSHIFT_VERSIONS="${ASSISTED_OPENSHIFT_VERSIONS:-}"
 
 ASSISTED_NAMESPACE="${ASSISTED_NAMESPACE:-assisted-installer}"
-ASSISTED_OPERATOR_INDEX="${ASSISTED_OPERATOR_INDEX:-quay.io/ocpmetal/assisted-service-index:latest}"
+ASSISTED_OPERATOR_INDEX="${ASSISTED_OPERATOR_INDEX:-quay.io/edge-infrastructure/assisted-service-index:latest}"
 
 ASSETS_DIR="${OCP_DIR}/saved-assets/assisted-installer-manifests"
 


### PR DESCRIPTION
The ocpmetal image is no longer being maintained or updated.
All assisted images should now be pulled from edge-infrastructure.

cc @dtantsur 