### PR TITLE
Install the yq util system-wise

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -100,7 +100,7 @@ fi
 
 # We use yq in a few places for processing YAML but it isn't packaged
 # for CentOS/RHEL so we have to install from pip.
-pip3 install --user 'yq>=2.10.0'
+sudo pip3 install 'yq>=2.10.0'
 
 # needed if we are using locally built images
 # We stop any systemd service so we can run in a container, since


### PR DESCRIPTION
This is to avoid the system not finding the yq binary when using
recent pip versions.