### PR TITLE
Use host network when building images

### DIFF
--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -90,7 +90,7 @@ for IMAGE_VAR in $(env | grep "_LOCAL_IMAGE=" | grep -o "^[^=]*") ; do
             sed -i "s/^FROM [^ ]*/FROM ${BASE_IMAGE_DIR}/g" ${IMAGE_DOCKERFILE}
         fi
 
-        sudo podman build --authfile $PULL_SECRET_FILE $BUILD_COMMAND_ARGS -t ${!IMAGE_VAR} -f $IMAGE_DOCKERFILE .
+        sudo podman build --network host --authfile $PULL_SECRET_FILE $BUILD_COMMAND_ARGS -t ${!IMAGE_VAR} -f $IMAGE_DOCKERFILE .
         cd -
         sudo podman push --tls-verify=false --authfile $PULL_SECRET_FILE ${!IMAGE_VAR} ${!IMAGE_VAR}
     fi

--- a/build-base-image.sh
+++ b/build-base-image.sh
@@ -19,4 +19,4 @@ if [[ -n ${BASE_IMAGE_FROM:-} ]]; then
     BUILD_COMMAND_ARGS+=" --build-arg REMOVE_OLD_REPOS=no"
 fi
 
-sudo podman build --tag ${BASE_IMAGE_DIR} ${BUILD_COMMAND_ARGS} -f "${BASE_IMAGE_DIR}/Dockerfile"
+sudo podman build --network host --tag ${BASE_IMAGE_DIR} ${BUILD_COMMAND_ARGS} -f "${BASE_IMAGE_DIR}/Dockerfile"

--- a/utils.sh
+++ b/utils.sh
@@ -130,7 +130,7 @@ function create_cluster() {
     if [[  ! -z "${ENABLE_CBO_TEST}" ]]; then
       # Create an empty image to be used by the CBO test deployment
       EMPTY_IMAGE=${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/empty:latest
-      echo -e "FROM quay.io/quay/busybox\nCMD [\"sleep\", \"infinity\"]" | sudo podman build -t ${EMPTY_IMAGE} -f - .
+      echo -e "FROM quay.io/quay/busybox\nCMD [\"sleep\", \"infinity\"]" | sudo podman build --network host -t ${EMPTY_IMAGE} -f - .
       sudo podman push --tls-verify=false --authfile ${REGISTRY_CREDS} ${EMPTY_IMAGE} ${EMPTY_IMAGE}
 
       cp assets/metal3-cbo-deployment.yaml ${assets_dir}/openshift/.


### PR DESCRIPTION
In case the host where dev-scripts is running has only localhost as
resolver, the dns resolution during build fails as it's removed from
/etc/resolv.conf since it's not reachable from the container.
If we need to reach external urls during image building, the entire
build fails, as the urls can't be resolved.
As a workaround use the --network host option only during build.
For more info see https://github.com/containers/podman/issues/13599
