### PR TITLE
AGENT-331: Add support for MCE disconnected scenario

### DIFF
--- a/agent/assets/agent-create-registries-conf-playbook.yaml
+++ b/agent/assets/agent-create-registries-conf-playbook.yaml
@@ -1,0 +1,19 @@
+- name: Create registries.conf for Agent Installer
+  hosts: localhost
+  collections:
+   - community.general
+  gather_facts: no
+  vars:
+    - mirror_images: "{{ lookup('env', 'MIRROR_IMAGES') }}"
+    - oc_mirror: "{{ lookup('env', 'OC_MIRROR') }}"
+    - mirror_path: "{{ lookup('env', 'MIRROR_PATH') }}"
+    - local_registry_dns_name: "{{ lookup('env', 'LOCAL_REGISTRY_DNS_NAME') }}"
+    - local_registry_port: "{{ lookup('env', 'LOCAL_REGISTRY_PORT') }}"
+    - mirror_image_url_suffix: "{{ lookup('env', 'MIRROR_IMAGE_URL_SUFFIX') }}"
+    - mirror_mce: "{{ lookup('env', 'MIRROR_MCE') }}"
+
+  tasks:
+  - name: write the registries.conf
+    template:
+      src: "registries_conf.j2"
+      dest: "{{ mirror_path }}/registries.conf"

--- a/agent/assets/registries_conf.j2
+++ b/agent/assets/registries_conf.j2
@@ -1,0 +1,69 @@
+{# base oc mirror registries.conf #}
+{% if oc_mirror == "true" %}
+[[registry]]
+prefix = ""
+location = "quay.io/openshift-release-dev/ocp-release"
+mirror-by-digest-only = false
+
+[[registry.mirror]]
+location = "{{ local_registry_dns_name }}:{{ local_registry_port }}/openshift/release-images"
+
+[[registry]]
+prefix = ""
+location = "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
+mirror-by-digest-only = false
+
+[[registry.mirror]]
+location = "{{ local_registry_dns_name }}:{{ local_registry_port }}/openshift/release"
+
+[[registry]]
+prefix = ""
+location = "registry.redhat.io/ubi8"
+mirror-by-digest-only = false
+
+[[registry.mirror]]
+location = "{{ local_registry_dns_name }}:{{ local_registry_port }}/ubi8"
+{# oc mirror registries.conf with MCE #}
+{% if mirror_mce == "true" %}
+[[registry]]
+prefix = ""
+location = "registry.redhat.io/multicluster-engine"
+mirror-by-digest-only = false
+
+[[registry.mirror]]
+location = "{{ local_registry_dns_name }}:{{ local_registry_port }}/multicluster-engine"
+
+[[registry]]
+prefix = ""
+location = "registry.redhat.io/rhel8"
+mirror-by-digest-only = false
+
+[[registry.mirror]]
+location = "{{ local_registry_dns_name }}:{{ local_registry_port }}/rhel8"
+
+[[registry]]
+prefix = ""
+location = "registry.redhat.io/redhat"
+mirror-by-digest-only = false
+
+[[registry.mirror]]
+location = "{{ local_registry_dns_name }}:{{ local_registry_port }}/redhat"
+{% endif %}
+{# legacy mirror registries.conf #}
+{% elif mirror_images == "true" %}
+[[registry]]
+prefix = ""
+location = "registry.ci.openshift.org/ocp/release"
+mirror-by-digest-only = false
+
+[[registry.mirror]]
+location = "{{ local_registry_dns_name }}:{{ local_registry_port }}/{{ mirror_image_url_suffix }}"
+
+[[registry]]
+prefix = ""
+location = "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
+mirror-by-digest-only = false
+
+[[registry.mirror]]
+location = "{{ local_registry_dns_name }}:{{ local_registry_port }}/{{ mirror_image_url_suffix }}"
+{% endif %}


### PR DESCRIPTION
These changes mirror MCE using `oc mirror` and updates registries.conf accordingly.

This PR is based off #1435 and is verified to work with the IPv4 disconnected scenario.

AGENT-331