### PR TITLE
Don't append to existing dnsmasq config

### DIFF
--- a/network.sh
+++ b/network.sh
@@ -198,7 +198,7 @@ function set_api_and_ingress_vip() {
           API_VIP=$(dig +noall +answer "api.${CLUSTER_DOMAIN}" @$(network_ip ${BAREMETAL_NETWORK_NAME}) | awk '{print $NF}')
           INGRESS_VIP=$(nth_ip $EXTERNAL_SUBNET_V4 4)
       fi
-      echo "address=/api.${CLUSTER_DOMAIN}/${API_VIP}" | sudo tee -a /etc/NetworkManager/dnsmasq.d/openshift-${CLUSTER_NAME}.conf
+      echo "address=/api.${CLUSTER_DOMAIN}/${API_VIP}" | sudo tee /etc/NetworkManager/dnsmasq.d/openshift-${CLUSTER_NAME}.conf
       echo "address=/.apps.${CLUSTER_DOMAIN}/${INGRESS_VIP}" | sudo tee -a /etc/NetworkManager/dnsmasq.d/openshift-${CLUSTER_NAME}.conf
       echo "listen-address=::1" | sudo tee -a /etc/NetworkManager/dnsmasq.d/openshift-${CLUSTER_NAME}.conf
 


### PR DESCRIPTION
Previously, if you ran two builds in a row without cleaning in between,
this would append a second copy of the dnsmasq config to the end of the
file. The presence of duplicate line in the config caused an error that
prevented NetworkManager from doing DNS lookups. This meant that even
cleaning was broken, so there was no obvious way to recover.

Overwrite the file instead of appending to it so that this doesn't
happen.