### PR TITLE
WIP webui: Allow embedding a webui service

### DIFF
--- a/agent/assets/webui/ui.bu.j2
+++ b/agent/assets/webui/ui.bu.j2
@@ -1,0 +1,30 @@
+variant: openshift
+version: 4.12
+systemd:
+  units:
+    - name: assisted-web-ui.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Assisted Service web-ui
+        Wants=network.target
+        RequiresMountsFor=%t/containers
+        Requires=assisted-service.service
+        BindsTo=assisted-service-pod.service
+        After=network-online.target assisted-service-pod.service
+        ConditionPathExists=/etc/assisted-service/node0
+
+        [Service]
+        Environment=PODMAN_SYSTEMD_UNIT=%n
+        Restart=on-failure
+        TimeoutStartSec=500
+        TimeoutStopSec=300
+        ExecStartPre=/bin/rm -f %t/%n.ctr-id
+        ExecStart=/usr/bin/podman run --net host --cidfile=%t/%n.ctr-id --cgroups=no-conmon --log-driver=journald --rm --pod-id-file=%t/assisted-service-pod.pod-id --sdnotify=conmon --replace -d --name=webui {{ webui_image }}
+        ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
+        ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
+        Type=notify
+        NotifyAccess=all
+
+        [Install]
+        WantedBy=multi-user.target

--- a/agent/assets/webui/webui-playbook.yaml
+++ b/agent/assets/webui/webui-playbook.yaml
@@ -1,0 +1,87 @@
+- name: Create webui content for Agent ISO
+  hosts: localhost
+  collections:
+   - community.general
+  gather_facts: no
+  vars:
+    - webui_image: "{{ lookup('env', 'WEBUI_IMAGE') }}"
+    - ocp_dir: "{{ loopkup('env', 'OCP_DIR') }}"
+
+  tasks:
+    - name: Check agent iso
+      ansible.builtin.file:
+        state: file
+        path: "{{ ocp_dir }}/agent.{{ ansible_architecture }}.iso"
+      register: agent_iso
+
+    - name: Create webui temp dir
+      ansible.builtin.tempfile:
+        state: directory
+        suffix: webui
+      register: ui_tempdir
+
+    - name: write UI butane
+      template:
+        src: "ui.bu.j2"
+        dest: "{{ ui_tempdir.path }}/ui.bu"
+
+    - name: Generate UI ignition
+      containers.podman.podman_container:
+        name: butane
+        state: started
+        detach: no
+        rm: yes
+        volume:
+          - "{{ ui_tempdir.path }}:/data"
+        image: quay.io/coreos/butane:release
+        command: "--pretty --strict /data/ui.bu -o /data/ui.ign"
+
+    
+    - name: Extract Agent ISO ignition
+      containers.podman.podman_container:
+        name: coreos-installer
+        state: started
+        detach: no
+        rm: yes
+        volume:
+          - "{{ agent_iso.path }}:/data/agent.iso"
+        image: quay.io/coreos/coreos-installer:release
+        command: "iso ignition show /data/agent.iso"
+      register: iso_ignition
+
+    - name: save ISO ignition
+      ansible.builtin.copy:
+        content: "{{ iso_ignition.stdout }}"
+        dest: "{{ ui_tempdir.path }}/iso.ign"
+
+    - name: Get kcli ignition merger tool
+      ansible.builtin.get_url:
+        url: https://raw.githubusercontent.com/karmab/kcli/master/extras/ignitionmerger.py
+        dest: "{{ ui_tempdir.path }}/ignitionmerger.py"
+        mode: "0755"
+
+    - name: Merge ignition
+      ansible.builtin.command:
+        argv:
+          - python
+          - "{{ ui_tempdir.path }}/ignitionmerger.py"
+          - "{{ ui_tempdir.path }}/iso.ign"
+          - "{{ ui_tempdir.path }}/ui.ign"
+      register: ignitionmerger
+
+    - name: save merged ignition
+      ansible.builtin.copy:
+        content: "{{ ignitionmerger.stdout }}"
+        dest: "{{ ui_tempdir.path }}/merged.ign"
+
+    - name: Embedding merged ignition
+      containers.podman.podman_container:
+        name: coreos-installer
+        state: started
+        detach: no
+        rm: yes
+        volume:
+          - "{{ ui_tempdir.path }}/merged.ign:/data/merged.ign"
+          - "{{ agent_iso.path }}:/data/agent.iso"
+        image: quay.io/coreos/coreos-installer:release
+        command: "iso ignition embed -f -i /data/merged.ign /data/agent.iso"

--- a/config_example.sh
+++ b/config_example.sh
@@ -667,3 +667,8 @@ set -x
 
 # Uncomment the following line to deploy the MCE operator, and to automatically import the current cluster as the hub cluster
 # export AGENT_DEPLOY_MCE=true
+
+# If you want to run the assisted service UI, you must set the following environment variables:
+# AGENT_EMBED_GUI=true
+# WEBUI_IMAGE="quay.io/edge-infrastructure/assisted-installer-ui:latest"
+# Note that if you can put a different WEBUI_IMAGE


### PR DESCRIPTION
dev-scripts currently supports running webui on node0 by sshing into it and using podman to run a webui image. This commits adds the ability to embed the logic to run the webui in the image itself, so it will run as soon as possible.

There should be some follow-up work to embed the image itself into the ISO to allow for disconnected. Until then, one could put the image reference to point to dev-scripts registry.

Signed-off-by: Antoni Segura Puimedon <antoni@redhat.com>