### PR TITLE
AGENT-429: Dynamically generate mirror configuration for agent

### DIFF
--- a/agent/assets/installconfig/install-agent-config-playbook.yaml
+++ b/agent/assets/installconfig/install-agent-config-playbook.yaml
@@ -31,15 +31,16 @@
     - pull_secret_contents: "{{ lookup('file', pull_secret) | to_json }}"
     - mirror_images: "{{ lookup('env', 'MIRROR_IMAGES') }}"
     - mirror_path: "{{ lookup('env', 'MIRROR_PATH') }}"
+    - mirror_info_file: "{{ lookup('env', 'MIRROR_INFO_FILE', default='') }}"
     - mirror_command: "{{ lookup('env', 'MIRROR_COMMAND') }}"
-    - local_image_url_suffix: "{{ lookup('env', 'LOCAL_IMAGE_URL_SUFFIX') }}"
     - local_registry_dns_name: "{{ lookup('env', 'LOCAL_REGISTRY_DNS_NAME') }}"
     - local_registry_port: "{{ lookup('env', 'LOCAL_REGISTRY_PORT') }}"
 
   tasks:
-  - name: Get additional trust bundle
+  - name: Get files for mirror configuration
     set_fact:
       ca_bundle_crt: "{{ lookup('file', mirror_path + '/ca-bundle.crt') | to_json }}"
+      image_content_sources: "{{ lookup('file', mirror_info_file) }}"
     when: mirror_images == 'true'
   - name: Get VIPs when not using SNO
     set_fact:

--- a/agent/assets/installconfig/install-config_yaml.j2
+++ b/agent/assets/installconfig/install-config_yaml.j2
@@ -70,18 +70,8 @@ pullSecret: {{ pull_secret_contents }}
 sshKey: {{ ssh_pub_key }} 
 {% if mirror_images == "true" %}
 imageContentSources:
