### PR TITLE
AGENT-245: DHCP only agent deployment

### DIFF
--- a/agent/01_agent_requirements.sh
+++ b/agent/01_agent_requirements.sh
@@ -10,6 +10,6 @@ source $SCRIPTDIR/common.sh
 early_deploy_validation
 
 if [[ -z ${AGENT_E2E_TEST_SCENARIO} ]]; then
-    echo "AGENT_E2E_TEST_SCENARIO is missing or empty. Did you forget to set the AGENT_E2E_TEST_SCENARIO env var in the config_<USER>.sh file? Supported values: COMPACT_IPV4, COMPACT_IPV6, HA_IPV4, HA_IPV6, SNO_IPV4, SNO_IPV6."
-    exit 1
+    printf "\nAGENT_E2E_TEST_SCENARIO is missing or empty. Did you forget to set the AGENT_E2E_TEST_SCENARIO env var in the config_<USER>.sh file?"
+    invalidAgentValue
 fi

--- a/agent/04_agent_configure.sh
+++ b/agent/04_agent_configure.sh
@@ -298,6 +298,7 @@ metadata:
   namespace: ${CLUSTER_NAMESPACE}
 rendezvousIP: ${AGENT_NODES_IPS[0]}
 EOF
+    set +x
     pull_secret=$(cat $PULL_SECRET_FILE)
     cat > "${MANIFESTS_PATH}/install-config.yaml" << EOF
 apiVersion: v1
@@ -382,5 +383,6 @@ if [[ $NETWORKING_MODE == "DHCP" ]]; then
   generate_install_config_agent_config
 else
   generate_cluster_manifests
-  generate_extra_cluster_manifests
 fi
+
+generate_extra_cluster_manifests

--- a/agent/04_agent_configure.sh
+++ b/agent/04_agent_configure.sh
@@ -325,7 +325,7 @@ networking:
   clusterNetwork:
   - cidr: ${cluster_network}
     hostPrefix: ${cluster_host_prefix}
-  networkType: OpenShiftSDN
+  networkType: ${NETWORK_TYPE}
   machineNetwork:
   - cidr: ${machine_network}
   serviceNetwork: 

--- a/agent/04_agent_configure.sh
+++ b/agent/04_agent_configure.sh
@@ -284,13 +284,11 @@ EOF
   fi
 }
 
