### PR TITLE
Add temporary support for mce installation

### DIFF
--- a/agent/04_agent_configure.sh
+++ b/agent/04_agent_configure.sh
@@ -461,7 +461,11 @@ EOF
 function oc_mirror_mce() {
    tmpimageset=$(mktemp --tmpdir "mceimageset--XXXXXXXXXX")
    _tmpfiles="$_tmpfiles $tmpimageset"
-
+   # TODO: Remove this once LSO is published to the 4.12 catalog.
+   local version="$(openshift_version ${OCP_DIR})"
+   if [[ ( -n "${AGENT_DEPLOY_MCE}" ) && ( ${version} == "4.12" || ${version} == "4.13" ) ]]; then
+     local OPENSHIFT_RELEASE_STREAM="4.11"
+   fi
    cat > "${tmpimageset}" << EOF
 ---
 apiVersion: mirror.openshift.io/v1alpha2


### PR DESCRIPTION
LSO has not been published to the 4.12 redhat-operators catalog, so it cannot be installed on OpenShift 4.12. Until this is resolved, installing LSO with 4.11 catalog as redhat-operators-v4-11.
 