### PR TITLE
AGENT-179: wait for cluster ready

### DIFF
--- a/agent/05_agent_create_cluster.sh
+++ b/agent/05_agent_create_cluster.sh
@@ -29,9 +29,31 @@ function attach_agent_iso() {
     done
 }
 
+function wait_for_cluster_ready() {
+
+  node0_name=$(printf ${MASTER_HOSTNAME_FORMAT} 0)
+  node0_ip=$(sudo virsh net-dumpxml ostestbm | xmllint --xpath "string(//dns[*]/host/hostname[. = '${node0_name}']/../@ip)" -)
+  ssh_opts=(-o 'StrictHostKeyChecking=no' -q core@${node0_ip})
+
+  until ssh "${ssh_opts[@]}" "[[ -f /var/lib/kubelet/kubeconfig ]]" 
+  do 
+    echo "Waiting for bootstrap... "
+    sleep 1m; 
+  done
+
+  sleep 5m
+
+  echo "Waiting for cluster ready... "
+  if ssh "${ssh_opts[@]}" "sudo  oc wait --for=condition=Ready nodes --all --timeout=60m --kubeconfig=/var/lib/kubelet/kubeconfig"; then
+    echo "Cluster is ready!"
+  else
+    exit 1
+  fi
+}
+
 create_image
 
 attach_agent_iso master $NUM_MASTERS
 attach_agent_iso worker $NUM_WORKERS
 
-
+wait_for_cluster_ready


### PR DESCRIPTION
This patch adds a rudimentary waiting condition to detect when the cluster is available and ready to be used.
This will be used to implement the first CI job.