### PR TITLE
AGENT-316: Add support for oc mirror

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -68,7 +68,7 @@ fi
 
 export ANSIBLE_FORCE_COLOR=true
 
-if [[ ! -z "${MIRROR_IMAGES}" || $(env | grep "_LOCAL_IMAGE=")  || ! -z "${ENABLE_CBO_TEST:-}" || ! -z "${ENABLE_LOCAL_REGISTRY}" ]]; then
+if use_podman_registry; then
     setup_local_registry
 fi
 
@@ -282,7 +282,7 @@ echo "${PROVISIONING_HOST_EXTERNAL_IP} ${LOCAL_REGISTRY_DNS_NAME}" | sudo tee -a
 # Remove any previous file, or podman login panics when reading the
 # blank authfile with a "assignment to entry in nil map" error
 rm -f ${REGISTRY_CREDS}
-if [[ ! -z "${MIRROR_IMAGES}" || $(env | grep "_LOCAL_IMAGE=")  || ! -z "${ENABLE_CBO_TEST:-}" || ! -z "${ENABLE_LOCAL_REGISTRY}" ]]; then
+if use_podman_registry; then
     # create authfile for local registry
     sudo podman login --authfile ${REGISTRY_CREDS} \
         -u ${REGISTRY_USER} -p ${REGISTRY_PASS} \

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ ocp_run:
 gather:
 	./must_gather.sh
 
-clean: ocp_cleanup ironic_cleanup proxy_cleanup host_cleanup assisted_deployment_cleanup agent_cleanup
+clean: ocp_cleanup ironic_cleanup proxy_cleanup host_cleanup assisted_deployment_cleanup agent_cleanup oc_mirror_cleanup
 
 assisted_deployment_cleanup:
 	./assisted_deployment.sh delete_all
@@ -80,6 +80,9 @@ podman_cleanup:
 
 proxy_cleanup:
 	./proxy_cleanup.sh
+
+oc_mirror_cleanup:
+	./oc_mirror_cleanup.sh
 
 bell:
 	@echo "Done!" $$'\a'

--- a/agent/01_agent_requirements.sh
+++ b/agent/01_agent_requirements.sh
@@ -4,12 +4,50 @@ set -o pipefail
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
-source $SCRIPTDIR/validation.sh
 source $SCRIPTDIR/common.sh
+source $SCRIPTDIR/agent/common.sh
+source $SCRIPTDIR/utils.sh
+source $SCRIPTDIR/validation.sh
 
 early_deploy_validation
 
 if [[ -z ${AGENT_E2E_TEST_SCENARIO} ]]; then
     printf "\nAGENT_E2E_TEST_SCENARIO is missing or empty. Did you forget to set the AGENT_E2E_TEST_SCENARIO env var in the config_<USER>.sh file?"
     invalidAgentValue
+fi
+
+if [[ ${REGISTRY_BACKEND} = "quay" ]]; then
+
+   mkdir -p ${WORKING_DIR}/mirror-registry
+   pushd ${WORKING_DIR}/mirror-registry
+   # run the exec in this dir as execution-environment.tar is also needed
+   mirror_registry_file=mirror-registry.tar.gz
+   mirror_registry_exec=${mirror_registry_file%%.*}
+   if [[ ! -f "./${mirror_registry_exec}" ]]; then
+      curl -O -L https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/mirror-registry/latest/${mirror_registry_file}
+      tar xzf ${mirror_registry_file}
+      chmod +x ${mirror_registry_exec}
+      rm -f ${mirror_registry_file}
+   fi
+   popd
+
+fi
+
+if [[ ! -z "${OC_MIRROR}" ]] && [[ "${OC_MIRROR}" == true ]]; then
+
+   oc_mirror_file=oc-mirror.tar.gz
+   oc_mirror_exec=${oc_mirror_file%%.*}
+   if [[ ! -f "/usr/local/bin/${oc_mirror_exec}" ]]; then
+      curl -O -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/${oc_mirror_file}
+      tar xzf ${oc_mirror_file}
+      chmod +x ${oc_mirror_exec}
+      sudo mv -f ${oc_mirror_exec} /usr/local/bin
+      rm -f ${oc_mirror_file}
+   fi
+
+   # set up the channel using the most recent candidate release
+   release_candidate=`oc mirror list releases --channel=candidate-${OPENSHIFT_RELEASE_STREAM} | tail -1`
+   export OPENSHIFT_RELEASE_TAG="${release_candidate}-x86_64"
+   export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/${MIRROR_IMAGE_URL_SUFFIX}:${OPENSHIFT_RELEASE_TAG}"
+
 fi

