### PR TITLE
[WIP] Update metal3-dev-env

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -19,13 +19,13 @@ if [ -z "${METAL3_DEV_ENV}" ]; then
   # TODO -- come up with a plan for continuously updating this
   # Note we only do this in the case where METAL3_DEV_ENV is
   # unset, to enable developer testing of local checkouts
-  git reset 6a8fb0d5543970b5d628e1204a3b3d3f9f70a63f --hard
+  git reset 6354a2ca58301fd64408e74a3d3f40fe2bd0e919 --hard
   popd
 fi
 
 # This must be aligned with the metal3-dev-env pinned version above, see
 # https://github.com/metal3-io/metal3-dev-env/blob/master/lib/common.sh
-export ANSIBLE_VERSION=${ANSIBLE_VERSION:-"5.9.0"}
+export ANSIBLE_VERSION=${ANSIBLE_VERSION:-"6.5.0"}
 
 # Update to latest packages first
 sudo dnf -y upgrade


### PR DESCRIPTION
CI complains about 

```
Problem: package gnutls-dane-3.6.16-4.el8.x86_64 requires gnutls(x86-64) = 3.6.16-4.el8, but none of the providers can be installed\n  - cannot install both gnutls-3.6.16-5.el8_6.x86_64 and gnutls-3.6.16-4.el8.x86_64\n  - cannot install the best update candidate for package gnutls-dane-3.6.16-4.el8.x86_64\n  - cannot install the best update candidate for package gnutls-3.6.16-4.el8.x86_64"
```