### PR TITLE
AGENT-350: Gather agent data with 'make agent_gather'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,9 @@ agent_create_cluster:
 agent_cleanup:
 	./agent/cleanup.sh
 
+agent_gather:
+	./agent/gather.sh
+
 agent_tests:
 	./agent/agent_tests.sh
 

--- a/agent/04_agent_configure.sh
+++ b/agent/04_agent_configure.sh
@@ -268,6 +268,7 @@ else
     ip=${AGENT_NODES_IPSV6[0]}
   fi
   configure_dnsmasq ${ip} ""
+  echo "${ip}" >> ${OCP_DIR}/node0-ip
 fi
 
 generate_cluster_manifests

--- a/agent/04_agent_configure.sh
+++ b/agent/04_agent_configure.sh
@@ -268,7 +268,7 @@ else
     ip=${AGENT_NODES_IPSV6[0]}
   fi
   configure_dnsmasq ${ip} ""
-  echo "${ip}" >> ${OCP_DIR}/node0-ip
+  echo "${ip}" > ${OCP_DIR}/node0-ip
 fi
 
 generate_cluster_manifests

--- a/agent/gather.sh
+++ b/agent/gather.sh
@@ -5,21 +5,15 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
 source $SCRIPTDIR/agent/04_agent_configure.sh
 
-get_static_ips_and_macs
-
-if [[ "$IP_STACK" = "v4" ]]; then
-    ip=${AGENT_NODES_IPS[0]}
-  else
-    ip=${AGENT_NODES_IPSV6[0]}
-  fi
+ip=$(head -n 1 ${OCP_DIR}/node0-ip)
 
 ssh -o 'ConnectTimeout=30' -o 'StrictHostKeyChecking=no' -o 'UserKnownHostsFile=/dev/null' core@${ip} << EOF
 # check is agent-gather command is present
 if ! command -v /usr/local/bin/agent-gather &> /dev/null
 then
-    echo "/usr/local/bin/agent-gather could not be found."
-    exit
+    echo "Skipping gathering agent logs, agent-gather script not present."
+    exit 0
 fi
 
-sudo /usr/local/bin/agent-gather -O | tar -xJvf -
+sudo /usr/local/bin/agent-gather
 EOF

--- a/agent/gather.sh
+++ b/agent/gather.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
+# shellcheck source=/dev/null
 set -euxo pipefail
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
-source $SCRIPTDIR/agent/04_agent_configure.sh
+source "$SCRIPTDIR"/agent/04_agent_configure.sh
 
-ip=$(<${OCP_DIR}/node0-ip)
+ip=$(<"${OCP_DIR}"/node0-ip)
 
-ssh -o 'ConnectTimeout=30' -o 'StrictHostKeyChecking=no' -o 'UserKnownHostsFile=/dev/null' core@${ip} if ! command -v /usr/local/bin/agent-gather '>&' /dev/null ';' then echo "Skipping gathering agent logs, agent-gather script not present." else sudo /usr/local/bin/agent-gather -o ';' fi >agent-gather.tar.xz
+ssh -o 'ConnectTimeout=30' -o 'StrictHostKeyChecking=no' -o 'UserKnownHostsFile=/dev/null' core@"${ip}" if ! command -v /usr/local/bin/agent-gather '>&' /dev/null ';' then echo "Skipping gathering agent logs, agent-gather script not present." else sudo /usr/local/bin/agent-gather -o ';' fi >agent-gather.tar.xz

--- a/agent/gather.sh
+++ b/agent/gather.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+
+source $SCRIPTDIR/agent/04_agent_configure.sh
+
+get_static_ips_and_macs
+
+if [[ "$IP_STACK" = "v4" ]]; then
+    ip=${AGENT_NODES_IPS[0]}
+  else
+    ip=${AGENT_NODES_IPSV6[0]}
+  fi
+
+ssh -o 'ConnectTimeout=30' -o 'StrictHostKeyChecking=no' -o 'UserKnownHostsFile=/dev/null' core@${ip} << EOF
+# check is agent-gather command is present
+if ! command -v /usr/local/bin/agent-gather &> /dev/null
+then
+    echo "/usr/local/bin/agent-gather could not be found."
+    exit
+fi
+
+sudo /usr/local/bin/agent-gather -O | tar -xJvf -
+EOF

--- a/agent/gather.sh
+++ b/agent/gather.sh
@@ -4,7 +4,7 @@ set -euxo pipefail
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
-source "$SCRIPTDIR"/agent/04_agent_configure.sh
+source "$SCRIPTDIR"/common.sh
 
 ip=$(<"${OCP_DIR}"/node0-ip)
 

--- a/agent/gather.sh
+++ b/agent/gather.sh
@@ -8,4 +8,11 @@ source "$SCRIPTDIR"/agent/04_agent_configure.sh
 
 ip=$(<"${OCP_DIR}"/node0-ip)
 
-ssh -o 'ConnectTimeout=30' -o 'StrictHostKeyChecking=no' -o 'UserKnownHostsFile=/dev/null' core@"${ip}" if ! command -v /usr/local/bin/agent-gather '>&' /dev/null ';' then echo "Skipping gathering agent logs, agent-gather script not present." else sudo /usr/local/bin/agent-gather -o ';' fi >agent-gather.tar.xz
+if ssh -o 'ConnectTimeout=30' -o 'StrictHostKeyChecking=no' -o 'UserKnownHostsFile=/dev/null' core@"${ip}" agent-gather -O >agent-gather.tar.xz; then
+    echo "Agent logs saved to agent-gather.tar.xz" >&2
+else
+    if [ $? == 127 ]; then
+        echo "Skipping gathering agent logs, agent-gather script not present." >&2
+    fi
+    rm agent-gather.tar.xz
+fi

--- a/agent/gather.sh
+++ b/agent/gather.sh
@@ -5,15 +5,6 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
 source $SCRIPTDIR/agent/04_agent_configure.sh
 
-ip=$(head -n 1 ${OCP_DIR}/node0-ip)
+ip=$(<${OCP_DIR}/node0-ip)
 
-ssh -o 'ConnectTimeout=30' -o 'StrictHostKeyChecking=no' -o 'UserKnownHostsFile=/dev/null' core@${ip} << EOF
-# check is agent-gather command is present
-if ! command -v /usr/local/bin/agent-gather &> /dev/null
-then
-    echo "Skipping gathering agent logs, agent-gather script not present."
-    exit 0
-fi
-
-sudo /usr/local/bin/agent-gather
-EOF
+ssh -o 'ConnectTimeout=30' -o 'StrictHostKeyChecking=no' -o 'UserKnownHostsFile=/dev/null' core@${ip} if ! command -v /usr/local/bin/agent-gather '>&' /dev/null ';' then echo "Skipping gathering agent logs, agent-gather script not present." else sudo /usr/local/bin/agent-gather -o ';' fi >agent-gather.tar.xz


### PR DESCRIPTION
A new target `make agent_gather` allows the user to gather useful troubleshooting data when things go wrong even before the API services are available.

Signed-off-by: Pawan Pinjarkar [ppinjark@redhat.com](mailto:ppinjark@redhat.com)