### PR TITLE
Save installer exit status in logs

### DIFF
--- a/utils.sh
+++ b/utils.sh
@@ -594,6 +594,7 @@ function removetmp(){
 }
 
 function auth_template_and_removetmp(){
+    echo $? > "$LOGDIR"/installer-status.txt
     generate_auth_template
     removetmp
 }


### PR DESCRIPTION
Make eats all exit codes:
http://www.gnu.org/software/make/manual/html_node/Running.html. So when
make fails, regardless of the error code the installer or dev-scripts
returns, make exits 2. Make's behavior seems to be non-configurable.

By recording it in the log, we can look for it later.