### PR TITLE
AGENT-164: Customize openshift installer checkout, build and extraction

### DIFF
--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -38,16 +38,6 @@ function extract_oc() {
     sudo mv "${extract_dir}/oc" /usr/local/bin
 }
 
-function extract_installer() {
-    local release_image
-    local outdir
-
-    release_image="$1"
-    outdir="$2"
-
-    extract_command openshift-baremetal-install "$1" "$2"
-}
-
 function save_release_info() {
     local release_image
     local outdir
@@ -84,29 +74,6 @@ function extract_rhcos_json() {
     podman cp "$baremetal_container":/var/cache/rhcos.json "$outdir" || true
 
     podman rm -f "$baremetal_container"
-}
-
-function clone_installer() {
-  # Clone repo, if not already present
-  if [[ ! -d $OPENSHIFT_INSTALL_PATH ]]; then
-    sync_repo_and_patch go/src/github.com/openshift/installer https://github.com/openshift/installer.git
-  fi
-}
-
-function build_installer() {
-  # Build installer
-  pushd .
-  cd $OPENSHIFT_INSTALL_PATH
-  TAGS="libvirt baremetal" DEFAULT_ARCH=$(get_arch) hack/build.sh
-  popd
-  # This is only needed in rhcos.sh for old versions which lack the
-  # openshift-install coreos-print-stream-json option
-  # That landed in 4.8, and in 4.10 this file moved, so just
-  # skip copying it if it's not in the "old" location ref
-  # https://github.com/openshift/installer/pull/5252
-  if [ -f "$OPENSHIFT_INSTALL_PATH/data/data/rhcos.json" ]; then
-    cp "$OPENSHIFT_INSTALL_PATH/data/data/rhcos.json" "$OCP_DIR"
-  fi
 }
 
 function baremetal_network_configuration() {

--- a/utils.sh
+++ b/utils.sh
@@ -266,16 +266,19 @@ function sync_repo_and_patch {
 
     pushd $DEST
 
-    DEFAULT_BRANCH=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')
+    REPO_NAME=$(basename "$1" .git | tr "a-z" "A-Z" | tr "-" "_")
+    REPO_BRANCH_VAR="${REPO_NAME}_REPO_BRANCH"
+    REPO_BRANCH=${!REPO_BRANCH_VAR:-$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')}
 
     git am --abort || true
-    git checkout ${DEFAULT_BRANCH}
+    git checkout ${REPO_BRANCH}
     git fetch origin
-    git rebase origin/${DEFAULT_BRANCH}
+    git rebase origin/${REPO_BRANCH}
 
     # If set, use the specified PR number
-    if test "$#" -gt "2" ; then
-      REPO_PR=$3
+    REPO_PR_VAR="${REPO_NAME}_REPO_PR"
+    REPO_PR=${!REPO_PR_VAR:-}
+    if [[ ! -z "${REPO_PR}" ]] ; then
       echo "Fetching PR ${REPO_PR}"
       git fetch origin pull/${REPO_PR}/head:pr${REPO_PR}
       git checkout pr${REPO_PR}


### PR DESCRIPTION
This patch modifies the openshift installer functions so that it will be possible to reuse the `03_build_installer.sh` also for non-baremetal flows (it will be used by the agent flow in a subsequent patch).

In addition, it allows the `sync_repo_and_patch` to use a different branch (also this feature will be required by the agent flow, as currently is being developed in its own installer branch)