### PR TITLE
Agent: use installer branch

### DIFF
--- a/agent/common.sh
+++ b/agent/common.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-export FLEETING_PATH=${FLEETING_PATH:-$WORKING_DIR/fleeting}
-export FLEETING_ISO=${FLEETING_ISO:-$FLEETING_PATH/output/fleeting.iso}
-export FLEETING_MANIFESTS_PATH="${FLEETING_PATH}/manifests"
-export FLEETING_PR=${FLEETING_PR:-}
+export FLEETING_ISO="${WORKING_DIR}/output/fleeting.iso"
+export FLEETING_MANIFESTS_PATH="${WORKING_DIR}/manifests"
+
+export INSTALLER_PR="${INSTALLER_PR:-}"
 export FLEETING_STATIC_IP_NODE0_ONLY=${FLEETING_STATIC_IP_NODE0_ONLY:-"false"}

--- a/config_example.sh
+++ b/config_example.sh
@@ -317,13 +317,10 @@ set -x
 ## Agent Deployment
 ##
 
-# To use a local checkout of the fleeting repo, instead of fetching the remote
-# main branch
-# export FLEETING_PATH=~/go/src/github.com/openshift-agent-team/fleeting
-
-# When set, the changes associated to the specified pull request (for the fleeting repo)
-# are fetched, instead of using the main branch
-# export FLEETING_PR=12
+# When set, the changes associated to the specified pull request (for the
+# installer repo) are fetched, instead of using the current repo status or the
+# agent-installer branch (if the repo does not exist)
+# export INSTALLER_PR=5852
 
 # Set whether static IPs will be used for all nodes or only Node0
 # export FLEETING_STATIC_IP_NODE0_ONLY="true"


### PR DESCRIPTION
Use the master-agent-installer branch of the openshift/installer repo
instead of the openshift-agent-team/fleeting prototype to do agent-based
installation.