### PR TITLE
OCPBUGS-4874: Remove hosts section from platform.baremetal

### DIFF
--- a/agent/roles/manifests/templates/install-config_yaml.j2
+++ b/agent/roles/manifests/templates/install-config_yaml.j2
@@ -60,11 +60,6 @@ platform:
 {% for ingress_vip in i_vips %}
       - {{ ingress_vip }}
 {% endfor %}
-    hosts:
-{% for mac in macs %}
-      - name: {{ hostnames[loop.index0] }}
-        bootMACAddress: {{ mac }}
-{% endfor %}
 {% endif %}
 pullSecret: {{ pull_secret_contents }}
 sshKey: {{ ssh_pub_key }} 


### PR DESCRIPTION
We shouldn't require users to set the host details in the install-config, given that they are not used for anything. A previous bug where we did require them was fixed as [OCPBUGS-3278](https://issues.redhat.com/browse/OCPBUGS-3278). Remove this section from the install-config template so that we cannot regress it.