### PR TITLE
OCPBUGS-4977: Revert "Use ansible 6"

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -19,13 +19,13 @@ if [ -z "${METAL3_DEV_ENV}" ]; then
   # TODO -- come up with a plan for continuously updating this
   # Note we only do this in the case where METAL3_DEV_ENV is
   # unset, to enable developer testing of local checkouts
-  git reset e92b3f87c2747462bbc84b835a4cbab351726b92 --hard
+  git reset 6a8fb0d5543970b5d628e1204a3b3d3f9f70a63f --hard
   popd
 fi
 
 # This must be aligned with the metal3-dev-env pinned version above, see
 # https://github.com/metal3-io/metal3-dev-env/blob/master/lib/common.sh
-export ANSIBLE_VERSION=${ANSIBLE_VERSION:-"6.6.0"}
+export ANSIBLE_VERSION=${ANSIBLE_VERSION:-"5.9.0"}
 
 # Update to latest packages first
 sudo dnf -y upgrade


### PR DESCRIPTION
Reverts openshift-metal3/dev-scripts#1483

The change brought in https://github.com/metal3-io/metal3-dev-env/pull/1059/commits/b8a223c452d5133984796cb314213fccc5397eae that adds redfish-virtualmedia to the bmc drivers tested in CI, breaking the dualstack jobs