### PR TITLE
Silence git checkout of master

### DIFF
--- a/utils.sh
+++ b/utils.sh
@@ -267,9 +267,9 @@ function sync_repo_and_patch {
     pushd $DEST
 
     git am --abort || true
-    git checkout master || git checkout main
+    git checkout master --quiet || git checkout main
     git fetch origin
-    git rebase origin/master || git rebase origin/main
+    git rebase origin/master --quiet || git rebase origin/main
     if test "$#" -gt "2" ; then
         git branch -D metalkube || true
         git checkout -b metalkube


### PR DESCRIPTION
On metal3-dev-env where the default branch has been renamed to main,
this command causes an ugly error message in the logs that has
resulted in a lot of wasted debug time. Since we expect that this
command is going to fail some of the time, let's suppress that
output. If there is a legitimate failure on this line, the second
command will also fail so we'll know where to look.