### PR TITLE
agent: patch openshift install version if missing

### DIFF
--- a/agent/03_agent_build_installer.sh
+++ b/agent/03_agent_build_installer.sh
@@ -6,6 +6,7 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 LOGDIR=${SCRIPTDIR}/logs
 source $SCRIPTDIR/logging.sh
 source $SCRIPTDIR/common.sh
+source $SCRIPTDIR/ocp_install_env.sh
 source $SCRIPTDIR/agent/common.sh
 
 # Use the development branch for building the openshift installer.
@@ -22,7 +23,22 @@ export OPENSHIFT_INSTALLER_CMD="openshift-install"
 
 source $SCRIPTDIR/03_build_installer.sh
 
+# Writes the currently used openshift version in the installer binary,
+# if it was built from src
+function patch_openshift_install_version() {
+    local res=$(grep -oba ._RELEASE_VERSION_LOCATION_.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX ${OCP_DIR}/openshift-install)
+    local location=${res%%:*}
+
+    # If the release marker was found then it means that the version is missing
+    if [[ ! -z ${location} ]]; then
+        version="$(openshift_release_version ${OCP_DIR})"
+        echo "Patching openshift-install with version ${version}"
+        printf "${version}\0" | dd of=${OCP_DIR}/openshift-install bs=1 seek=${location} conv=notrunc &> /dev/null 
+    fi
+}
+
 # Copy install binary if built from src
-if [ ! -z "$KNI_INSTALL_FROM_GIT" -a -f "$OPENSHIFT_INSTALL_PATH/bin/openshift-install" ]; then 
+if [ ! -z "$KNI_INSTALL_FROM_GIT" -a -f "$OPENSHIFT_INSTALL_PATH/bin/openshift-install" ]; then
     cp "$OPENSHIFT_INSTALL_PATH/bin/openshift-install" "$OCP_DIR"
+    patch_openshift_install_version
 fi


### PR DESCRIPTION
Agent installer extracts the version information directly from the binary, and it's used to configure the assisted-service via the RELEASE_IMAGES env var. When building from src anyhow this info is missing, so this patches the binary similary to what the `oc adm release extract` command does.
Since assisted-service will check the content of the RELEASE_IMAGES with the `.metadata.version` field of the extracted release info, we're going to patch it otherwise the installation process won't start.