### PR TITLE
Include NUM_WORKERS in agent based installs

### DIFF
--- a/agent/03_agent_deployment.sh
+++ b/agent/03_agent_deployment.sh
@@ -91,6 +91,7 @@ spec:
     - ${SERVICE_NETWORK}
   provisionRequirements:
     controlPlaneAgents: ${NUM_MASTERS}
+    workerAgents: ${NUM_WORKERS}
   sshPublicKey: ${SSH_PUB_KEY}
 EOF
 


### PR DESCRIPTION
AgentClusterInstall.Spec.provisionRequirements.workerAgents should
reflect the value set in NUM_WORKERS.

This allows high availability clusters to be installed through
the agent based installer flow.