### PR TITLE
For agent, if RELEASE_IMAGE is a digest don't set override

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -448,13 +448,14 @@ if [[ -n "$MIRROR_IMAGES" || -z "$IP_STACK" || "$IP_STACK" = "v6" ]]; then
 
    # We're going to be using a locally modified release image
    if [[ ! -z ${AGENT_E2E_TEST_SCENARIO} ]]; then
-	   # For the agent installer version check a valid tag must be supplied (not 'latest').
-	  if [[ ${#OPENSHIFT_RELEASE_TAG} = 64 ]] && [[ ${OPENSHIFT_RELEASE_TAG} =~ [:alnum:] ]]; then
-	     # If the tag is a digest, add sha identifier
-             export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/${LOCAL_IMAGE_URL_SUFFIX}@sha256:${OPENSHIFT_RELEASE_TAG}"
-	  else
-             export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/${LOCAL_IMAGE_URL_SUFFIX}:${OPENSHIFT_RELEASE_TAG}"
-	  fi
+        # For the agent installer version check, a valid tag must be supplied (not 'latest').
+	if [[ ${#OPENSHIFT_RELEASE_TAG} = 64 ]] && [[ ${OPENSHIFT_RELEASE_TAG} =~ [:alnum:] ]]; then
+	    # If the tag is a digest, don't change the override from OPENSHIFT_RELEASE_IMAGE
+	    # Since mirror-by-digest-only = true on the bootstrap
+	    echo "Not changing OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE since digest is being used"
+	else
+            export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/${LOCAL_IMAGE_URL_SUFFIX}:${OPENSHIFT_RELEASE_TAG}"
+	fi
    else
        # 04_setup_ironic requires tag to be 'latest'
        export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/${LOCAL_IMAGE_URL_SUFFIX}:latest"


### PR DESCRIPTION
if the RELEASE_IMAGE is a digest it should be used as is since registries.conf will have mirror-by-digest-only=true.