### PR TITLE
network: add support to dualstack

### DIFF
--- a/network.sh
+++ b/network.sh
@@ -23,6 +23,9 @@ function wrap_if_ipv6(){
     echo "$1"
 }
 
+export STRINGS_SEPARATOR=","
+export PATH_CONF_DNSMASQ="/etc/NetworkManager/dnsmasq.d/openshift-${CLUSTER_NAME}.conf"
+
 export IP_STACK=${IP_STACK:-"v6"}
 export HOST_IP_STACK=${HOST_IP_STACK:-${IP_STACK}}
 
@@ -193,26 +196,88 @@ if [ -n "${NETWORK_CONFIG_FOLDER:-}" ]; then
   NETWORK_CONFIG_FOLDER="$(readlink -m $NETWORK_CONFIG_FOLDER)"
 fi
 
-function set_api_and_ingress_vip() {
+function is_varset_add_comma() {
+    # Arguments:
+    #     First argument: the var to be checked if is already set
+    #     Second argument: new value to be assigned to the var
+    #
+    # Description:
+    #     Adds comma as separator in case var is already set. Useful for multiple API_VIP or INGRESS_VIP
+    #     Example: 192.168.111.5,fd2e:6f44:5dd8:c956::14
+    #
+    # Returns:
+    #     Print the string using comma
+
+    # if string is *NOT* NULL/empty
+    if [[ -n "${1}" ]]; then
+        echo "$1,$2"
+    else
+        echo "$2"
+    fi
+}
+
+function get_vips() {
+    # Arguments:
+    #     None
+    #
+    # Description:
+    #     Gets the INGRESS VIP and API VIP addresses (ipv4 and ipv6)
+    #
+    # Returns:
+    #     None
+    #
+    if [[ -n "${EXTERNAL_SUBNET_V4}" ]]; then
+        API_VIP=$(dig +noall +answer "api.${CLUSTER_DOMAIN}" @$(network_ip ${BAREMETAL_NETWORK_NAME}) | awk '{print $NF}')
+        INGRESS_VIP=$(nth_ip $EXTERNAL_SUBNET_V4 4)
+    fi
+
+    if [[ -n "${EXTERNAL_SUBNET_V6}" ]]; then
+        API_VIP=$(is_varset_add_comma "${API_VIP}" $(dig -t AAAA +noall +answer "api.${CLUSTER_DOMAIN}" @$(network_ip ${BAREMETAL_NETWORK_NAME}) | awk '{print $NF}'))
+        INGRESS_VIP=$(is_varset_add_comma "${INGRESS_VIP}" $(nth_ip $EXTERNAL_SUBNET_V6 4))
+    fi
+}
+
+
+function add_dnsmasq_multi_entry() {
+    # Arguments:
+    #     First argument: the type of entry to be added in openshift-${CLUSTER_NAME}.conf
+    #     Types available: apivip OR ingressvip
+    #
+    #     Second argument: The list (or single entry) of apivip or ingressvip
+    #
+    # Description:
+    #     Add entries into openshift-${CLUSTERNAME}.conf for dnsmasq
+    #
+    # Returns:
+    #     None
+    for i in ${2//${STRINGS_SEPARATOR}/ }; do
+        if [ "${1}" = "apivip" ] ; then
+            echo "address=/api.${CLUSTER_DOMAIN}/${i}" | sudo tee "${PATH_CONF_DNSMASQ}"
+        fi
+
+        if [ "${1}" = "ingressvip" ] ; then
+            echo "address=/.apps.${CLUSTER_DOMAIN}/${i}" | sudo tee -a "${PATH_CONF_DNSMASQ}"
+        fi
+    done
+}
+
+set_api_and_ingress_vip() {
   # NOTE: This is equivalent to the external API DNS record pointing the API to the API VIP
   if [ "$MANAGE_BR_BRIDGE" == "y" ] ; then
-      if [[ -z "${EXTERNAL_SUBNET_V4}" ]]; then
-          API_VIP=$(dig -t AAAA +noall +answer "api.${CLUSTER_DOMAIN}" @$(network_ip ${BAREMETAL_NETWORK_NAME}) | awk '{print $NF}')
-          INGRESS_VIP=$(nth_ip $EXTERNAL_SUBNET_V6 4)
-      else
-          API_VIP=$(dig +noall +answer "api.${CLUSTER_DOMAIN}" @$(network_ip ${BAREMETAL_NETWORK_NAME}) | awk '{print $NF}')
-          INGRESS_VIP=$(nth_ip $EXTERNAL_SUBNET_V4 4)
-      fi
-      echo "address=/api.${CLUSTER_DOMAIN}/${API_VIP}" | sudo tee /etc/NetworkManager/dnsmasq.d/openshift-${CLUSTER_NAME}.conf
-      echo "address=/.apps.${CLUSTER_DOMAIN}/${INGRESS_VIP}" | sudo tee -a /etc/NetworkManager/dnsmasq.d/openshift-${CLUSTER_NAME}.conf
-      echo "listen-address=::1" | sudo tee -a /etc/NetworkManager/dnsmasq.d/openshift-${CLUSTER_NAME}.conf
+      get_vips
+
+      add_dnsmasq_multi_entry "apivip" "${API_VIP}"
+      add_dnsmasq_multi_entry "ingressvip" "${INGRESS_VIP}"
+
+      echo "listen-address=::1" | sudo tee -a "${PATH_CONF_DNSMASQ}"
 
       # Risk reduction for CVE-2020-25684, CVE-2020-25685, and CVE-2020-25686
       # See: https://access.redhat.com/security/vulnerabilities/RHSB-2021-001
-      echo "cache-size=0" | sudo tee -a /etc/NetworkManager/dnsmasq.d/openshift-${CLUSTER_NAME}.conf
+      echo "cache-size=0" | sudo tee -a "${PATH_CONF_DNSMASQ}"
 
       sudo systemctl reload NetworkManager
   else
+      # Specific for users *NOT* using devscript with KVM (virsh) for deploy. (Reads: baremetal)
       if [[ -z "${EXTERNAL_SUBNET_V4}" ]]; then
           API_VIP=$(dig -t AAAA +noall +answer "api.${CLUSTER_DOMAIN}"  | awk '{print $NF}')
       else

--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -122,6 +122,58 @@ EOF
   fi
 }
 
+function renderVIPs() {
+    # Arguments:
+    #     First argument: field name
+    #     Second argument: value for the field
+    #
+    # Description:
+    #     This function helps to write in a YAML format multiple resources. (i.e: apiVIPs and ingressVIPs)
+    #     Example: apiVIPs, "192.168.11.5, fd2e:6f44:5dd8:c956::15"
+    #
+    # Returns:
+    #     YAML formatted resource
+    STRINGS_SEPARATOR=","
+    resource="${2}";
+
+    echo "    ${1}"
+    for data in ${resource//${STRINGS_SEPARATOR}/ }; do
+        echo "    - ${data}"
+    done
+}
+
+function setVIPs() {
+    # Arguments:
+    #     The type of VIP: apivips OR ingressvips
+    #
+    # Description:
+    #     apiVIP and ingressVIP both has been DEPRECATED in 4.12 in favor of apiVIPs and ingressVIPs.
+    #     This functions helps to write the new apiVIPs/ingressVIPs format or set the old fields.
+    #
+    # Returns:
+    #     The YAML formatted APIVIP or INGRESSVIP (supports new and old format)
+    case "${1}" in
+    "apivips")
+        if printf '4.12\n%s\n' "$(openshift_version)" | sort -V -C; then
+            # OCP version is equals or newer as 4.12 and supports the new VIPs fields
+            renderVIPs "apiVIPs:" "${API_VIP}"
+        else
+            # OCP version is older as 4.12 and does not support the new VIPs fields
+            echo "    apiVIP: ${API_VIP}"
+        fi
+    ;;
+    "ingressvips")
+        if printf '4.12\n%s\n' "$(openshift_version)" | sort -V -C; then
+            # OCP version is equals or newer as 4.12 and supports the new VIPs fields
+            renderVIPs "ingressVIPs:" "${INGRESS_VIP}"
+        else
+            # OCP version is older as 4.12 and does not support the new VIPs fields
+            echo "    ingressVIP: ${INGRESS_VIP}"
+        fi
+    ;;
+    esac
+}
+
 function libvirturi() {
     if [[ "$REMOTE_LIBVIRT" -ne 0 ]]; then
 cat <<EOF
@@ -236,8 +288,8 @@ $(baremetal_network_configuration)
     externalBridge: ${BAREMETAL_NETWORK_NAME}
     bootstrapOSImage: http://$(wrap_if_ipv6 $MIRROR_IP)/images/${MACHINE_OS_BOOTSTRAP_IMAGE_NAME}?sha256=${MACHINE_OS_BOOTSTRAP_IMAGE_UNCOMPRESSED_SHA256}
 $(cluster_os_image)
-    apiVIP: ${API_VIP}
-    ingressVIP: ${INGRESS_VIP}
+$(setVIPs apivips)
+$(setVIPs ingressvips)
 $(dnsvip)
     hosts:
 EOF

--- a/vm_setup_vars.yml
+++ b/vm_setup_vars.yml
@@ -35,6 +35,12 @@ flavors:
 baremetal_network_cidr_v4: "{{ lookup('env', 'EXTERNAL_SUBNET_V4') }}"
 baremetal_network_cidr_v6: "{{ lookup('env', 'EXTERNAL_SUBNET_V6') }}"
 baremetal_network_cidr: "{{ baremetal_network_cidr_v4 | default(baremetal_network_cidr_v6, true) }}"
+
+dns_dualstackhost:
+  - ip: "{{ baremetal_network_cidr_v6 | nthhost(5) }}"
+    hostnames:
+      - "api"
+
 dns_extrahosts:
   - ip: "{{ baremetal_network_cidr | nthhost(5) }}"
     hostnames:
@@ -75,7 +81,7 @@ external_network:
       - 65535
     domain: "{{ cluster_domain }}"
     dns:
-      hosts: "{{dns_extrahosts + dns_customhosts | default([])}}"
+      hosts: "{{ dns_extrahosts + dns_customhosts + dns_dualstackhost if lookup('env', 'EXTERNAL_SUBNET_V6') else dns_extrahosts + dns_customhosts }}"
       forwarders:
         - domain: "apps.{{ cluster_domain }}"
           addr: "127.0.0.1"


### PR DESCRIPTION
The dualstack introduces apiVIPs and ingressVIPs and deprecate
apiVIP and ingressVIP fields. This change just adapt the script.

Signed-off-by: Douglas Schilling Landgraf <dougsland@redhat.com>