### PR TITLE
Use manifest listed quay.io/libpod/registry to support arm64 testing

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -319,7 +319,7 @@ export VBMC_MAX_PORT=$((VBMC_BASE_PORT + NUM_MASTERS + NUM_WORKERS + NUM_EXTRA_W
 export REDFISH_EMULATOR_IGNORE_BOOT_DEVICE="${REDFISH_EMULATOR_IGNORE_BOOT_DEVICE:-False}"
 
 # Which docker registry image should we use?
-export DOCKER_REGISTRY_IMAGE=${DOCKER_REGISTRY_IMAGE:-"quay.io/libpod/registry:2"}
+export DOCKER_REGISTRY_IMAGE=${DOCKER_REGISTRY_IMAGE:-"quay.io/libpod/registry:2.8"}
 
 export KUBECONFIG="${SCRIPTDIR}/ocp/$CLUSTER_NAME/auth/kubeconfig"
 


### PR DESCRIPTION
We'd like to use this quay.io/libpod/registry:2.8 because it is manifest listed with arm + x86. Will simplify our ci logic.
