### PR TITLE
OPNET-156: Add static and bond network configs

### DIFF
--- a/network-configs/bond/ostest-master-0.yaml
+++ b/network-configs/bond/ostest-master-0.yaml
@@ -1,0 +1,18 @@
+networkConfig: &BOND
+  interfaces:
+  - name: bond0
+    type: bond
+    state: up
+    ipv4:
+      dhcp: true
+      enabled: true
+      auto-dns: true
+      auto-gateway: true
+      auto-routes: true
+    link-aggregation:
+      mode: active-backup
+      options:
+        miimon: '100'
+      port:
+      - enp2s0
+      - enp3s0

--- a/network-configs/bond/ostest-master-1.yaml
+++ b/network-configs/bond/ostest-master-1.yaml
@@ -1,0 +1,1 @@
+networkConfig: *BOND

--- a/network-configs/bond/ostest-master-2.yaml
+++ b/network-configs/bond/ostest-master-2.yaml
@@ -1,0 +1,1 @@
+networkConfig: *BOND

--- a/network-configs/bond/ostest-worker-0.yaml
+++ b/network-configs/bond/ostest-worker-0.yaml
@@ -1,0 +1,1 @@
+networkConfig: *BOND

--- a/network-configs/bond/ostest-worker-1.yaml
+++ b/network-configs/bond/ostest-worker-1.yaml
@@ -1,0 +1,1 @@
+networkConfig: *BOND

--- a/network-configs/static/hosts.yaml
+++ b/network-configs/static/hosts.yaml
@@ -1,0 +1,15 @@
+- ip: 192.168.111.110
+  hostnames:
+    - "master-0"
+- ip: 192.168.111.111
+  hostnames:
+    - "master-1"
+- ip: 192.168.111.112
+  hostnames:
+    - "master-2"
+- ip: 192.168.111.113
+  hostnames:
+    - "worker-0"
+- ip: 192.168.111.114
+  hostnames:
+    - "worker-1"

--- a/network-configs/static/ostest-master-0.yaml
+++ b/network-configs/static/ostest-master-0.yaml
@@ -1,0 +1,19 @@
+networkConfig:
+  interfaces:
+  - name: enp2s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "192.168.111.110"
+        prefix-length: 24
+      enabled: true
+  dns-resolver:
+    config:
+      server:
+      - 192.168.111.1
+  routes:
+    config:
+    - destination: 0.0.0.0/0
+      next-hop-address: 192.168.111.1
+      next-hop-interface: enp2s0

--- a/network-configs/static/ostest-master-1.yaml
+++ b/network-configs/static/ostest-master-1.yaml
@@ -1,0 +1,19 @@
+networkConfig:
+  interfaces:
+  - name: enp2s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "192.168.111.111"
+        prefix-length: 24
+      enabled: true
+  dns-resolver:
+    config:
+      server:
+      - 192.168.111.1
+  routes:
+    config:
+    - destination: 0.0.0.0/0
+      next-hop-address: 192.168.111.1
+      next-hop-interface: enp2s0

--- a/network-configs/static/ostest-master-2.yaml
+++ b/network-configs/static/ostest-master-2.yaml
@@ -1,0 +1,19 @@
+networkConfig:
+  interfaces:
+  - name: enp2s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "192.168.111.112"
+        prefix-length: 24
+      enabled: true
+  dns-resolver:
+    config:
+      server:
+      - 192.168.111.1
+  routes:
+    config:
+    - destination: 0.0.0.0/0
+      next-hop-address: 192.168.111.1
+      next-hop-interface: enp2s0

--- a/network-configs/static/ostest-worker-0.yaml
+++ b/network-configs/static/ostest-worker-0.yaml
@@ -1,0 +1,19 @@
+networkConfig:
+  interfaces:
+  - name: enp2s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "192.168.111.113"
+        prefix-length: 24
+      enabled: true
+  dns-resolver:
+    config:
+      server:
+      - 192.168.111.1
+  routes:
+    config:
+    - destination: 0.0.0.0/0
+      next-hop-address: 192.168.111.1
+      next-hop-interface: enp2s0

--- a/network-configs/static/ostest-worker-1.yaml
+++ b/network-configs/static/ostest-worker-1.yaml
@@ -1,0 +1,19 @@
+networkConfig:
+  interfaces:
+  - name: enp2s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "192.168.111.114"
+        prefix-length: 24
+      enabled: true
+  dns-resolver:
+    config:
+      server:
+      - 192.168.111.1
+  routes:
+    config:
+    - destination: 0.0.0.0/0
+      next-hop-address: 192.168.111.1
+      next-hop-interface: enp2s0


### PR DESCRIPTION
These are some example configs that can be used with the NETWORK_CONFIG_FOLDER option added in #1418. In addition to making it easy for new users to test the networkConfig feature, this will also make it easier to run such configurations in CI.

To use, just set the variable to the appropriate path. For example:

export NETWORK_CONFIG_FOLDER=network-configs/static