### PR TITLE
AGENT-216: Add agent support for disconnected installs

### DIFF
--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -102,30 +102,7 @@ done
 
 if [ ! -z "${MIRROR_IMAGES}" ]; then
 
-    # combine global and local secrets
-    # pull from one registry and push to local one
-    # hence credentials are different
-
-    EXTRACT_DIR=$(mktemp --tmpdir -d "mirror-installer--XXXXXXXXXX")
-    _tmpfiles="$_tmpfiles $EXTRACT_DIR"
-
-    oc adm release mirror \
-       --insecure=true \
-        -a ${PULL_SECRET_FILE}  \
-        --from ${OPENSHIFT_RELEASE_IMAGE} \
-        --to-release-image ${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/local-release-image:${OPENSHIFT_RELEASE_TAG} \
-        --to ${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/local-release-image 2>&1 | tee ${MIRROR_LOG_FILE}
-    echo "export MIRRORED_RELEASE_IMAGE=$OPENSHIFT_RELEASE_IMAGE" > /tmp/mirrored_release_image
-
-    #To ensure that you use the correct images for the version of OpenShift Container Platform that you selected,
-    #you must extract the installation program from the mirrored content:
-    if [ -z "$KNI_INSTALL_FROM_GIT" ]; then
-      oc adm release extract --registry-config "${PULL_SECRET_FILE}" \
-        --command=openshift-baremetal-install --to "${EXTRACT_DIR}" \
-        "${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/local-release-image:${OPENSHIFT_RELEASE_TAG}"
-
-      mv -f "${EXTRACT_DIR}/openshift-baremetal-install" ${OCP_DIR}
-    fi
+    setup_release_mirror
 
     # Build a local release image, if no *_LOCAL_IMAGE env variables are set then this is just a copy of the release image
     sudo podman image build --authfile $PULL_SECRET_FILE -t $OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE -f $DOCKERFILE

--- a/agent/03_agent_build_installer.sh
+++ b/agent/03_agent_build_installer.sh
@@ -18,9 +18,6 @@ export INSTALLER_REPO_BRANCH=agent-installer
 # Override build tags
 export OPENSHIFT_INSTALLER_BUILD_TAGS=" "
 
-# Override command name in case of extraction
-export OPENSHIFT_INSTALLER_CMD="openshift-install"
-
 source $SCRIPTDIR/03_build_installer.sh
 
 # Writes the currently used openshift version in the installer binary,
@@ -40,5 +37,6 @@ function patch_openshift_install_version() {
 # Copy install binary if built from src
 if [ ! -z "$KNI_INSTALL_FROM_GIT" -a -f "$OPENSHIFT_INSTALL_PATH/bin/openshift-install" ]; then
     cp "$OPENSHIFT_INSTALL_PATH/bin/openshift-install" "$OCP_DIR"
+
     patch_openshift_install_version
 fi

--- a/agent/04_agent_configure.sh
+++ b/agent/04_agent_configure.sh
@@ -141,7 +141,7 @@ EOF
 
     local releaseImage=${OPENSHIFT_RELEASE_IMAGE}
     if [ ! -z "${MIRROR_IMAGES}" ]; then
-        releaseImage="${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/local-release-image:${OPENSHIFT_RELEASE_TAG}"
+        releaseImage="${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE}"
     fi
 
     cat > "${MANIFESTS_PATH}/cluster-image-set.yaml" << EOF

--- a/agent/04_agent_configure.sh
+++ b/agent/04_agent_configure.sh
@@ -63,11 +63,15 @@ function get_static_ips_and_macs() {
 function generate_cluster_manifests() {
 
   MANIFESTS_PATH="${OCP_DIR}/cluster-manifests"
+  MIRROR_PATH="${OCP_DIR}/mirror"
 
   # Fetch current OpenShift version from the release payload
   VERSION="$(openshift_version ${OCP_DIR})"
 
   mkdir -p ${MANIFESTS_PATH}
+  if [ ! -z "${MIRROR_IMAGES}" ]; then
+    mkdir -p ${MIRROR_PATH}
+  fi
   
   if [[ "$IP_STACK" = "v4" ]]; then
     CLUSTER_NETWORK=${CLUSTER_SUBNET_V4}
@@ -135,14 +139,44 @@ spec:
     name: pull-secret
 EOF
 
+    local releaseImage=${OPENSHIFT_RELEASE_IMAGE}
+    if [ ! -z "${MIRROR_IMAGES}" ]; then
+        releaseImage="${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/local-release-image:${OPENSHIFT_RELEASE_TAG}"
+    fi
+
     cat > "${MANIFESTS_PATH}/cluster-image-set.yaml" << EOF
 apiVersion: hive.openshift.io/v1
 kind: ClusterImageSet
 metadata:
   name: openshift-${VERSION}
 spec:
-  releaseImage: ${OPENSHIFT_RELEASE_IMAGE}
+  releaseImage: $releaseImage
 EOF
+
+if [ ! -z "${MIRROR_IMAGES}" ]; then
+# TODO - get the mirror registry info from output of 'oc adm release mirror'
+
+    cat > "${MIRROR_PATH}/registries.conf" << EOF
+[[registry]]
+prefix = ""
+location = "registry.ci.openshift.org/ocp/release"
+mirror-by-digest-only = false
+
+[[registry.mirror]]
+location = "${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/local-release-image"
+
+[[registry]]
+prefix = ""
+location = "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
+mirror-by-digest-only = false
+
+[[registry.mirror]]
+location = "${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/local-release-image"
+EOF
+
+cp $REGISTRY_DIR/certs/$REGISTRY_CRT ${MIRROR_PATH}/ca-bundle.crt
+
+fi
 
     cat > "${MANIFESTS_PATH}/infraenv.yaml" << EOF
 apiVersion: agent-install.openshift.io/v1beta1
@@ -229,6 +263,15 @@ write_pull_secret
 sudo yum install -y nmstate
 
 get_static_ips_and_macs
+
+
+if [ ! -z "${MIRROR_IMAGES}" ]; then
+
+  setup_local_registry
+
+  setup_release_mirror
+
+fi
 
 if [[ "${NUM_MASTERS}" > "1" ]]; then
   set_api_and_ingress_vip

--- a/agent/common.sh
+++ b/agent/common.sh
@@ -2,3 +2,11 @@
 set -euxo pipefail
 
 export AGENT_STATIC_IP_NODE0_ONLY=${AGENT_STATIC_IP_NODE0_ONLY:-"false"}
+
+# Override command name in case of extraction
+export OPENSHIFT_INSTALLER_CMD="openshift-install"
+
+if [ -n "$MIRROR_IMAGES" ]; then
+    # We're going to be using a locally modified release image
+    export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/local-release-image:${OPENSHIFT_RELEASE_TAG}"
+fi

--- a/utils.sh
+++ b/utils.sh
@@ -389,6 +389,34 @@ EOF
     fi
 }
 
+function setup_release_mirror {
+
+    # combine global and local secrets
+    # pull from one registry and push to local one
+    # hence credentials are different
+
+    oc adm release mirror \
+       --insecure=true \
+        -a ${PULL_SECRET_FILE}  \
+        --from ${OPENSHIFT_RELEASE_IMAGE} \
+        --to-release-image ${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/local-release-image:${OPENSHIFT_RELEASE_TAG} \
+        --to ${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/local-release-image 2>&1 | tee ${MIRROR_LOG_FILE}
+    echo "export MIRRORED_RELEASE_IMAGE=$OPENSHIFT_RELEASE_IMAGE" > /tmp/mirrored_release_image
+
+    #To ensure that you use the correct images for the version of OpenShift Container Platform that you selected,
+    #you must extract the installation program from the mirrored content:
+    if [ -z "$KNI_INSTALL_FROM_GIT" ]; then
+      EXTRACT_DIR=$(mktemp --tmpdir -d "mirror-installer--XXXXXXXXXX")
+      _tmpfiles="$_tmpfiles $EXTRACT_DIR"
+
+      oc adm release extract --registry-config "${PULL_SECRET_FILE}" \
+        --command=openshift-baremetal-install --to "${EXTRACT_DIR}" \
+        "${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/local-release-image:${OPENSHIFT_RELEASE_TAG}"
+
+      mv -f "${EXTRACT_DIR}/openshift-baremetal-install" ${OCP_DIR}
+    fi
+}
+
 function setup_local_registry() {
 
     # httpd-tools provides htpasswd utility

--- a/utils.sh
+++ b/utils.sh
@@ -406,14 +406,16 @@ function setup_release_mirror {
     #To ensure that you use the correct images for the version of OpenShift Container Platform that you selected,
     #you must extract the installation program from the mirrored content:
     if [ -z "$KNI_INSTALL_FROM_GIT" ]; then
+      local installer="${OPENSHIFT_INSTALLER_CMD:-openshift-baremetal-install}"
+
       EXTRACT_DIR=$(mktemp --tmpdir -d "mirror-installer--XXXXXXXXXX")
       _tmpfiles="$_tmpfiles $EXTRACT_DIR"
 
       oc adm release extract --registry-config "${PULL_SECRET_FILE}" \
-        --command=openshift-baremetal-install --to "${EXTRACT_DIR}" \
+        --command=$installer --to "${EXTRACT_DIR}" \
         "${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/local-release-image:${OPENSHIFT_RELEASE_TAG}"
 
-      mv -f "${EXTRACT_DIR}/openshift-baremetal-install" ${OCP_DIR}
+      mv -f "${EXTRACT_DIR}/$installer" ${OCP_DIR}
     fi
 }
 


### PR DESCRIPTION
First step in using disconnected installs for agent. The new files required for disconnected installs are created (registries.conf and ca-bundle.crt) and the release image is mirrored to the local image server.

A follow on will add images for the assisted-* components to the local image server.

To test set:
export MIRROR_IMAGES=true
export INSTALLER_REPO_PR=5992
export KNI_INSTALL_FROM_GIT=true