--- a/agent/common.sh
+++ b/agent/common.sh
@@ -11,8 +11,14 @@ export CLUSTER_HOST_PREFIX_V4="24"
 export EXTERNAL_SUBNET_V6="fd2e:6f44:5dd8:c956::/64"
 
 if [ -n "$MIRROR_IMAGES" ]; then
-    # We're going to be using a locally modified release image
-    export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/local-release-image:${OPENSHIFT_RELEASE_TAG}"
+
+    export MIRROR_IMAGE_URL_SUFFIX="localimages/local-release-image"
+
+    if [ "${OC_MIRROR}" == true ]; then
+        export MIRROR_IMAGE_URL_SUFFIX="openshift/release-images"
+    fi
+
+    export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/${MIRROR_IMAGE_URL_SUFFIX}:${OPENSHIFT_RELEASE_TAG}"
 fi
 
 function getReleaseImage() {

--- a/config_example.sh
+++ b/config_example.sh
@@ -513,6 +513,15 @@ set -x
 #
 #export ENABLE_LOCAL_REGISTRY=true
 
+# REGISTRY_BACKEND
+# Define the local registry to use when ENABLE_LOCAL_REGISTRY=true
+# The default (legacy) registry is started by podman
+# The other available backend is quay which is installed by the
+# mirror-registry application
+# Default: podman
+# Choices: podman, quay
+# export REGISTRY_BACKEND=podman
+
 # LOCAL_REGISTRY_DNS_NAME -
 # Local image registry DNS name.
 # Default: "virthost.$CLUSTER_NAME.test.metalkube.org"
@@ -549,6 +558,19 @@ set -x
 # Default: true
 #
 #export MIRROR_IMAGES=true
+
+# OC_MIRROR -
+# When MIRROR_IMAGES is true, use the 'mirror-registry' command to create the
+# registry and the 'oc mirror' command to do the mirroring.
+# Note, this is currently only supported for the Agent implementation.
+# Default: false
+#export OC_MIRROR=false
+
+# When using OC_MIRROR the auths for the mirror will be added to DOCKER_CONFIG_FILE
+# or an UNAUTHORIZED error will result when attempting to use it. An example entry
+# in this file is:
+# "virthost.ostest.test.metalkube.org:8443": { "auth": "c3RhY2s6cXVheXBhc3N3b3Jk" },
+#export DOCKER_CONFIG_FILE=$HOME/.docker/config.json
 
 # MIRROR_OLM -
 # Comma-separated list of OLM operators to mirror into the local registry. This

--- a/network.sh
+++ b/network.sh
@@ -119,7 +119,6 @@ elif [[ "$IP_STACK" = "v6" ]]; then
   export SERVICE_SUBNET_V6=${SERVICE_SUBNET_V6:-"fd02::/112"}
   export NETWORK_TYPE=${NETWORK_TYPE:-"OVNKubernetes"}
   export MIRROR_IMAGES=true
-  export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/local-release-image:latest"
 elif [[ "$IP_STACK" = "v4v6" ]]; then
   export CLUSTER_SUBNET_V4=${CLUSTER_SUBNET_V4:-"10.128.0.0/14"}
   export CLUSTER_SUBNET_V6=${CLUSTER_SUBNET_V6:-"fd01::/48"}

--- a/oc_mirror.sh
+++ b/oc_mirror.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# Utility functions to create a local mirror registry using 'mirror-registry' and mirror
+# a release using 'oc mirror'
+
+function add_auth_to_pull_secret() {
+
+   quay_auths=$1
+
+   tmpauthfile=$(mktemp --tmpdir "quayauth--XXXXXXXXXX")
+   _tmpfiles="$_tmpfiles $tmpauthfile"
+   tmppullsecret=$(mktemp --tmpdir "pullsecret--XXXXXXXXXX")
+   _tmpfiles="$_tmpfiles $tmppullsecret"
+
+
+   cat > "${tmpauthfile}" << EOF
+{
+  "auths": {
+    "${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}": {
+      "auth": "$quay_auths"
+    }
+  }
+}
+EOF
+
+   jq -s '.[0] * .[1]' ${tmpauthfile} ${PULL_SECRET_FILE} > ${tmppullsecret}
+   cp ${tmppullsecret} ${PULL_SECRET_FILE}
+
+}
+
+function update_docker_config() {
+
+   if [[ -f ${DOCKER_CONFIG_FILE} ]]; then
+      tmpdockerconfig=$(mktemp --tmpdir "dockerconfig--XXXXXXXXXX")
+      _tmpfiles="$_tmpfiles $tmpdockerconfig"
+
+      cp ${DOCKER_CONFIG_FILE} ${DOCKER_CONFIG_FILE}.old
+      jq -s '.[0] * .[1]' ${DOCKER_CONFIG_FILE} ${PULL_SECRET_FILE} > ${tmpdockerconfig}
+      cp ${tmpdockerconfig} ${DOCKER_CONFIG_FILE}
+      echo "In order to use the mirror registry, entries have been added to ${DOCKER_CONFIG_FILE}"
+   else
+      echo "The ${DOCKER_CONFIG_FILE} does not exist, access to the local registry may fail authorization"
+   fi
+}
+
+function setup_quay_mirror_registry() {
+
+   mkdir -p ${WORKING_DIR}/quay-install
+   pushd ${WORKING_DIR}/mirror-registry
+   sudo ./mirror-registry install --quayHostname ${LOCAL_REGISTRY_DNS_NAME} --quayRoot ${WORKING_DIR}/quay-install/ --initUser ${REGISTRY_USER} --initPassword ${REGISTRY_PASS} --sslCheckSkip -v
+
+   quay_auths=`echo -n "${REGISTRY_USER}:${REGISTRY_PASS}" | base64 -w0`
+
+   add_auth_to_pull_secret ${quay_auths}
+   popd
+}
+
+# Set up a mirror using the 'oc mirror' command
+# The backend registry can be either 'podman' or 'quay'
+function setup_oc_mirror() {
+
+   update_docker_config
+
+   # Create imageset containing the local URL and the OCP release to mirror
+   tmpimageset=$(mktemp --tmpdir "imageset--XXXXXXXXXX")
+   _tmpfiles="$_tmpfiles $tmpimageset"
+
+   cat > "${tmpimageset}" << EOF
+apiVersion: mirror.openshift.io/v1alpha2
+kind: ImageSetConfiguration
+archiveSize: 4
+storageConfig:
+  registry:
+    imageURL: ${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/origin:latest
+    skipTLS: true
+mirror:
+  platform:
+    channels:
+    - name: candidate-${OPENSHIFT_RELEASE_STREAM}
+      type: ocp
+  additionalImages:
+  - name: registry.redhat.io/ubi8/ubi:latest
+EOF
+
+   pushd ${WORKING_DIR}
+   oc mirror --dest-skip-tls --config ${tmpimageset} docker://${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}
+   popd
+
+}

--- a/oc_mirror_cleanup.sh
+++ b/oc_mirror_cleanup.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+source common.sh
+
+if [ -d "${WORKING_DIR}/mirror-registry" ]; then
+   pushd ${WORKING_DIR}/mirror-registry
+   sudo ./mirror-registry uninstall --quayRoot ${WORKING_DIR}/quay-install/ -v --autoApprove
+   popd
+   rm -rf "${WORKING_DIR}/mirror-registry"
+fi
+
+if [[ -f "/usr/local/bin/oc-mirror" ]]; then
+  sudo rm "/usr/local/bin/oc-mirror"
+fi
+
+if [ -d "${WORKING_DIR}/oc-mirror-workspace" ]; then
+   rm -rf "${WORKING_DIR}/oc-mirror-workspace"
+fi
+
+if [ -d "${WORKING_DIR}/quay-install" ]; then
+   rm -rf "${WORKING_DIR}/quay-install"
+fi
+
+# restore docker config file that was updated with auth settings
+if [[ -f ${DOCKER_CONFIG_FILE}.old ]]; then
+   cp ${DOCKER_CONFIG_FILE}.old ${DOCKER_CONFIG_FILE}
+   rm ${DOCKER_CONFIG_FILE}.old
+fi

--- a/registry_cleanup.sh
+++ b/registry_cleanup.sh
@@ -13,3 +13,4 @@ if sudo podman container exists registry; then
 fi
 
 sudo rm -rf $WORKING_DIR/registry
+sudo rm -rf $WORKING_DIR/mirror_registry


### PR DESCRIPTION
Add a new variable - OC_MIRROR to mirror images using the `oc mirror` command.  If OC_MIRROR is not set then the mirroring will be done using 'oc adm release mirror'.  In addition a new variable REGISTRY_BACKEND is used to determine hw the registry is set, either the legacy way by creating a podman registry, or via the mirror-registry command.

Note that OC_MIRROR is currently only supported for the Agent implementation.