### PR TITLE
NO-ISSUE: Pin community.general collection to version 4.8.1

### DIFF
--- a/images/Dockerfile.ci
+++ b/images/Dockerfile.ci
@@ -6,7 +6,7 @@ ENV HOME /output
 RUN INSTALL_PKGS="ansible python-pip nss_wrapper" && \
     yum install -y $INSTALL_PKGS && \
     pip install packet-python && \
-    ansible-galaxy collection install community.general && \
+    ansible-galaxy collection install "community.general:4.8.1" && \
     yum clean all && \
     rm -rf /var/cache/yum/* && \
     chmod -R g+rwx /output && \


### PR DESCRIPTION
The provisioning of equinix machines is broken because it fails with:
```
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Unsupported parameters for (packet_device) module: tags Supported parameters include: always_pxe, auth_token, count,
 count_offset, device_ids, facility, features, hostnames, ipxe_script_url, locked, operating_system, plan, project_id, state, user_data, wait_for_public_IPv, wait_timeout"}
```

This issue seems to be related to the latest version (`5.0.0`) of the `community.general` ansible collection which drops the support for ansible 2.9 that we install (https://github.com/ansible-collections/community.general/blob/stable-5/CHANGELOG.rst#major-changes)

This change pins the `community.general` ansible collection to the previous version `4.8.1` which seems to work well.