### PR TITLE
agent: set api dns entry for SNO clusters

### DIFF
--- a/agent/04_agent_configure.sh
+++ b/agent/04_agent_configure.sh
@@ -509,6 +509,15 @@ fi
 
 if [[ "${NUM_MASTERS}" > "1" ]]; then
    set_api_and_ingress_vip
+else
+  # For SNO clusters, at least the api dns entry must be set
+  # otherwise oc/openshift-install commands requiring the
+  # kubeconfig will not work properly
+  ip=${AGENT_NODES_IPS[0]}
+  if [[ "$IP_STACK" != "v4" ]]; then
+    ip=${AGENT_NODES_IPSV6[0]}
+  fi
+  configure_dnsmasq ${ip} ""
 fi
 
 if [[ $NETWORKING_MODE == "DHCP" ]]; then


### PR DESCRIPTION
SNO clusters require at least the api dns entry to be set, otherwise the oc/openshift-install commands will not work properly