-{% if mirror_command == "oc-mirror" %}
-- mirrors:
-    - "{{ local_registry_dns_name }}:{{ local_registry_port }}/openshift/release-images"
-  source: "quay.io/openshift-release-dev/ocp-release"
-- mirrors:
-    - "{{ local_registry_dns_name }}:{{ local_registry_port }}/openshift/release"
-  source: "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
-- mirrors:
-    - "{{ local_registry_dns_name }}:{{ local_registry_port }}/ubi8"
-  source: "registry.redhat.io/ubi8"
-{% if agent_deploy_mce == "true" %}
-{# oc mirror registries.conf with MCE #}
+{{ image_content_sources }}
+{% if (mirror_command == "oc-mirror") and (agent_deploy_mce == "true") %}
 - mirrors:
     - "{{ local_registry_dns_name }}:{{ local_registry_port }}/multicluster-engine"
   source: "registry.redhat.io/multicluster-engine"
@@ -91,15 +81,6 @@ imageContentSources:
 - mirrors:
     - "{{ local_registry_dns_name }}:{{ local_registry_port }}/redhat"
   source: "registry.redhat.io/redhat"
-{% endif %}
-{% else %}
-{# oc_mirror = oc-adm #}
-- mirrors:
-    - "{{ local_registry_dns_name }}:{{ local_registry_port }}/{{ local_image_url_suffix }}"
-  source: "registry.ci.openshift.org/ocp/release"
-- mirrors:
-    - "{{ local_registry_dns_name }}:{{ local_registry_port }}/{{ local_image_url_suffix }}"
-  source: "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
 {% endif %}
 additionalTrustBundle: {{ ca_bundle_crt }}
 {% endif %}

--- a/agent/assets/ztp/registries-conf-playbook.yaml
+++ b/agent/assets/ztp/registries-conf-playbook.yaml
@@ -5,14 +5,18 @@
   gather_facts: no
   vars:
     - agent_deploy_mce: "{{ lookup('env', 'AGENT_DEPLOY_MCE') }}"
-    - local_image_url_suffix: "{{ lookup('env', 'LOCAL_IMAGE_URL_SUFFIX') }}"
     - local_registry_dns_name: "{{ lookup('env', 'LOCAL_REGISTRY_DNS_NAME') }}"
     - local_registry_port: "{{ lookup('env', 'LOCAL_REGISTRY_PORT') }}"
     - mirror_images: "{{ lookup('env', 'MIRROR_IMAGES') }}"
     - mirror_path: "{{ lookup('env', 'MIRROR_PATH') }}"
     - mirror_command: "{{ lookup('env', 'MIRROR_COMMAND') }}"
+    - mirror_info_file: "{{ lookup('env', 'MIRROR_INFO_FILE', default='') }}"
 
   tasks:
+  - name: Get mirror settings
+    set_fact:
+      registries: "{{ lookup('file', mirror_info_file) }}"
+    when: mirror_images == 'true'
   - name: write the registries.conf
     template:
       src: "registries_conf.j2"

--- a/agent/assets/ztp/registries_conf.j2
+++ b/agent/assets/ztp/registries_conf.j2
@@ -1,30 +1,8 @@
+{% if mirror_images == "true" %}
 {# base oc mirror registries.conf #}
-{% if mirror_command == "oc-mirror" %}
-[[registry]]
-prefix = ""
-location = "quay.io/openshift-release-dev/ocp-release"
-mirror-by-digest-only = false
-
-[[registry.mirror]]
-location = "{{ local_registry_dns_name }}:{{ local_registry_port }}/openshift/release-images"
-
-[[registry]]
-prefix = ""
-location = "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
-mirror-by-digest-only = false
-
-[[registry.mirror]]
-location = "{{ local_registry_dns_name }}:{{ local_registry_port }}/openshift/release"
-
-[[registry]]
-prefix = ""
-location = "registry.redhat.io/ubi8"
-mirror-by-digest-only = false
-
-[[registry.mirror]]
-location = "{{ local_registry_dns_name }}:{{ local_registry_port }}/ubi8"
+{{ registries }}
+{% if (mirror_command == "oc-mirror") and (agent_deploy_mce == "true") %}
 {# oc mirror registries.conf with MCE #}
-{% if agent_deploy_mce == "true" %}
 [[registry]]
 prefix = ""
 location = "registry.redhat.io/multicluster-engine"
@@ -49,21 +27,4 @@ mirror-by-digest-only = false
 [[registry.mirror]]
 location = "{{ local_registry_dns_name }}:{{ local_registry_port }}/redhat"
 {% endif %}
-{# legacy mirror registries.conf #}
-{% elif mirror_images == "true" %}
-[[registry]]
-prefix = ""
-location = "registry.ci.openshift.org/ocp/release"
-mirror-by-digest-only = false
-
-[[registry.mirror]]
-location = "{{ local_registry_dns_name }}:{{ local_registry_port }}/{{ local_image_url_suffix }}"
-
-[[registry]]
-prefix = ""
-location = "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
-mirror-by-digest-only = false
-
-[[registry.mirror]]
-location = "{{ local_registry_dns_name }}:{{ local_registry_port }}/{{ local_image_url_suffix }}"
 {% endif %}


### PR DESCRIPTION
The mirror registries configuration for the agent is currently hardcoded. This is incorrect when a particular release image digest is defined, for example here is the ICSP for recent 4.12 image when using:
OPENSHIFT_RELEASE_IMAGE=registry.ci.openshift.org/ocp/release@sha256:508e696f24fc844cbbf9599ee6516c2f76d032f363a041df0441e3629ce64807

imageContentSources:
- mirrors:
  - virthost.ostest.test.metalkube.org:5000/localimages/local-release-image 
 source: registry.ci.openshift.org/ocp/4.12-2022-11-11-131611
- mirrors:
  - virthost.ostest.test.metalkube.org:5000/localimages/local-release-image 
 source: registry.ci.openshift.org/ocp/release

The mirror registries should be extracted from the log files when the 'oc adm release mirror' or 'oc mirror' commands are run. This will be correct for all images and is easier to maintain.

For the ZTP manifests an extra conversion is needed to put it in the expected format for registries.conf.