### PR TITLE
Rename "fleeting.iso" to "agent.iso"

### DIFF
--- a/agent/05_agent_create_cluster.sh
+++ b/agent/05_agent_create_cluster.sh
@@ -23,7 +23,7 @@ function attach_agent_iso() {
     for (( n=0; n<${2}; n++ ))
     do
         name=${CLUSTER_NAME}_${1}_${n}
-        sudo virt-xml ${name} --add-device --disk "${OCP_DIR}/output/fleeting.iso",device=cdrom,target.dev=sdc
+        sudo virt-xml ${name} --add-device --disk "${OCP_DIR}/output/agent.iso",device=cdrom,target.dev=sdc
         sudo virt-xml ${name} --edit target=sda --disk="boot_order=1"
         sudo virt-xml ${name} --edit target=sdc --disk="boot_order=2" --start
     done


### PR DESCRIPTION
fleeting was the temp name for agent-installer.