### PR TITLE
Fix Assisted Service cleanup script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ ocp_run:
 gather:
 	./must_gather.sh
 
-clean: ocp_cleanup ironic_cleanup proxy_cleanup host_cleanup assisted_deployment_cleanup agent_cleanup  registry_cleanup oc_mirror_cleanup
+clean: ocp_cleanup ironic_cleanup proxy_cleanup host_cleanup agent_cleanup registry_cleanup oc_mirror_cleanup
 
 assisted_deployment_cleanup:
 	./assisted_deployment.sh delete_all

--- a/assisted_deployment.sh
+++ b/assisted_deployment.sh
@@ -327,10 +327,8 @@ function delete_hive() {
 }
 
 function delete_all() {
-    if  [ "$NODES_PLATFORM" = "assisted" ]; then
-        delete_assisted
-        delete_hive
-    fi
+    delete_assisted
+    delete_hive
 
     # Skipping LocalVolume cleanup on purpose.
 }


### PR DESCRIPTION
This PR fixes the script responsible for cleaning up the Assisted
Service deployment. It previously relied on the variable
`NODES_PLATFORM` that has a value of `libvirt` and is unrelated
to how the Assisted Service is deployed. With this change the
Make target `assisted_deployment_cleanup` works correctly again.

This PR changes the generic `clean` target as Assisted cleanup is
redundant at this point as underlying OCP cluster has already been
deleted.