### PR TITLE
Add interface for custom networkConfig

### DIFF
--- a/config_example.sh
+++ b/config_example.sh
@@ -347,6 +347,25 @@ set -x
 # (Currently this just expects a non-empty value, the IP is fixed to .9)
 # export ENABLE_BOOTSTRAP_STATIC_IP=true
 
+# NETWORK_CONFIG_FOLDER -
+# Set this to the location of a folder containing networkConfigs for the nodes
+# in the deployment. The filenames correspond to the name of the host. For
+# example, to provide a networkConfig for master-0 in a default dev-scripts
+# deployment, create a file named `ostest-master-0.yaml` in the specified
+# folder that contains the networkConfig (including the key "networkConfig").
+#
+# This folder may also contain a file named `hosts.yaml` which is a list of
+# additional DNS entries to configure in the libvirt DNS. This should be a
+# list of entries with the following format:
+# - ip: 192.168.111.110
+#   hostnames:
+#     - "master-0"
+
+# BOND_PRIMARY_INTERFACE -
+# When set to any value this will cause dev-scripts to include duplicate nics
+# on the primary network. This is intended for testing bonded network configs
+# and may not work without a bond config.
+
 ################################################################################
 ## VM Settings
 ##

--- a/network.sh
+++ b/network.sh
@@ -188,6 +188,11 @@ if  [[ ! -z "${INSTALLER_PROXY:-}" ]]; then
   fi
 fi
 
+if [ -n "${NETWORK_CONFIG_FOLDER:-}" ]; then
+  # We need an absolute path to this location
+  NETWORK_CONFIG_FOLDER="$(readlink -m $NETWORK_CONFIG_FOLDER)"
+fi
+
 function set_api_and_ingress_vip() {
   # NOTE: This is equivalent to the external API DNS record pointing the API to the API VIP
   if [ "$MANAGE_BR_BRIDGE" == "y" ] ; then

--- a/utils.sh
+++ b/utils.sh
@@ -226,7 +226,7 @@ function node_map_to_install_config_hosts() {
         bootMACAddress: ${mac}
         bootMode: ${boot_mode}
 EOF
-        if [ -n "$NETWORK_CONFIG_FOLDER" ]; then
+        if [ -n "${NETWORK_CONFIG_FOLDER:-}" ]; then
             node_network_config="${NETWORK_CONFIG_FOLDER}/${name}.yaml"
             if [ -e "$node_network_config" ]; then
                 cat "$node_network_config" | sed "s/\(.*\)/        \1/"

--- a/utils.sh
+++ b/utils.sh
@@ -226,6 +226,12 @@ function node_map_to_install_config_hosts() {
         bootMACAddress: ${mac}
         bootMode: ${boot_mode}
 EOF
+        if [ -n "$NETWORK_CONFIG_FOLDER" ]; then
+            node_network_config="${NETWORK_CONFIG_FOLDER}/${name}.yaml"
+            if [ -e "$node_network_config" ]; then
+                cat "$node_network_config" | sed "s/\(.*\)/        \1/"
+            fi
+        fi
 
         # FIXME(stbenjam) Worker code in installer should accept
         # "default" as well -- currently the mapping doesn't work,

--- a/vm_setup_vars.yml
+++ b/vm_setup_vars.yml
@@ -79,3 +79,5 @@ external_network:
       forwarders:
         - domain: "apps.{{ cluster_domain }}"
           addr: "127.0.0.1"
+
+networks: "{{ provisioning_network + external_network + (extra_networks | default([])) if not lookup('env', 'BOND_PRIMARY_INTERFACE') else provisioning_network + external_network + external_network + (extra_networks | default([])) }}"

--- a/vm_setup_vars.yml
+++ b/vm_setup_vars.yml
@@ -46,6 +46,10 @@ dns_extrahosts:
     hostnames:
       - "virthost"
 
+network_config_folder: "{{ lookup('env', 'NETWORK_CONFIG_FOLDER') | default(false) }}"
+hosts_config: "{{ lookup('template', network_config_folder + '/hosts.yaml', errors='ignore') | default('[]', true) | from_yaml }}"
+dns_customhosts: "{{ [] if not network_config_folder else hosts_config }}"
+
 provisioning_network:
   - name: "{{ provisioning_network_name  }}"
     bridge: "{{ provisioning_network_name  }}"
@@ -71,7 +75,7 @@ external_network:
       - 65535
     domain: "{{ cluster_domain }}"
     dns:
-      hosts: "{{dns_extrahosts | default([])}}"
+      hosts: "{{dns_extrahosts + dns_customhosts | default([])}}"
       forwarders:
         - domain: "apps.{{ cluster_domain }}"
           addr: "127.0.0.1"


### PR DESCRIPTION
This provides a way to specify a custom networkConfig for each node
in a deployment. The user sets NETWORK_CONFIG_FOLDER to a path that
contains YAML files named for each node. The contents of these files
are included in the install-config definition for the appropriate
node.