-function generate_install_config_agent_config() {
+function generate_agent_config() {
 
   MANIFESTS_PATH="${OCP_DIR}"
   mkdir -p ${MANIFESTS_PATH}
   
-  setNetworkingVars
-
     cat > "${MANIFESTS_PATH}/agent-config.yaml" << EOF
 apiVersion: v1alpha1
 metadata:
@@ -298,8 +296,17 @@ metadata:
   namespace: ${CLUSTER_NAMESPACE}
 rendezvousIP: ${AGENT_NODES_IPS[0]}
 EOF
-    set +x
-    pull_secret=$(cat $PULL_SECRET_FILE)
+}
+
+function generate_install_config() {
+
+  MANIFESTS_PATH="${OCP_DIR}"
+  mkdir -p ${MANIFESTS_PATH}
+  
+  setNetworkingVars
+
+  set +x
+  pull_secret=$(cat $PULL_SECRET_FILE)
     cat > "${MANIFESTS_PATH}/install-config.yaml" << EOF
 apiVersion: v1
 baseDomain: ${BASE_DOMAIN}
@@ -380,7 +387,8 @@ fi
   fi
 
 if [[ $NETWORKING_MODE == "DHCP" ]]; then
-  generate_install_config_agent_config
+  generate_agent_config
+  generate_install_config
 else
   generate_cluster_manifests
 fi

--- a/agent/04_agent_configure.sh
+++ b/agent/04_agent_configure.sh
@@ -14,7 +14,7 @@ source $SCRIPTDIR/ocp_install_env.sh
 
 early_deploy_validation
 
-CLUSTER_NAMESPACE=cluster0
+CLUSTER_NAMESPACE=${CLUSTER_NAMESPACE:-"cluster0"}
 
 function get_static_ips_and_macs() {
 
@@ -67,15 +67,15 @@ function get_static_ips_and_macs() {
 
 function setNetworkingVars() {
    if [[ "$IP_STACK" = "v4" ]]; then
-    CLUSTER_NETWORK=${CLUSTER_SUBNET_V4}
-    SERVICE_NETWORK=${SERVICE_SUBNET_V4}
-    MACHINE_NETWORK=${EXTERNAL_SUBNET_V4}
-    CLUSTER_HOST_PREFIX=${CLUSTER_HOST_PREFIX_V4}
+    cluster_network=${CLUSTER_SUBNET_V4}
+    service_network=${SERVICE_SUBNET_V4}
+    machine_network=${EXTERNAL_SUBNET_V4}
+    cluster_host_prefix=${CLUSTER_HOST_PREFIX_V4}
   elif [[ "$IP_STACK" = "v6" ]]; then
-    CLUSTER_NETWORK=${CLUSTER_SUBNET_V6}
-    SERVICE_NETWORK=${SERVICE_SUBNET_V6}
-    MACHINE_NETWORK=${EXTERNAL_SUBNET_V6}
-    CLUSTER_HOST_PREFIX=${CLUSTER_HOST_PREFIX_V6}
+    cluster_network=${CLUSTER_SUBNET_V6}
+    service_network=${SERVICE_SUBNET_V6}
+    machine_network=${EXTERNAL_SUBNET_V6}
+    cluster_host_prefix=${CLUSTER_HOST_PREFIX_V6}
   fi
 }
 
@@ -115,10 +115,10 @@ cat >> "${MANIFESTS_PATH}/agent-cluster-install.yaml" << EOF
     name: openshift-${VERSION}
   networking:
     clusterNetwork:
-    - cidr: ${CLUSTER_NETWORK}
-      hostPrefix: ${CLUSTER_HOST_PREFIX}
+    - cidr: ${cluster_network}
+      hostPrefix: ${cluster_host_prefix}
     serviceNetwork:
-    - ${SERVICE_NETWORK}
+    - ${service_network}
     networkType: ${NETWORK_TYPE}
   provisionRequirements:
     controlPlaneAgents: ${NUM_MASTERS}
@@ -242,7 +242,7 @@ spec:
           enabled: true
           address:
             - ip: ${AGENT_NODES_IPS[i]}
-              prefix-length: ${CLUSTER_HOST_PREFIX}
+              prefix-length: ${cluster_host_prefix}
           dhcp: false
     dns-resolver:
       config:
@@ -315,13 +315,13 @@ metadata:
   namespace: ${CLUSTER_NAMESPACE}
 networking:
   clusterNetwork:
-  - cidr: ${CLUSTER_NETWORK}
-    hostPrefix: ${CLUSTER_HOST_PREFIX}
+  - cidr: ${cluster_network}
+    hostPrefix: ${cluster_host_prefix}
   networkType: OpenShiftSDN
   machineNetwork:
-  - cidr: ${MACHINE_NETWORK}
+  - cidr: ${machine_network}
   serviceNetwork: 
-  - ${SERVICE_NETWORK}
+  - ${service_network}
 platform:
 EOF
 # The assumption here is if number of masters is one

--- a/common.sh
+++ b/common.sh
@@ -269,11 +269,6 @@ export EXTRA_WORKER_MEMORY=${EXTRA_WORKER_MEMORY:-${WORKER_MEMORY}}
 export EXTRA_WORKER_DISK=${EXTRA_WORKER_DISK:-${WORKER_DISK}}
 export EXTRA_WORKER_VCPU=${EXTRA_WORKER_VCPU:-${WORKER_VCPU}}
 
-
-
-
-
-
 # Ironic vars (Image can be use <NAME>_LOCAL_IMAGE to override)
 export IRONIC_IMAGE=${IRONIC_IMAGE:-"quay.io/metal3-io/ironic:main"}
 export IRONIC_DATA_DIR="${WORKING_DIR}/ironic"
@@ -373,20 +368,19 @@ export AGENT_DEPLOY_MCE=${AGENT_DEPLOY_MCE:-}
 
 
 if [[ ! -z ${AGENT_E2E_TEST_SCENARIO} ]]; then
-  export IP_STACK=$(echo ${AGENT_E2E_TEST_SCENARIO##*_IP} | tr V v)
-
+  IFS='_'
+  read -a arr <<<"$AGENT_E2E_TEST_SCENARIO"
   delimiterCount=$(echo "$AGENT_E2E_TEST_SCENARIO" | tr -cd '_' | wc -c)
-  if [[ "$delimiterCount" == "1" ]]; then
-    SCENARIO=${AGENT_E2E_TEST_SCENARIO%%_*}
-  elif [[ "$delimiterCount" == "2" ]]; then
-    export NETWORKING_MODE=${AGENT_E2E_TEST_SCENARIO%%_*}
+  unset IFS
+
+  SCENARIO=${arr[0]}
+  export IP_STACK=$(echo ${arr[1]##*IP} | tr V v)
+  
+  if [[ "$delimiterCount" == "2" ]]; then
+    export NETWORKING_MODE=${arr[2]}
     if [[ $NETWORKING_MODE != "DHCP" ]]; then
       invalidAgentValue
     fi
-    SCENARIO=${AGENT_E2E_TEST_SCENARIO#*_}
-    SCENARIO=${SCENARIO%_*}
-  else
-      invalidAgentValue
   fi
 
   case "$SCENARIO" in

--- a/common.sh
+++ b/common.sh
@@ -413,6 +413,7 @@ if [[ ! -z ${AGENT_E2E_TEST_SCENARIO} ]]; then
           export MASTER_DISK=120
           export MASTER_MEMORY=32768
           export NUM_WORKERS=0
+          export NETWORK_TYPE="OVNKubernetes"
           ;;
       *)
         invalidAgentValue

--- a/config_example.sh
+++ b/config_example.sh
@@ -622,11 +622,23 @@ set -x
 
 # Set a single config variable AGENT_E2E_TEST_SCENARIO to create a cluster for the different scenarios 
 # i.e. Single Node Openshift(SNO), Highly Available (HA) or Compact cluster.
-# The only supported values for AGENT_E2E_TEST_SCENARIO are COMPACT_IPV4, COMPACT_IPV6, HA_IPV4, HA_IPV6, SNO_IPV4 and SNO_IPV6.
+# The only supported values for AGENT_E2E_TEST_SCENARIO are 
+# - COMPACT_IPV4
+# - COMPACT_IPV6
+# - DHCP_COMPACT_IPV4
+# - DHCP_COMPACT_IPV6
+# - HA_IPV4
+# - HA_IPV6
+# - DHCP_HA_IPV4
+# - DHCP_HA_IPV6 
+# - SNO_IPV4
+# - SNO_IPV6
+# - DHCP_SNO_IPV4
+# - DHCP_SNO_IPV6
 # When set, the code internally sets other low level details such as disk size, memory, number of masters and workers,
 # cpu and ip stack.
 # This config variable is used only by the agent based installer and is required.
-# export AGENT_E2E_TEST_SCENARIO=HA_IPV4
+# export AGENT_E2E_TEST_SCENARIO=DHCP_COMPACT_IPV4
 
 # Uncomment the following line to deploy the MCE operator, and to automatically import the current cluster as the hub cluster
 # export AGENT_DEPLOY_MCE=true

--- a/config_example.sh
+++ b/config_example.sh
@@ -625,20 +625,20 @@ set -x
 # The only supported values for AGENT_E2E_TEST_SCENARIO are 
 # - COMPACT_IPV4
 # - COMPACT_IPV6
-# - DHCP_COMPACT_IPV4
-# - DHCP_COMPACT_IPV6
+# - COMPACT_IPV4_DHCP
+# - COMPACT_IPV6_DHCP
 # - HA_IPV4
 # - HA_IPV6
-# - DHCP_HA_IPV4
-# - DHCP_HA_IPV6 
+# - HA_IPV4_DHCP
+# - HA_IPV6 _DHCP
 # - SNO_IPV4
 # - SNO_IPV6
-# - DHCP_SNO_IPV4
-# - DHCP_SNO_IPV6
+# - SNO_IPV4_DHCP
+# - SNO_IPV6_DHCP
 # When set, the code internally sets other low level details such as disk size, memory, number of masters and workers,
 # cpu and ip stack.
 # This config variable is used only by the agent based installer and is required.
-# export AGENT_E2E_TEST_SCENARIO=DHCP_COMPACT_IPV4
+# export AGENT_E2E_TEST_SCENARIO=COMPACT_IPV4_DHCP
 
 # Uncomment the following line to deploy the MCE operator, and to automatically import the current cluster as the hub cluster
 # export AGENT_DEPLOY_MCE=true


### PR DESCRIPTION
This PR supports DHCP agent deployment with just agent-config.yaml and install-config.yaml. Set only `rendezvousIP` in the agent-config.yaml ( no hosts at all or no hosts with any network config). Devscripts provides no nmstateconfig.yaml

To create a DHCP agent deployment, `export AGENT_E2E_TEST_SCENARIO=HA_IPV4_DHCP` in config_\<user\>.sh.

Also, this is a change for 4.12 so `export OPENSHIFT_RELEASE_STREAM=4.12`

To test, run `make agent`