### PR TITLE
Agent: change input/output directories

### DIFF
--- a/agent/04_agent_configure.sh
+++ b/agent/04_agent_configure.sh
@@ -61,8 +61,7 @@ function get_static_ips_and_macs() {
 
 function generate_cluster_manifests() {
 
-  # To be change in ${OCP_DIR}/cluster-manifests
-  MANIFESTS_PATH="${OCP_DIR}/manifests"
+  MANIFESTS_PATH="${OCP_DIR}/cluster-manifests"
 
   mkdir -p ${MANIFESTS_PATH}
   
@@ -225,3 +224,6 @@ set_api_and_ingress_vip
 
 generate_cluster_manifests
 
+
+# TODO: remove this once installer reads from cluster-manifests directory
+ln -s cluster-manifests ${OCP_DIR}/manifests

--- a/agent/04_agent_configure.sh
+++ b/agent/04_agent_configure.sh
@@ -227,3 +227,6 @@ generate_cluster_manifests
 
 # TODO: remove this once installer reads from cluster-manifests directory
 ln -s cluster-manifests ${OCP_DIR}/manifests
+
+# TODO: remove this once installer writes to the working directory
+ln -s output/agent.iso ${OCP_DIR}/agent.iso

--- a/agent/05_agent_create_cluster.sh
+++ b/agent/05_agent_create_cluster.sh
@@ -33,7 +33,7 @@ function attach_agent_iso() {
     for (( n=0; n<${2}; n++ ))
     do
         name=${CLUSTER_NAME}_${1}_${n}
-        sudo virt-xml ${name} --add-device --disk "${OCP_DIR}/output/agent.iso",device=cdrom,target.dev=sdc
+        sudo virt-xml ${name} --add-device --disk "${OCP_DIR}/agent.iso",device=cdrom,target.dev=sdc
         sudo virt-xml ${name} --edit target=sda --disk="boot_order=1"
         sudo virt-xml ${name} --edit target=sdc --disk="boot_order=2" --start
     done


### PR DESCRIPTION
Rename `manifests` to `cluster-manifests`
Expect agent.iso in work directory, not in `outputs` subdirectory.

Use symlinks to prevent CI breakage until this is changed in the installer.