### PR TITLE
Bug 2087096: Add a dummy interface to IPv6 bridge

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -238,6 +238,12 @@ if [ "$MANAGE_BR_BRIDGE" == "y" ] ; then
     fi
 fi
 
+# The IPv6 bridge interface will remain in DOWN state with NO-CARRIER unless an interface is added,
+# so add a dummy interface to ensure the bridge comes up
+if [[ -n "${EXTERNAL_SUBNET_V6}" ]] && [ ! "$INT_IF" ]; then
+    sudo ip link add name ${BAREMETAL_NETWORK_NAME}-dummy up master ${BAREMETAL_NETWORK_NAME} type dummy
+fi
+
 IPTABLES=iptables
 if [[ "$(ipversion $PROVISIONING_HOST_IP)" == "6" ]]; then
     IPTABLES=ip6tables

--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -52,6 +52,9 @@ fi
 if [ "$MANAGE_BR_BRIDGE" == "y" ]; then
     sudo ifdown ${BAREMETAL_NETWORK_NAME} || true
     sudo ip link delete ${BAREMETAL_NETWORK_NAME} || true
+    if [[ -d /sys/class/net/${BAREMETAL_NETWORK_NAME}-dummy ]]; then
+       sudo ip link delete ${BAREMETAL_NETWORK_NAME}-dummy || true
+    fi
     sudo rm -f /etc/sysconfig/network-scripts/ifcfg-${BAREMETAL_NETWORK_NAME}
 fi
 


### PR DESCRIPTION
In order to ensure that the IPv6 bridge interface comes up add a dummy interface. This is needed for versions of NetworkManager after 1.32.