### PR TITLE
AGENT-158: Add support for testing agent with dual-stack

### DIFF
--- a/agent/common.sh
+++ b/agent/common.sh
@@ -6,6 +6,10 @@ export AGENT_STATIC_IP_NODE0_ONLY=${AGENT_STATIC_IP_NODE0_ONLY:-"false"}
 # Override command name in case of extraction
 export OPENSHIFT_INSTALLER_CMD="openshift-install"
 
+# Override to consistently use the proper subnet
+export CLUSTER_HOST_PREFIX_V4="24"
+export EXTERNAL_SUBNET_V6="fd2e:6f44:5dd8:c956::/64"
+
 if [ -n "$MIRROR_IMAGES" ]; then
     # We're going to be using a locally modified release image
     export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/local-release-image:${OPENSHIFT_RELEASE_TAG}"

--- a/common.sh
+++ b/common.sh
@@ -355,7 +355,7 @@ fi
 # Agent specific configuration 
 
 function invalidAgentValue() {
-  printf "Found invalid value \"$AGENT_E2E_TEST_SCENARIO\" for AGENT_E2E_TEST_SCENARIO. \nSupported values: \nCOMPACT_IPV4\nCOMPACT_IPV6\nDHCP_COMPACT_IPV4\nDHCP_COMPACT_IPV6\nHA_IPV4\nHA_IPV6\nDHCP_HA_IPV4\nDHCP_HA_IPV6\nSNO_IPV4\nSNO_IPV6\nDHCP_SNO_IPV4\nDHCP_SNO_IPV6\n"
+  printf "Found invalid value \"$AGENT_E2E_TEST_SCENARIO\" for AGENT_E2E_TEST_SCENARIO. Supported values: 'COMPACT_IPXX', 'HA_IPXX', or 'SNO_IPXX', where XX is 'V4', 'V6', or 'V4V6'"
   exit 1
 }
 
@@ -365,7 +365,6 @@ export NETWORKING_MODE=${NETWORKING_MODE:-}
 
 # Enable MCE deployment
 export AGENT_DEPLOY_MCE=${AGENT_DEPLOY_MCE:-}
-
 
 if [[ ! -z ${AGENT_E2E_TEST_SCENARIO} ]]; then
   IFS='_'
@@ -423,5 +422,9 @@ if [[ ! -z ${AGENT_E2E_TEST_SCENARIO} ]]; then
     export MASTER_MEMORY=32768
   fi
 
+  if [[ $IP_STACK != 'v4' ]] && [[ $IP_STACK != 'v6' ]] && [[ $IP_STACK != 'v4v6' ]]; then
+    echo "Invalid value $IP_STACK for IP stack, use 'V4', 'V6', or 'V4V6'."
+    exit 1
+  fi
 fi
 


### PR DESCRIPTION
Add dual-stack testing. The nmstate config now takes both v4 and v6 interfaces in dual-stack. In addition the agent-cluster-install.yaml takes the v4 and v6 subnets in ClusterNetwork, ServiceNetwork, and the now MachineNetwork.

Tested with COMPACT_IPV4, COMPACT_IPv6, and COMPACT_IPV4V6.