### PR TITLE
Use kubeconfig option in cluster up message

### DIFF
--- a/06_create_cluster.sh
+++ b/06_create_cluster.sh
@@ -71,4 +71,4 @@ if [[ ! -z "${ENABLE_METALLB_MODE}" ]]; then
 	fi
 fi
 
-echo "Cluster up, you can interact with it via oc --config ${KUBECONFIG} <command>"
+echo "Cluster up, you can interact with it via oc --kubeconfig ${KUBECONFIG} <command>"


### PR DESCRIPTION
oc option `--config` does not exist. 
````
$ oc --config <path> get no             
Error: unknown flag: --config
See 'oc get --help' for usage.
````

This PR addresses it and uses `--kubeconfig` in the cluster-up message instead.