### PR TITLE
Ensure bootstrap_ip doesn't fail

### DIFF
--- a/utils.sh
+++ b/utils.sh
@@ -552,7 +552,7 @@ function bootstrap_ip {
                       | grep "${pref_ip}" \
                       | tail -n1 \
                       | awk '{print $5}' \
-                      | sed -e 's/\(.*\)\/.*/\1/'
+                      | sed -e 's/\(.*\)\/.*/\1/' || true
   else
     echo "Unable to retrieve bootstrap IP with infinite leases enabled." 1>&2
   fi


### PR DESCRIPTION
Force the command to get the bootstrap ip to succeed.

If running a DHCP server outside of dev-scripts
(with MANAGE_BR_BRIDGE=n) then the net-dhcp-leases command
will return nothing, because we have "set -o pipefail" this
causes the whole script to stall.