### PR TITLE
Fix typo in the oc command after cluster is ready

### DIFF
--- a/06_create_cluster.sh
+++ b/06_create_cluster.sh
@@ -87,4 +87,6 @@ if [[ ! -z "${ENABLE_VIRTUAL_MEDIA_VIA_EXTERNAL_NETWORK}" ]]; then
     oc patch provisioning provisioning-configuration --type merge -p "{\"spec\":{\"virtualMediaViaExternalNetwork\":true}}"
 fi
 
-echo "Cluster up, you can interact with it via oc --config ${KUBECONFIG} <command>"
+echo "Cluster up, you can interact with it via oc --kubeconfig ${KUBECONFIG} <command>"
+echo "To avoid using the --kubeconfig flag on each command, set KUBECONFIG variable with: export KUBECONFIG=${KUBECONFIG}"
+


### PR DESCRIPTION
The correct flag is --kubeconfig

Also add single line instruction to message to set the KUBECONFIG
environment variable.