### PR TITLE
Make sure we test for containers with a full name match

### DIFF
--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -138,8 +138,8 @@ if [ ! -z "${MIRROR_IMAGES}" ]; then
 fi
 
 for name in ironic ironic-api ironic-conductor ironic-inspector dnsmasq httpd-${PROVISIONING_NETWORK_NAME} mariadb ipa-downloader; do
-    sudo podman ps | grep -w "$name$" && sudo podman kill $name
-    sudo podman ps --all | grep -w "$name$" && sudo podman rm $name -f
+    sudo podman ps | grep -w " $name$" && sudo podman kill $name
+    sudo podman ps --all | grep -w " $name$" && sudo podman rm $name -f
 done
 
 # Remove existing pod


### PR DESCRIPTION
We were matching containers with a common ending.