### PR TITLE
AGENT-165: revert PR1404 to re-enable release image hard-coding

### DIFF
--- a/agent/04_agent_configure.sh
+++ b/agent/04_agent_configure.sh
@@ -87,7 +87,7 @@ spec:
   clusterDeploymentRef:
     name: ${CLUSTER_NAME}
   imageSetRef:
-    name: openshift-${OPENSHIFT_RELEASE_STREAM}
+    name: openshift-v4.10.0
   networking:
     clusterNetwork:
     - cidr: ${CLUSTER_NETWORK}
@@ -129,9 +129,9 @@ EOF
 apiVersion: hive.openshift.io/v1
 kind: ClusterImageSet
 metadata:
-  name: openshift-${OPENSHIFT_RELEASE_STREAM}
+  name: openshift-v4.10.0
 spec:
-  releaseImage: ${OPENSHIFT_RELEASE_IMAGE}
+  releaseImage: quay.io/openshift-release-dev/ocp-release:4.10.10-x86_64
 EOF
 
     cat > "${MANIFESTS_PATH}/infraenv.yaml" << EOF


### PR DESCRIPTION
The installer code has reverted back to hard-coding in:
https://github.com/openshift/installer/pull/5954/

Revert dev-scripts back to hard-coding so that the release
image versions are consistent. Reverts #1404.

Without revert, local agent deployments are failing because
the ClusterImageSet is set with spec.releaseImage:

registry.ci.openshift.org/ocp/release:4.11.0-0.nightly-2022-06-01-200905

while the assisted-service RELEASE_IMAGES env var has:

quay.io/openshift-release-dev/ocp-release:4.10.0-rc.1-x86_64

The mismatch causes create-cluster-and-infraenv.service to fail.