### PR TITLE
Check for existing cluster before deployment

### DIFF
--- a/sanitychecks.sh
+++ b/sanitychecks.sh
@@ -5,6 +5,13 @@ set -euxo pipefail
 # The minimum amount of space required for a default installation, expressed in GB
 MIN_SPACE_REQUIRED=${MIN_SPACE_REQUIRED:=80}
 
+function verifyClean {
+    if [ -d "ocp/${CLUSTER_NAME}" ]; then
+      echo "A cluster named '${CLUSTER_NAME}' already exists on this host. Run 'make clean' to remove it before doing another deployment."
+      exit 1
+    fi
+}
+
 function verifyWorkingDir {
   if [ ! -d $WORKING_DIR ]; then
     echo "WORKING_DIR ${WORKING_DIR} is not a directory"
@@ -31,6 +38,7 @@ function verifyFreeSpace {
   fi
 }
 
+verifyClean
 verifyWorkingDir
 verifyFreeSpace
 


### PR DESCRIPTION
One thing I've noticed is that a lot of new dev-scripts users don't realize they need to run make clean between deployments. This adds a check for the ocp/<cluster name> directory before deployment and stops if it already exists. That directory is created pretty early in the process and removed by make clean so it should be a good indicator of whether a deployment has already been run. It's also specific to a given cluster so it shouldn't affect environments that are running multiple clusters of different names.