### PR TITLE
AGENT-164: Use openshift installer for the agent flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: default all agent agent_cleanup agent_deployment requirements configure ironic ocp_run install_config clean ocp_cleanup ironic_cleanup host_cleanup cache_cleanup registry_cleanup proxy_cleanup workingdir_cleanup podman_cleanup bell
+.PHONY: default all agent agent_cleanup agent_build_installer agent_configure agent_create_cluster requirements configure ironic ocp_run install_config clean ocp_cleanup ironic_cleanup host_cleanup cache_cleanup registry_cleanup proxy_cleanup workingdir_cleanup podman_cleanup bell
 default: requirements configure build_installer ironic install_config ocp_run bell
 
 all: default
@@ -7,10 +7,16 @@ all: default
 assisted: assisted_deployment bell
 
 # Deploy cluster with agent installer flow
-agent: requirements configure agent_deployment
+agent: requirements configure agent_build_installer agent_configure agent_create_cluster
 
-agent_deployment:
-	./agent/03_agent_deployment.sh
+agent_build_installer:
+	./agent/03_agent_build_installer.sh
+
+agent_configure:
+	./agent/04_agent_configure.sh
+
+agent_create_cluster:
+	./agent/05_agent_create_cluster.sh
 
 agent_cleanup:
 	./agent/cleanup.sh

--- a/agent/03_agent_build_installer.sh
+++ b/agent/03_agent_build_installer.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+
+LOGDIR=${SCRIPTDIR}/logs
+source $SCRIPTDIR/logging.sh
+source $SCRIPTDIR/common.sh
+source $SCRIPTDIR/agent/common.sh
+
+# Use the development branch for building the openshift installer.
+# Used only when KNI_INSTALL_FROM_GIT is set and OPENSHIFT_INSTALL_PATH
+# does not exists. This setting will be removed once the development
+# branch will be merged in the installer main
+export INSTALLER_REPO_BRANCH=agent-installer
+
+# Override build tags
+export OPENSHIFT_INSTALLER_BUILD_TAGS=" "
+
+# Override command name in case of extraction
+export OPENSHIFT_INSTALLER_CMD="openshift-install"
+
+source $SCRIPTDIR/03_build_installer.sh
+
+# Copy install binary if built from src
+if [ ! -z "$KNI_INSTALL_FROM_GIT" -a -f "$OPENSHIFT_INSTALL_PATH/bin/openshift-install" ]; then 
+    cp "$OPENSHIFT_INSTALL_PATH/bin/openshift-install" "$OCP_DIR"
+fi

--- a/agent/05_agent_create_cluster.sh
+++ b/agent/05_agent_create_cluster.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+
+LOGDIR=${SCRIPTDIR}/logs
+source $SCRIPTDIR/logging.sh
+source $SCRIPTDIR/common.sh
+source $SCRIPTDIR/network.sh
+source $SCRIPTDIR/utils.sh
+source $SCRIPTDIR/validation.sh
+source $SCRIPTDIR/agent/common.sh
+
+early_deploy_validation
+
+function create_image() {
+  pushd ${OCP_DIR}
+  ./openshift-install --dir "${OCP_DIR}" --log-level=debug agent create image
+  popd  
+}
+
+function attach_agent_iso() {
+    for (( n=0; n<${2}; n++ ))
+    do
+        name=${CLUSTER_NAME}_${1}_${n}
+        sudo virt-xml ${name} --add-device --disk "${OCP_DIR}/output/fleeting.iso",device=cdrom,target.dev=sdc
+        sudo virt-xml ${name} --edit target=sda --disk="boot_order=1"
+        sudo virt-xml ${name} --edit target=sdc --disk="boot_order=2" --start
+    done
+}
+
+create_image
+
+attach_agent_iso master $NUM_MASTERS
+attach_agent_iso worker $NUM_WORKERS
+
+

--- a/agent/README.md
+++ b/agent/README.md
@@ -22,3 +22,32 @@ compact cluster:
 Then run the `agent` target:
 
     $ make agent
