### PR TITLE
fix agent builds when local mirror is used

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -449,13 +449,13 @@ if [[ -n "$MIRROR_IMAGES" || -z "${IP_STACK:-}" || "$IP_STACK" = "v6" ]]; then
    # We're going to be using a locally modified release image
    if [[ ! -z ${AGENT_E2E_TEST_SCENARIO} ]]; then
         # For the agent installer version check, a valid tag must be supplied (not 'latest').
-	if [[ ${#OPENSHIFT_RELEASE_TAG} = 64 ]] && [[ ${OPENSHIFT_RELEASE_TAG} =~ [:alnum:] ]]; then
-	    # If the tag is a digest, don't change the override from OPENSHIFT_RELEASE_IMAGE
-	    # Since mirror-by-digest-only = true on the bootstrap
-	    echo "Not changing OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE since digest is being used"
-	else
-            export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/${LOCAL_IMAGE_URL_SUFFIX}:${OPENSHIFT_RELEASE_TAG}"
-	fi
+       if [[ ${#OPENSHIFT_RELEASE_TAG} = 64 ]] && [[ ${OPENSHIFT_RELEASE_TAG} =~ [:alnum:] ]]; then
+         # If the tag is a digest, let's keep the override as OPENSHIFT_RELEASE_IMAGE
+         # Since mirror-by-digest-only = true on the bootstrap 
+           export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="${OPENSHIFT_RELEASE_IMAGE}"
+       else
+           export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/${LOCAL_IMAGE_URL_SUFFIX}:${OPENSHIFT_RELEASE_TAG}"
+       fi
    else
        # 04_setup_ironic requires tag to be 'latest'
        export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/${LOCAL_IMAGE_URL_SUFFIX}:latest"


### PR DESCRIPTION
Keep OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE as OPENSHIFT_RELEASE_IMAGE when the release tag is a digest (usually this happens in the CI), since it's used in different parts of the workflow (ie when generating the ztp manifests)