### PR TITLE
Use correct output directory for all assets

### DIFF
--- a/agent/05_agent_create_cluster.sh
+++ b/agent/05_agent_create_cluster.sh
@@ -14,9 +14,13 @@ source $SCRIPTDIR/agent/common.sh
 early_deploy_validation
 
 function create_image() {
-  pushd ${OCP_DIR}
-  ./openshift-install --dir "${OCP_DIR}" --log-level=debug agent create image
-  popd  
+    local asset_dir="${1:-${OCP_DIR}}"
+    local openshift_install="$(realpath "${OCP_DIR}/openshift-install")"
+    # TODO: replace pushd with --dir argument once nothing in agent
+    # installer depends on the working directory
+    pushd "${asset_dir}"
+    "${openshift_install}" --log-level=debug agent create image
+    popd
 }
 
 function attach_agent_iso() {


### PR DESCRIPTION
We can't cd into the working directory *and* pass a --dir, because
assets end up getting written to ocp/ostest/ocp/ostest.

Eventually we will prefer passing --dir, but for now there is legacy
fleeting code that looks for files relevant to the current working
directory.