### PR TITLE
El8 compat 01 installation

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -69,6 +69,12 @@ ansible-galaxy install -r vm-setup/requirements.yml
 # temporarily capping it until the issue is fixed
 ansible-galaxy collection install 'ansible.netcommon:<2.6.0'
 ansible-galaxy collection install --upgrade ansible.posix community.general
+
+if ! python -c 'import selinux'; then
+   dnf copr enable -y apuimedo/libselinux-py39
+   sudo dnf install -y python39-libselinux
+fi
+
 ANSIBLE_FORCE_COLOR=true ansible-playbook \
   -e "working_dir=$WORKING_DIR" \
   -e "virthost=$HOSTNAME" \

--- a/validation.sh
+++ b/validation.sh
@@ -4,7 +4,7 @@ set -o pipefail
 
 # Perform some validation steps that we always want done.
 function early_either_validation() {
-    if [ "$USER" != "root" -a "${XDG_RUNTIME_DIR:-}" == "/run/user/0" ] ; then
+    if [ "$USER" != "root" -a "$(systemd-path user-runtime)" == "/run/user/0" ] ; then
         error "Please use a non-root user, WITH a login shell (e.g. su - USER)"
         exit 1
     fi
@@ -16,7 +16,7 @@ function early_either_validation() {
     fi
 
     # Check OS
-    if [[ ! $(awk -F= '/^ID=/ { print $2 }' /etc/os-release | tr -d '"') =~ ^(centos|rhel)$ ]]; then
+    if ! (source /etc/os-release; [[ "$ID" =~ ^(centos|rhel)$ || "$ID_LIKE" =~ (centos|rhel) ]]); then
         error "Unsupported OS"
         exit 1
     fi


### PR DESCRIPTION
el8 01-script compatibility improvements

There's some el8 distros out there that were failing the 01 script due
to:
* Reporting differently their ID in os-release
* Not setting XDG_*
* Missing py39 dependencies

This commit should sort out those things in a more generic way.

It also adds support for having the config out of tree, in the
freedesktop expected place for configurations. Note that since one can
use the config to set the pull secret location, I did not touch its
default.