### PR TITLE
Use SCSI as cdrombus when the provisioner node architecture is aarch64

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -94,8 +94,8 @@ configure_chronyd
 export VNC_CONSOLE=true
 if [[ $(uname -m) == "aarch64" ]]; then
   VNC_CONSOLE=false
+  echo "libvirt_cdrombus: scsi" >> vm_setup_vars.yml
 fi
-
 
 ansible-playbook \
     -e @vm_setup_vars.yml \


### PR DESCRIPTION
openshift-metal3/dev-scripts#1483 bumped the version of metal3-dev-env to a commit including the changes in metal3-io/metal3-dev-env#1022. However, SATA is unavailable as a disk/cdrom bus for arm64 hypervisors, and #1483 broke the CI for arm64.




```
"msg": "libvirtError: unsupported configuration: SATA is not supported with this QEMU binary"
```

Failures in CI:
 - https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-multiarch-master-nightly-4.11-ocp-e2e-metal-ipi-ovn-arm64/1602625608012009472
 - https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/qe-private-deck/logs/periodic-ci-openshift-openshift-tests-private-release-4.13-arm64-nightly-baremetalds-ipi-ovn-ipv4-p1-f4/1603156946309877760



The fix is also being tested in the legacy QE CI at: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Flexy-install/164775/console



To avoid defining a default libvirt_cdrombus value in dev-scripts for amd64, this commit also appends the cdrombus to use for arm64 in the vm_setup_vars.yml file, letting the amd64 hosts continue using the default defined by the upstream metal3-dev-env at https://github.com/metal3-io/metal3-dev-env/blob/1eabf22137b37bb12e13b97108eb71df15776080/vm-setup/roles/libvirt/defaults/main.yml#L16.



Closes OCPQE-13237

cc @deepsm007 @jeffdyoung @elfosardo @jadhaj