### PR TITLE
AGENT-392: Add support for install-config.yaml/agent-config.yaml

### DIFF
--- a/agent/04_agent_configure.sh
+++ b/agent/04_agent_configure.sh
@@ -412,23 +412,20 @@ function generate_install_agent_config() {
   mkdir -p ${INSTALL_CONFIG_PATH}
 
   # set arrays as strings to pass in env
-  nodes_macs=$(printf '%s#' "${AGENT_NODES_MACS[@]}")
-  export AGENT_NODES_MACS_STR=${nodes_macs::-1}
-  nodes_ips=$(printf '%s#' "${AGENT_NODES_IPS[@]}")
+  nodes_ips=$(printf '%s,' "${AGENT_NODES_IPS[@]}")
   export AGENT_NODES_IPS_STR=${nodes_ips::-1}
-  nodes_ipsv6=$(printf '%s#' "${AGENT_NODES_IPSV6[@]}")
+  nodes_ipsv6=$(printf '%s,' "${AGENT_NODES_IPSV6[@]}")
   export AGENT_NODES_IPSV6_STR=${nodes_ipsv6::-1}
-  nodes_hostnames=$(printf '%s#' "${AGENT_NODES_HOSTNAMES[@]}")
+  nodes_macs=$(printf '%s,' "${AGENT_NODES_MACS[@]}")
+  export AGENT_NODES_MACS_STR=${nodes_macs::-1}
+  nodes_hostnames=$(printf '%s,' "${AGENT_NODES_HOSTNAMES[@]}")
   export AGENT_NODES_HOSTNAMES_STR=${nodes_hostnames::-1}
 
+  export API_VIPS=${API_VIPS}
+  export INGRESS_VIPS=${INGRESS_VIPS}
+
   if [[ "$IP_STACK" = "v4v6" ]]; then
-     export API_VIP=${API_VIPS}
-     export INGRESS_VIP=${INGRESS_VIPS}
      export PROVISIONING_HOST_EXTERNAL_IP_DUALSTACK=$(nth_ip $EXTERNAL_SUBNET_V6 1)
-  else
-     export API_VIP=${API_VIPS%${VIPS_SEPARATOR}*}
-     export INGRESS_VIP=${INGRESS_VIPS%${VIPS_SEPARATOR}*}
-     export PROVISIONING_HOST_EXTERNAL_IP_DUALSTACK=""
   fi
 
   if [[ ! -z "${MIRROR_IMAGES}" ]]; then

--- a/agent/04_agent_configure.sh
+++ b/agent/04_agent_configure.sh
@@ -421,8 +421,13 @@ function generate_install_agent_config() {
   nodes_hostnames=$(printf '%s#' "${AGENT_NODES_HOSTNAMES[@]}")
   export AGENT_NODES_HOSTNAMES_STR=${nodes_hostnames::-1}
 
-  export API_VIP=${API_VIPS%${VIPS_SEPARATOR}*}
-  export INGRESS_VIP=${INGRESS_VIPS%${VIPS_SEPARATOR}*}
+  if [[ "$IP_STACK" = "v4v6" ]]; then
+     export API_VIP=${API_VIPS}
+     export INGRESS_VIP=${INGRESS_VIPS}
+  else
+     export API_VIP=${API_VIPS%${VIPS_SEPARATOR}*}
+     export INGRESS_VIP=${INGRESS_VIPS%${VIPS_SEPARATOR}*}
+  fi
 
   if [[ ! -z "${MIRROR_IMAGES}" ]]; then
     # Store the certs for registry

--- a/agent/04_agent_configure.sh
+++ b/agent/04_agent_configure.sh
@@ -421,8 +421,10 @@ function generate_install_agent_config() {
   nodes_hostnames=$(printf '%s,' "${AGENT_NODES_HOSTNAMES[@]}")
   export AGENT_NODES_HOSTNAMES_STR=${nodes_hostnames::-1}
 
-  export API_VIPS=${API_VIPS}
-  export INGRESS_VIPS=${INGRESS_VIPS}
+  if [[ "${NUM_MASTERS}" > "1" ]]; then
+     export API_VIPS=${API_VIPS}
+     export INGRESS_VIPS=${INGRESS_VIPS}
+  fi
 
   if [[ "$IP_STACK" = "v4v6" ]]; then
      export PROVISIONING_HOST_EXTERNAL_IP_DUALSTACK=$(nth_ip $EXTERNAL_SUBNET_V6 1)

--- a/agent/04_agent_configure.sh
+++ b/agent/04_agent_configure.sh
@@ -457,8 +457,8 @@ if [[ ${AGENT_USE_ZTP_MANIFESTS} == true ]]; then
   nodes_hostnames=$(printf '%s#' "${AGENT_NODES_HOSTNAMES[@]}")
   export AGENT_NODES_HOSTNAMES_STR=${nodes_hostnames::-1}
 
-  export API_VIP=${API_VIPs%${STRINGS_SEPARATOR}*}
-  export INGRESS_VIP=${INGRESS_VIPs%${STRINGS_SEPARATOR}*}
+  export API_VIP=${API_VIPS%${VIPS_SEPARATOR}*}
+  export INGRESS_VIP=${INGRESS_VIPS%${VIPS_SEPARATOR}*}
 
   if [[ ! -z "${MIRROR_IMAGES}" ]]; then
     # Store the certs for registry

--- a/agent/04_agent_configure.sh
+++ b/agent/04_agent_configure.sh
@@ -15,7 +15,7 @@ source $SCRIPTDIR/oc_mirror.sh
 
 early_deploy_validation
 
-CLUSTER_NAMESPACE=${CLUSTER_NAMESPACE:-"cluster0"}
+export CLUSTER_NAMESPACE=${CLUSTER_NAMESPACE:-"cluster0"}
 
 function get_nmstate_interface_block {
 
@@ -377,87 +377,6 @@ EOF
   fi
 }
 
-function generate_agent_config() {
-
-  MANIFESTS_PATH="${OCP_DIR}"
-  mkdir -p ${MANIFESTS_PATH}
-
-    cat > "${MANIFESTS_PATH}/agent-config.yaml" << EOF
-apiVersion: v1alpha1
-metadata:
-  name: ${CLUSTER_NAME}
-  namespace: ${CLUSTER_NAMESPACE}
-rendezvousIP: ${AGENT_NODES_IPS[0]}
-EOF
-}
-
-function generate_install_config() {
-
-  MANIFESTS_PATH="${OCP_DIR}"
-  mkdir -p ${MANIFESTS_PATH}
-
-  setNetworkingVars
-
-  set +x
-  pull_secret=$(cat $PULL_SECRET_FILE)
-    cat > "${MANIFESTS_PATH}/install-config.yaml" << EOF
-apiVersion: v1
-baseDomain: ${BASE_DOMAIN}
-compute:
-- hyperthreading: Enabled
-  name: worker
-  replicas: ${NUM_WORKERS}
-controlPlane:
-  hyperthreading: Enabled
-  name: master
-  replicas: ${NUM_MASTERS}
-metadata:
-  name: ${CLUSTER_NAME}
-  namespace: ${CLUSTER_NAMESPACE}
-networking:
-  clusterNetwork:
-  - cidr: ${cluster_network}
-    hostPrefix: ${cluster_host_prefix}
-  networkType: ${NETWORK_TYPE}
-  machineNetwork:
-  - cidr: ${machine_network}
-  serviceNetwork:
-  - ${service_network}
-platform:
-EOF
-# The assumption here is if number of masters is one
-# we want to generate an install config for none platform
-# to create a SNO cluster.
-if [[ "${NUM_MASTERS}" == "1" ]]; then
-cat >> "${MANIFESTS_PATH}/install-config.yaml" << EOF
-  none: {}
-EOF
-else
-cat >> "${MANIFESTS_PATH}/install-config.yaml" << EOF
-    baremetal:
-      apiVips:
-        - ${API_VIP}
-      ingressVips:
-        - ${INGRESS_VIP}
-      hosts:
-EOF
- num_ips=${#AGENT_NODES_IPS[@]}
- for (( i=0; i<$num_ips; i++ ))
-    do
-      cat >> "${MANIFESTS_PATH}/install-config.yaml" << EOF
-          - name: host${i}
-            bootMACAddress: ${AGENT_NODES_MACS[i]}
-EOF
-    done
-fi
-cat >> "${MANIFESTS_PATH}/install-config.yaml" << EOF
-fips: false
-sshKey: ${SSH_PUB_KEY}
-pullSecret:  '${pull_secret}'
-EOF
-    set -x
-}
-
 function oc_mirror_mce() {
    tmpimageset=$(mktemp --tmpdir "mceimageset--XXXXXXXXXX")
    _tmpfiles="$_tmpfiles $tmpimageset"
@@ -511,11 +430,48 @@ if [[ "${NUM_MASTERS}" > "1" ]]; then
    set_api_and_ingress_vip
 fi
 
-if [[ $NETWORKING_MODE == "DHCP" ]]; then
-  generate_agent_config
-  generate_install_config
-else
-  generate_cluster_manifests
+MANIFESTS_PATH="${OCP_DIR}/cluster-manifests"
+
+mkdir -p ${MANIFESTS_PATH}
+if [ ! -z "${MIRROR_IMAGES}" ]; then
+  export MIRROR_PATH="${SCRIPTDIR}/${OCP_DIR}/mirror"
+  mkdir -p ${MIRROR_PATH}
+fi
+
+if [[ ${AGENT_USE_ZTP_MANIFESTS} == true ]]; then
+
+   generate_cluster_manifests
+
+ else
+
+  INSTALL_CONFIG_PATH="${OCP_DIR}"
+  mkdir -p ${INSTALL_CONFIG_PATH}
+
+  # set arrays as strings to pass in env
+  nodes_macs=$(printf '%s#' "${AGENT_NODES_MACS[@]}")
+  export AGENT_NODES_MACS_STR=${nodes_macs::-1}
+  nodes_ips=$(printf '%s#' "${AGENT_NODES_IPS[@]}")
+  export AGENT_NODES_IPS_STR=${nodes_ips::-1}
+  nodes_ipsv6=$(printf '%s#' "${AGENT_NODES_IPSV6[@]}")
+  export AGENT_NODES_IPSV6_STR=${nodes_ipsv6::-1}
+  nodes_hostnames=$(printf '%s#' "${AGENT_NODES_HOSTNAMES[@]}")
+  export AGENT_NODES_HOSTNAMES_STR=${nodes_hostnames::-1}
+
+  export API_VIP=${API_VIPs%${STRINGS_SEPARATOR}*}
+  export INGRESS_VIP=${INGRESS_VIPs%${STRINGS_SEPARATOR}*}
+
+  if [[ ! -z "${MIRROR_IMAGES}" ]]; then
+    # Store the certs for registry
+    if [[ "${REGISTRY_BACKEND}" = "podman" ]]; then
+       cp $REGISTRY_DIR/certs/$REGISTRY_CRT ${MIRROR_PATH}/ca-bundle.crt
+    else
+       cp ${WORKING_DIR}/quay-install/quay-rootCA/rootCA.pem ${MIRROR_PATH}/ca-bundle.crt
+    fi
+  fi
+
+  ansible-playbook -vvv \
+	  -e install_path=${SCRIPTDIR}/${INSTALL_CONFIG_PATH} \
+	  "${SCRIPTDIR}/agent/assets/installconfig/install-agent-config-playbook.yaml"
 fi
 
 generate_extra_cluster_manifests

--- a/agent/04_agent_configure.sh
+++ b/agent/04_agent_configure.sh
@@ -424,9 +424,11 @@ function generate_install_agent_config() {
   if [[ "$IP_STACK" = "v4v6" ]]; then
      export API_VIP=${API_VIPS}
      export INGRESS_VIP=${INGRESS_VIPS}
+     export PROVISIONING_HOST_EXTERNAL_IP_DUALSTACK=$(nth_ip $EXTERNAL_SUBNET_V6 1)
   else
      export API_VIP=${API_VIPS%${VIPS_SEPARATOR}*}
      export INGRESS_VIP=${INGRESS_VIPS%${VIPS_SEPARATOR}*}
+     export PROVISIONING_HOST_EXTERNAL_IP_DUALSTACK=""
   fi
 
   if [[ ! -z "${MIRROR_IMAGES}" ]]; then

--- a/agent/assets/installconfig/agent-config_yaml.j2
+++ b/agent/assets/installconfig/agent-config_yaml.j2
@@ -1,0 +1,82 @@
+{% set ips = agent_nodes_ips.split('#') %}
+{% set ipsv6 = agent_nodes_ipsv6.split('#') %}
+{% set macs = agent_nodes_macs.split('#') %}
+{% set hostnames = agent_nodes_hostnames.split('#') %}
+apiVersion: v1alpha1
+metadata:
+  name: {{ cluster_name }} 
+  namespace: {{ cluster_namespace }}
+rendezvousIP: {{ ips[0] }} 
+{% if networking_mode != "dhcp" %}
+hosts:
+{% for hostname in hostnames %}
+    - hostname: {{ hostname }}
+      interfaces:
+        - name: eth0 
+          macAddress: {{ macs[loop.index0] }} 
+      networkConfig:
+        interfaces:
+          - name: eth0
+            type: ethernet
+            state: up
+            mac-address: {{ macs[loop.index0] }} 
+{% if ip_stack == "v4" %}
+            ipv4:
+              enabled: true
+              address:
+                - ip: {{ ips[loop.index0] }} 
+                  prefix-length: {{ cluster_host_prefix_v4 }}
+              dhcp: false
+        dns-resolver:
+          config:
+            server:
+              - {{ provisioning_host_external_ip }} 
+        routes:
+          config:
+            - destination: 0.0.0.0/0
+              next-hop-address: {{ provisioning_host_external_ip }} 
+              next-hop-interface: eth0
+              table-id: 254
+{% elif ip_stack == "v6" %}
+            ipv6:
+              enabled: true
+              address:
+                - ip: {{ ipsv6[loop.index0] }} 
+                  prefix-length: {{ cluster_host_prefix_v6 }} 
+              dhcp: false
+        dns-resolver:
+          config:
+            server:
+              - {{ provisioning_host_external_ip }} 
+        routes:
+          config:
+            - destination: ::/0 
+              next-hop-address: {{ provisioning_host_external_ip }} 
+              next-hop-interface: eth0
+              table-id: 254
+{% else %}
+            ipv4:
+              enabled: true
+              address:
+                - ip: {{ ips[loop.index0] }} 
+                  prefix-length: {{ cluster_host_prefix_v4 }} 
+              dhcp: false
+            ipv6:
+              enabled: true
+              address:
+                - ip: {{ ipsv6[loop.index0] }} 
+                  prefix-length: {{ cluster_host_prefix_v6 }} 
+              dhcp: false
+        dns-resolver:
+          config:
+            server:
+              - {{ provisioning_host_external_ip }} 
+        routes:
+          config:
+            - destination: 0.0.0.0/0
+              next-hop-address: {{ provisioning_host_external_ip }} 
+              next-hop-interface: eth0
+              table-id: 254
+{% endif %}
+{% endfor %}
+{% endif %}

--- a/agent/assets/installconfig/agent-config_yaml.j2
+++ b/agent/assets/installconfig/agent-config_yaml.j2
@@ -1,7 +1,7 @@
-{% set ips = agent_nodes_ips.split('#') %}
-{% set ipsv6 = agent_nodes_ipsv6.split('#') %}
-{% set macs = agent_nodes_macs.split('#') %}
-{% set hostnames = agent_nodes_hostnames.split('#') %}
+{% set ips = agent_nodes_ips.split(',') %}
+{% set ipsv6 = agent_nodes_ipsv6.split(',') %}
+{% set macs = agent_nodes_macs.split(',') %}
+{% set hostnames = agent_nodes_hostnames.split(',') %}
 apiVersion: v1alpha1
 metadata:
   name: {{ cluster_name }} 

--- a/agent/assets/installconfig/agent-config_yaml.j2
+++ b/agent/assets/installconfig/agent-config_yaml.j2
@@ -71,10 +71,15 @@ hosts:
           config:
             server:
               - {{ provisioning_host_external_ip }} 
+              - {{ provisioning_host_external_ip_dualstack }}
         routes:
           config:
             - destination: 0.0.0.0/0
               next-hop-address: {{ provisioning_host_external_ip }} 
+              next-hop-interface: eth0
+              table-id: 254
+            - destination: ::/0
+              next-hop-address: {{ provisioning_host_external_ip_dualstack }}
               next-hop-interface: eth0
               table-id: 254
 {% endif %}

--- a/agent/assets/installconfig/install-agent-config-playbook.yaml
+++ b/agent/assets/installconfig/install-agent-config-playbook.yaml
@@ -32,12 +32,16 @@
     - pull_secret_contents: "{{ lookup('file', pull_secret) | to_json }}"
     - mirror_images: "{{ lookup('env', 'MIRROR_IMAGES') }}"
     - mirror_path: "{{ lookup('env', 'MIRROR_PATH') }}"
+    - mirror_command: "{{ lookup('env', 'MIRROR_COMMAND') }}"
     - local_image_url_suffix: "{{ lookup('env', 'LOCAL_IMAGE_URL_SUFFIX') }}"
     - local_registry_dns_name: "{{ lookup('env', 'LOCAL_REGISTRY_DNS_NAME') }}"
     - local_registry_port: "{{ lookup('env', 'LOCAL_REGISTRY_PORT') }}"
-    - ca_bundle_crt: "{{ lookup('file', mirror_path + '/ca-bundle.crt') | to_json }}"
 
   tasks:
+  - name: Get additional trust bundle
+    set_fact:
+      ca_bundle_crt: "{{ lookup('file', mirror_path + '/ca-bundle.crt') | to_json }}"
+    when: mirror_images == 'true'
   - name: write the install-config.yaml 
     template:
       src: "install-config_yaml.j2"

--- a/agent/assets/installconfig/install-agent-config-playbook.yaml
+++ b/agent/assets/installconfig/install-agent-config-playbook.yaml
@@ -4,6 +4,7 @@
    - community.general
   gather_facts: no
   vars:
+    - agent_deploy_mce: "{{ lookup('env', 'AGENT_DEPLOY_MCE') }}"
     - cluster_name: "{{ lookup('env', 'CLUSTER_NAME') }}"
     - cluster_namespace: "{{ lookup('env', 'CLUSTER_NAMESPACE') }}"
     - base_domain: "{{ lookup('env', 'BASE_DOMAIN') }}"

--- a/agent/assets/installconfig/install-agent-config-playbook.yaml
+++ b/agent/assets/installconfig/install-agent-config-playbook.yaml
@@ -1,0 +1,48 @@
+- name: Create install-config and agent-config for Agent Installer
+  hosts: localhost
+  collections:
+   - community.general
+  gather_facts: no
+  vars:
+    - cluster_name: "{{ lookup('env', 'CLUSTER_NAME') }}"
+    - cluster_namespace: "{{ lookup('env', 'CLUSTER_NAMESPACE') }}"
+    - base_domain: "{{ lookup('env', 'BASE_DOMAIN') }}"
+    - num_workers: "{{ lookup('env', 'NUM_WORKERS') }}"
+    - num_masters: "{{ lookup('env', 'NUM_MASTERS') }}"
+    - network_type: "{{ lookup('env', 'NETWORK_TYPE') }}"
+    - ip_stack: "{{ lookup('env', 'IP_STACK') }}"
+    - api_vips: "{{ lookup('env', 'API_VIP') }}"
+    - ingress_vips: "{{ lookup('env', 'INGRESS_VIP') }}"
+    - agent_nodes_macs: "{{ lookup('env', 'AGENT_NODES_MACS_STR') }}"
+    - agent_nodes_ips: "{{ lookup('env', 'AGENT_NODES_IPS_STR') }}"
+    - agent_nodes_ipsv6: "{{ lookup('env', 'AGENT_NODES_IPSV6_STR') }}"
+    - agent_nodes_hostnames: "{{ lookup('env', 'AGENT_NODES_HOSTNAMES_STR') }}"
+    - cluster_host_prefix_v4: "{{ lookup('env', 'CLUSTER_HOST_PREFIX_V4') }}"
+    - cluster_host_prefix_v6: "{{ lookup('env', 'CLUSTER_HOST_PREFIX_V6') }}"
+    - cluster_subnet_v4: "{{ lookup('env', 'CLUSTER_SUBNET_V4') }}"
+    - cluster_subnet_v6: "{{ lookup('env', 'CLUSTER_SUBNET_V6') }}"
+    - service_subnet_v4: "{{ lookup('env', 'SERVICE_SUBNET_V4') }}"
+    - service_subnet_v6: "{{ lookup('env', 'SERVICE_SUBNET_V6') }}"
+    - external_subnet_v4: "{{ lookup('env', 'EXTERNAL_SUBNET_V4') }}"
+    - external_subnet_v6: "{{ lookup('env', 'EXTERNAL_SUBNET_V6') }}"
+    - provisioning_host_external_ip: "{{ lookup('env', 'PROVISIONING_HOST_EXTERNAL_IP') }}"
+    - networking_mode: "{{ lookup('env', 'NETWORKING_MODE') }}"
+    - ssh_pub_key: "{{ lookup('env', 'SSH_PUB_KEY') }}"
+    - pull_secret: "{{ lookup('env', 'PULL_SECRET_FILE') }}"
+    - pull_secret_contents: "{{ lookup('file', pull_secret) | to_json }}"
+    - mirror_images: "{{ lookup('env', 'MIRROR_IMAGES') }}"
+    - mirror_path: "{{ lookup('env', 'MIRROR_PATH') }}"
+    - local_image_url_suffix: "{{ lookup('env', 'LOCAL_IMAGE_URL_SUFFIX') }}"
+    - local_registry_dns_name: "{{ lookup('env', 'LOCAL_REGISTRY_DNS_NAME') }}"
+    - local_registry_port: "{{ lookup('env', 'LOCAL_REGISTRY_PORT') }}"
+    - ca_bundle_crt: "{{ lookup('file', mirror_path + '/ca-bundle.crt') | to_json }}"
+
+  tasks:
+  - name: write the install-config.yaml 
+    template:
+      src: "install-config_yaml.j2"
+      dest: "{{ install_path }}/install-config.yaml"
+  - name: write the agent-config.yaml 
+    template:
+      src: "agent-config_yaml.j2"
+      dest: "{{ install_path }}/agent-config.yaml"

--- a/agent/assets/installconfig/install-agent-config-playbook.yaml
+++ b/agent/assets/installconfig/install-agent-config-playbook.yaml
@@ -16,8 +16,6 @@
     - agent_nodes_ips: "{{ lookup('env', 'AGENT_NODES_IPS_STR') }}"
     - agent_nodes_ipsv6: "{{ lookup('env', 'AGENT_NODES_IPSV6_STR') }}"
     - agent_nodes_hostnames: "{{ lookup('env', 'AGENT_NODES_HOSTNAMES_STR') }}"
-    - ingress_vips: "{{ lookup('env', 'INGRESS_VIPS') }}"
-    - api_vips: "{{ lookup('env', 'API_VIPS') }}"
     - cluster_host_prefix_v4: "{{ lookup('env', 'CLUSTER_HOST_PREFIX_V4') }}"
     - cluster_host_prefix_v6: "{{ lookup('env', 'CLUSTER_HOST_PREFIX_V6') }}"
     - cluster_subnet_v4: "{{ lookup('env', 'CLUSTER_SUBNET_V4') }}"
@@ -43,6 +41,11 @@
     set_fact:
       ca_bundle_crt: "{{ lookup('file', mirror_path + '/ca-bundle.crt') | to_json }}"
     when: mirror_images == 'true'
+  - name: Get VIPs when not using SNO
+    set_fact:
+      ingress_vips: "{{ lookup('env', 'INGRESS_VIPS') }}"
+      api_vips: "{{ lookup('env', 'API_VIPS') }}"
+    when: num_masters != 1
   - name: Get external IPV6 address when set for dualstack
     set_fact:
       provisioning_host_external_ip_dualstack: "{{ lookup('env', 'PROVISIONING_HOST_EXTERNAL_IP_DUALSTACK') }}"

--- a/agent/assets/installconfig/install-agent-config-playbook.yaml
+++ b/agent/assets/installconfig/install-agent-config-playbook.yaml
@@ -27,6 +27,7 @@
     - external_subnet_v4: "{{ lookup('env', 'EXTERNAL_SUBNET_V4') }}"
     - external_subnet_v6: "{{ lookup('env', 'EXTERNAL_SUBNET_V6') }}"
     - provisioning_host_external_ip: "{{ lookup('env', 'PROVISIONING_HOST_EXTERNAL_IP') }}"
+    - provisioning_host_external_ip_dualstack: "{{ lookup('env', 'PROVISIONING_HOST_EXTERNAL_IP_DUALSTACK') }}"
     - networking_mode: "{{ lookup('env', 'NETWORKING_MODE') }}"
     - ssh_pub_key: "{{ lookup('env', 'SSH_PUB_KEY') }}"
     - pull_secret: "{{ lookup('env', 'PULL_SECRET_FILE') }}"

--- a/agent/assets/installconfig/install-agent-config-playbook.yaml
+++ b/agent/assets/installconfig/install-agent-config-playbook.yaml
@@ -12,12 +12,12 @@
     - num_masters: "{{ lookup('env', 'NUM_MASTERS') }}"
     - network_type: "{{ lookup('env', 'NETWORK_TYPE') }}"
     - ip_stack: "{{ lookup('env', 'IP_STACK') }}"
-    - api_vips: "{{ lookup('env', 'API_VIP') }}"
-    - ingress_vips: "{{ lookup('env', 'INGRESS_VIP') }}"
     - agent_nodes_macs: "{{ lookup('env', 'AGENT_NODES_MACS_STR') }}"
     - agent_nodes_ips: "{{ lookup('env', 'AGENT_NODES_IPS_STR') }}"
     - agent_nodes_ipsv6: "{{ lookup('env', 'AGENT_NODES_IPSV6_STR') }}"
     - agent_nodes_hostnames: "{{ lookup('env', 'AGENT_NODES_HOSTNAMES_STR') }}"
+    - ingress_vips: "{{ lookup('env', 'INGRESS_VIPS') }}"
+    - api_vips: "{{ lookup('env', 'API_VIPS') }}"
     - cluster_host_prefix_v4: "{{ lookup('env', 'CLUSTER_HOST_PREFIX_V4') }}"
     - cluster_host_prefix_v6: "{{ lookup('env', 'CLUSTER_HOST_PREFIX_V6') }}"
     - cluster_subnet_v4: "{{ lookup('env', 'CLUSTER_SUBNET_V4') }}"
@@ -27,7 +27,6 @@
     - external_subnet_v4: "{{ lookup('env', 'EXTERNAL_SUBNET_V4') }}"
     - external_subnet_v6: "{{ lookup('env', 'EXTERNAL_SUBNET_V6') }}"
     - provisioning_host_external_ip: "{{ lookup('env', 'PROVISIONING_HOST_EXTERNAL_IP') }}"
-    - provisioning_host_external_ip_dualstack: "{{ lookup('env', 'PROVISIONING_HOST_EXTERNAL_IP_DUALSTACK') }}"
     - networking_mode: "{{ lookup('env', 'NETWORKING_MODE') }}"
     - ssh_pub_key: "{{ lookup('env', 'SSH_PUB_KEY') }}"
     - pull_secret: "{{ lookup('env', 'PULL_SECRET_FILE') }}"
@@ -44,6 +43,10 @@
     set_fact:
       ca_bundle_crt: "{{ lookup('file', mirror_path + '/ca-bundle.crt') | to_json }}"
     when: mirror_images == 'true'
+  - name: Get external IPV6 address when set for dualstack
+    set_fact:
+      provisioning_host_external_ip_dualstack: "{{ lookup('env', 'PROVISIONING_HOST_EXTERNAL_IP_DUALSTACK') }}"
+    when: ip_stack == 'v4v6'
   - name: write the install-config.yaml 
     template:
       src: "install-config_yaml.j2"

--- a/agent/assets/installconfig/install-config_yaml.j2
+++ b/agent/assets/installconfig/install-config_yaml.j2
@@ -65,10 +65,10 @@ sshKey: {{ ssh_pub_key }}
 imageContentSources:
 {% if mirror_command == "oc-mirror" %}
 - mirrors:
-    - "{{ local_registry_dns_name }}:{{ local_registry_port }}/{{ local_image_url_suffix }}"
+    - "{{ local_registry_dns_name }}:{{ local_registry_port }}/openshift/release-images"
   source: "quay.io/openshift-release-dev/ocp-release"
 - mirrors:
-    - "{{ local_registry_dns_name }}:{{ local_registry_port }}/{{ local_image_url_suffix }}"
+    - "{{ local_registry_dns_name }}:{{ local_registry_port }}/openshift/release"
   source: "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
 - mirrors:
     - "{{ local_registry_dns_name }}:{{ local_registry_port }}/ubi8"

--- a/agent/assets/installconfig/install-config_yaml.j2
+++ b/agent/assets/installconfig/install-config_yaml.j2
@@ -5,6 +5,7 @@ compute:
   name: worker
   replicas: {{ num_workers }} 
 controlPlane:
+  architecture: amd64
   hyperthreading: Enabled
   name: master
   replicas: {{ num_masters }} 

--- a/agent/assets/installconfig/install-config_yaml.j2
+++ b/agent/assets/installconfig/install-config_yaml.j2
@@ -63,11 +63,36 @@ pullSecret: {{ pull_secret_contents }}
 sshKey: {{ ssh_pub_key }} 
 {% if mirror_images == "true" %}
 imageContentSources:
+{% if mirror_command == "oc-mirror" %}
+- mirrors:
+    - "{{ local_registry_dns_name }}:{{ local_registry_port }}/{{ local_image_url_suffix }}"
+  source: "quay.io/openshift-release-dev/ocp-release"
+- mirrors:
+    - "{{ local_registry_dns_name }}:{{ local_registry_port }}/{{ local_image_url_suffix }}"
+  source: "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
+- mirrors:
+    - "{{ local_registry_dns_name }}:{{ local_registry_port }}/ubi8"
+  source: "registry.redhat.io/ubi8"
+{% if agent_deploy_mce == "true" %}
+{# oc mirror registries.conf with MCE #}
+- mirrors:
+    - "{{ local_registry_dns_name }}:{{ local_registry_port }}/multicluster-engine"
+  source: "registry.redhat.io/multicluster-engine"
+- mirrors:
+    - "{{ local_registry_dns_name }}:{{ local_registry_port }}/rhel8"
+  source: "registry.redhat.io/rhel8"
+- mirrors:
+    - "{{ local_registry_dns_name }}:{{ local_registry_port }}/redhat"
+  source: "registry.redhat.io/redhat"
+{% endif %}
+{% else %}
+{# oc_mirror = oc-adm #}
 - mirrors:
     - "{{ local_registry_dns_name }}:{{ local_registry_port }}/{{ local_image_url_suffix }}"
   source: "registry.ci.openshift.org/ocp/release"
 - mirrors:
     - "{{ local_registry_dns_name }}:{{ local_registry_port }}/{{ local_image_url_suffix }}"
   source: "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
+{% endif %}
 additionalTrustBundle: {{ ca_bundle_crt }}
 {% endif %}

--- a/agent/assets/installconfig/install-config_yaml.j2
+++ b/agent/assets/installconfig/install-config_yaml.j2
@@ -1,0 +1,73 @@
+apiVersion: v1
+baseDomain: {{ base_domain }}
+compute:
+- hyperthreading: Enabled
+  name: worker
+  replicas: {{ num_workers }} 
+controlPlane:
+  hyperthreading: Enabled
+  name: master
+  replicas: {{ num_masters }} 
+metadata:
+  name: {{ cluster_name }} 
+  namespace: {{ cluster_namespace }}
+networking:
+{% if ip_stack == "v4" %}
+  clusterNetwork:
+  - cidr: {{ cluster_subnet_v4 }}
+    hostPrefix: {{ cluster_host_prefix_v4 }}
+  machineNetwork:
+  - cidr: {{ external_subnet_v4 }}
+  serviceNetwork:
+  - {{ service_subnet_v4 }}
+{% elif ip_stack == "v6" %}
+  clusterNetwork:
+  - cidr: {{ cluster_subnet_v6 }}
+    hostPrefix: {{ cluster_host_prefix_v6 }}
+  machineNetwork:
+  - cidr: {{ external_subnet_v6 }}
+  serviceNetwork:
+  - {{ service_subnet_v6 }}
+{% else %}
+  clusterNetwork:
+  - cidr: {{ cluster_subnet_v4 }}
+    hostPrefix: {{ cluster_host_prefix_v4 }}
+  - cidr: {{ cluster_subnet_v6 }}
+    hostPrefix: {{ cluster_host_prefix_v6 }}
+  machineNetwork:
+  - cidr: {{ external_subnet_v4 }}
+  - cidr: {{ external_subnet_v6 }}
+  serviceNetwork:
+  - {{ service_subnet_v4 }}
+  - {{ service_subnet_v6 }}
+{% endif %}
+  networkType: {{ network_type }} 
+platform:
+{% if num_masters == "1" %}
+  none: {}
+{% else %}
+{% set macs = agent_nodes_macs.split('#') %}
+{% set hostnames = agent_nodes_hostnames.split('#') %}
+  baremetal:
+    apiVIPs:
+      - {{ api_vips }} 
+    ingressVIPs:
+      - {{ ingress_vips }}
+    hosts:
+{% for mac in macs %}
+      - name: {{ hostnames[loop.index0] }}
+        bootMACAddress: {{ mac }}
+{% endfor %}
+{% endif %}
+pullSecret: {{ pull_secret_contents }}
+sshKey: {{ ssh_pub_key }} 
+{% if mirror_images == "true" %}
+imageContentSources:
+- mirrors:
+    - "{{ local_registry_dns_name }}:{{ local_registry_port }}/{{ local_image_url_suffix }}"
+  source: "registry.ci.openshift.org/ocp/release"
+- mirrors:
+    - "{{ local_registry_dns_name }}:{{ local_registry_port }}/{{ local_image_url_suffix }}"
+  source: "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
+additionalTrustBundle: {{ ca_bundle_crt }}
+{% endif %}

--- a/agent/assets/installconfig/install-config_yaml.j2
+++ b/agent/assets/installconfig/install-config_yaml.j2
@@ -47,8 +47,8 @@ platform:
 {% if num_masters == "1" %}
   none: {}
 {% else %}
-{% set macs = agent_nodes_macs.split('#') %}
-{% set hostnames = agent_nodes_hostnames.split('#') %}
+{% set macs = agent_nodes_macs.split(',') %}
+{% set hostnames = agent_nodes_hostnames.split(',') %}
   baremetal:
     apiVIPs:
 {% set a_vips = api_vips.split(',') %}

--- a/agent/assets/installconfig/install-config_yaml.j2
+++ b/agent/assets/installconfig/install-config_yaml.j2
@@ -51,9 +51,15 @@ platform:
 {% set hostnames = agent_nodes_hostnames.split('#') %}
   baremetal:
     apiVIPs:
-      - {{ api_vips }} 
+{% set a_vips = api_vips.split(',') %}
+{% for api_vip in a_vips %}
+      - {{ api_vip }}
+{% endfor %}
     ingressVIPs:
-      - {{ ingress_vips }}
+{% set i_vips = ingress_vips.split(',') %}
+{% for ingress_vip in i_vips %}
+      - {{ ingress_vip }}
+{% endfor %}
     hosts:
 {% for mac in macs %}
       - name: {{ hostnames[loop.index0] }}

--- a/agent/common.sh
+++ b/agent/common.sh
@@ -10,7 +10,9 @@ export OPENSHIFT_INSTALLER_CMD="openshift-install"
 
 # Override to consistently use the proper subnet
 export CLUSTER_HOST_PREFIX_V4="24"
-export EXTERNAL_SUBNET_V6="fd2e:6f44:5dd8:c956::/64"
+if [[ "$IP_STACK" != "v4" ]]; then
+   export EXTERNAL_SUBNET_V6="fd2e:6f44:5dd8:c956::/64"
+fi
 
 function getReleaseImage() {
     local releaseImage=${OPENSHIFT_RELEASE_IMAGE}

--- a/agent/common.sh
+++ b/agent/common.sh
@@ -3,6 +3,8 @@ set -euxo pipefail
 
 export AGENT_STATIC_IP_NODE0_ONLY=${AGENT_STATIC_IP_NODE0_ONLY:-"false"}
 
+export AGENT_USE_ZTP_MANIFESTS=${AGENT_USE_ZTP_MANIFESTS=:-"false"}
+
 # Override command name in case of extraction
 export OPENSHIFT_INSTALLER_CMD="openshift-install"
 

--- a/common.sh
+++ b/common.sh
@@ -448,13 +448,14 @@ if [[ -n "$MIRROR_IMAGES" || -z "${IP_STACK:-}" || "$IP_STACK" = "v6" ]]; then
 
    # We're going to be using a locally modified release image
    if [[ ! -z ${AGENT_E2E_TEST_SCENARIO} ]]; then
-	   # For the agent installer version check a valid tag must be supplied (not 'latest').
-	  if [[ ${#OPENSHIFT_RELEASE_TAG} = 64 ]] && [[ ${OPENSHIFT_RELEASE_TAG} =~ [:alnum:] ]]; then
-	     # If the tag is a digest, add sha identifier
-             export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/${LOCAL_IMAGE_URL_SUFFIX}@sha256:${OPENSHIFT_RELEASE_TAG}"
-	  else
-             export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/${LOCAL_IMAGE_URL_SUFFIX}:${OPENSHIFT_RELEASE_TAG}"
-	  fi
+        # For the agent installer version check, a valid tag must be supplied (not 'latest').
+	if [[ ${#OPENSHIFT_RELEASE_TAG} = 64 ]] && [[ ${OPENSHIFT_RELEASE_TAG} =~ [:alnum:] ]]; then
+	    # If the tag is a digest, don't change the override from OPENSHIFT_RELEASE_IMAGE
+	    # Since mirror-by-digest-only = true on the bootstrap
+	    echo "Not changing OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE since digest is being used"
+	else
+            export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/${LOCAL_IMAGE_URL_SUFFIX}:${OPENSHIFT_RELEASE_TAG}"
+	fi
    else
        # 04_setup_ironic requires tag to be 'latest'
        export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/${LOCAL_IMAGE_URL_SUFFIX}:latest"

--- a/config_example.sh
+++ b/config_example.sh
@@ -667,3 +667,7 @@ set -x
 
 # Uncomment the following line to deploy the MCE operator, and to automatically import the current cluster as the hub cluster
 # export AGENT_DEPLOY_MCE=true
+
+# Set the following value to true to supply ZTP manifests to the installer. By default the install-config.yaml/agent-config.yaml
+# will be used as input to the installer.
+# export AGENT_USE_ZTP_MANIFESTS=false


### PR DESCRIPTION
Add support for install-config.yaml and agent-config.yaml for agent deployments and use it by default. ZTP manifests can still be used by setting the new 'AGENT_USE_ZTP_MANIFESTS' to true.  This uses ansible and jinja to create the yaml files files based on https://github.com/openshift-metal3/dev-scripts/pull/1458.