+
+# Agent flow steps
+
+| No | Step | Description | Agent specific? |
+|---|---|---|---|
+| 01 | requirements | Installs all the required software and dependencies | no |
+| 02 | configure | Setup the network and VMs as per the specified configuration | no |
+| 03 | agent_build_installer | Builds (or extract from the release payload) the openshift installer | yes |
+| 04 | agent_configure | Further network customization and agent manifests creation (stored in `OCP_DIR`)  | yes |
+| 05 | agent_create_cluster | Generates the agent image using openshift installer and boots the VM | yes |
+| - | agent_cleanup | Deletes the agent manifests and images | yes | 
+
+# Agent artifacts
+
+Agent artifacts are stored in the `OCP_DIR` folder, located in the current dev-scripts checkout
+
+# Usage scenarios
+
+It's possible to use dev-scripts for different scenarios / goals, and the following section will describe
+the recommended configurations through some concrete examples.
+
+| Recommended scenario | Configuration | Notes |
+| --- | --- | --- |
+| dev | `KNI_INSTALL_FROM_GIT=true`<br>`OPENSHIFT_INSTALL_PATH=~/git/installer` | Useful for testing while developing a new feature, using an already existing local checkout |
+| qe | `KNI_INSTALL_FROM_GIT=true`<br>`INSTALLER_REPO_PR=5891` | Recommended for testing a PR if the installer sources are _not_ locally available<br> (repo will be checked out in `~/go/src/github.com/openshift/installer`) |
+| qe | `KNI_INSTALL_FROM_GIT=true` | As the previous case, but focusing on the latest sources available |
+| dev/qe |  | In this case the latest _nightly_ release is automatically downloaded, and the installer is extracted<br>from that payload. `OPENSHIFT_RELEASE_STREAM` and `OPENSHIFT_RELEASE_TYPE` respectively<br>are used to determine the version and stream to be gathered |
+| dev/qe | `OPENSHIFT_RELEASE_IMAGE=`<br>`registry.ci.openshift.org/ocp/release:4.11.0-0.nightly-2022-05-11-054135` | As before, but pinning to a specific release version |
+| CI | `OPENSHIFT_RELEASE_IMAGE=<ephemeral payload pullspec>`<br>`OPENSHIFT_CI=true` | This is the configuration used in the CI to test an ephemeral payload |

--- a/agent/cleanup.sh
+++ b/agent/cleanup.sh
@@ -12,10 +12,5 @@ source $SCRIPTDIR/agent/common.sh
 
 early_cleanup_validation
 
-if [ -d "${FLEETING_MANIFESTS_PATH}" ]; then
-    rm -f ${FLEETING_MANIFESTS_PATH}/*.yaml
-fi
-
-if [ -f "${FLEETING_ISO}" ]; then
-    rm -f ${FLEETING_ISO}
-fi
+rm -rf "${OCP_DIR}/manifests"
+rm -rf "${OCP_DIR}/output"

--- a/agent/common.sh
+++ b/agent/common.sh
@@ -1,8 +1,4 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-export FLEETING_PATH=${FLEETING_PATH:-$WORKING_DIR/fleeting}
-export FLEETING_ISO=${FLEETING_ISO:-$FLEETING_PATH/output/fleeting.iso}
-export FLEETING_MANIFESTS_PATH="${FLEETING_PATH}/manifests"
-export FLEETING_PR=${FLEETING_PR:-}
-export FLEETING_STATIC_IP_NODE0_ONLY=${FLEETING_STATIC_IP_NODE0_ONLY:-"false"}
+export AGENT_STATIC_IP_NODE0_ONLY=${AGENT_STATIC_IP_NODE0_ONLY:-"false"}

--- a/config_example.sh
+++ b/config_example.sh
@@ -317,13 +317,5 @@ set -x
 ## Agent Deployment
 ##
 
-# To use a local checkout of the fleeting repo, instead of fetching the remote
-# main branch
-# export FLEETING_PATH=~/go/src/github.com/openshift-agent-team/fleeting
-
-# When set, the changes associated to the specified pull request (for the fleeting repo)
-# are fetched, instead of using the main branch
-# export FLEETING_PR=12
-
 # Set whether static IPs will be used for all nodes or only Node0
-# export FLEETING_STATIC_IP_NODE0_ONLY="true"
+# export AGENT_STATIC_IP_NODE0_ONLY="true"


### PR DESCRIPTION
This patch requires https://github.com/openshift-metal3/dev-scripts/pull/1392

It changes the agent flow in order to use the openshift installer, by reusing the existing build installer step (properly customized where required).
A new `agent_build_installer` has been added to rebuild the installer from source or extract it from the release payload (more docs on this point will follow), and it could be used also in standalone way if required.
The previous `agent_deployment` step was split in two:
* `agent_configure` will now configure the environment and networking, and also create the manifests (this step could be further split in future)
* `agent_create_cluster` generates the image and starts the cluster installation.

The current working dir is set under $OCP_DIR, by default the `ocp/ostest` folder within your local dev-scripts check out