### PR TITLE
assisted-service: Add imageStorage to the service configuration

### DIFF
--- a/assisted_deployment.sh
+++ b/assisted_deployment.sh
@@ -253,6 +253,13 @@ spec:
   resources:
    requests:
     storage: 8Gi
+ imageStorage:
+  storageClassName: assisted-service
+  accessModes:
+  - ReadWriteOnce
+  resources:
+   requests:
+    storage: 10Gi
 EOF
 }
 


### PR DESCRIPTION
With https://github.com/openshift/assisted-service/pull/3067 we have
introduced an `imageStorage` configuration option that needs to be set
in the AgentServiceConfig for Infrastructure Operator.

This PR adds the configuration, so that `make assisted` target can
deploy the operator seamlessly.

/cc @mresvanis