### PR TITLE
AGENT-239: Use IPv6 addresses in nmstate config

### DIFF
--- a/agent/04_agent_configure.sh
+++ b/agent/04_agent_configure.sh
@@ -207,6 +207,14 @@ EOF
 
     num_ips=${#AGENT_NODES_IPS[@]}
 
+    if [[ "$IP_STACK" = "v4" ]]; then
+       interface_type="ipv4"
+       route_dest="0.0.0.0/0"
+    else
+       interface_type="ipv6"
+       route_dest="::/0"
+    fi
+
     # Create a yaml for each host in nmstateconfig.yaml
     for (( i=0; i<$num_ips; i++ ))
     do
@@ -225,7 +233,7 @@ spec:
         type: ethernet
         state: up
         mac-address: ${AGENT_NODES_MACS[i]}
-        ipv4:
+        ${interface_type}:
           enabled: true
           address:
             - ip: ${AGENT_NODES_IPS[i]}
@@ -237,7 +245,7 @@ spec:
           - ${PROVISIONING_HOST_EXTERNAL_IP}
     routes:
       config:
-        - destination: 0.0.0.0/0
+        - destination: ${route_dest}
           next-hop-address: ${PROVISIONING_HOST_EXTERNAL_IP}
           next-hop-interface: eth0
           table-id: 254

--- a/agent/05_agent_create_cluster.sh
+++ b/agent/05_agent_create_cluster.sh
@@ -67,6 +67,10 @@ function force_mirror_disconnect() {
 }
 
 function enable_assisted_service_ui() {
+  if [[ "${IP_STACK}" = "v6" ]]; then
+       echo "In a disconnected environment the assisted-installer GUI cannot be enabled"
+       return
+  fi
   node0_ip=$(get_node0_ip)
   ssh_opts=(-o 'StrictHostKeyChecking=no' -o 'UserKnownHostsFile=/dev/null' -q core@${node0_ip})
 


### PR DESCRIPTION
For agent IPv6 testing set up the nmstate config to use IPv6 addressing.

I've tested this with both IPv6 and IPv4 using 4.12 and https://github.com/openshift/installer/pull/6249