### PR TITLE
AGENT-499: Fixes for auth when using quay registry

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -69,7 +69,7 @@ fi
 
 export ANSIBLE_FORCE_COLOR=true
 
-if use_podman_registry; then
+if use_registry ""; then
     setup_local_registry
 fi
 
@@ -280,15 +280,15 @@ fi
 sudo sed -i "/${LOCAL_REGISTRY_DNS_NAME}/d" /etc/hosts
 echo "${PROVISIONING_HOST_EXTERNAL_IP} ${LOCAL_REGISTRY_DNS_NAME}" | sudo tee -a /etc/hosts
 
-# Remove any previous file, or podman login panics when reading the
-# blank authfile with a "assignment to entry in nil map" error
-rm -f ${REGISTRY_CREDS}
-if use_podman_registry; then
+if use_registry "podman"; then
+    # Remove any previous file, or podman login panics when reading the
+    # blank authfile with a "assignment to entry in nil map" error
+    rm -f ${REGISTRY_CREDS}
     # create authfile for local registry
     sudo podman login --authfile ${REGISTRY_CREDS} \
         -u ${REGISTRY_USER} -p ${REGISTRY_PASS} \
         ${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}
-else
+elif ! use_registry "quay"; then
     # Create a blank authfile in order to have something valid when we read it in 04_setup_ironic.sh
     echo '{}' | sudo dd of=${REGISTRY_CREDS}
 fi

--- a/oc_mirror.sh
+++ b/oc_mirror.sh
@@ -10,9 +10,6 @@ function add_auth_to_pull_secret() {
 
    tmpauthfile=$(mktemp --tmpdir "quayauth--XXXXXXXXXX")
    _tmpfiles="$_tmpfiles $tmpauthfile"
-   tmppullsecret=$(mktemp --tmpdir "pullsecret--XXXXXXXXXX")
-   _tmpfiles="$_tmpfiles $tmppullsecret"
-
 
    cat > "${tmpauthfile}" << EOF
 {
@@ -24,9 +21,7 @@ function add_auth_to_pull_secret() {
 }
 EOF
 
-   jq -s '.[0] * .[1]' ${tmpauthfile} ${PULL_SECRET_FILE} > ${tmppullsecret}
-   cp ${tmppullsecret} ${PULL_SECRET_FILE}
-
+   cp ${tmpauthfile} ${REGISTRY_CREDS}
 }
 
 function update_docker_config() {

--- a/utils.sh
+++ b/utils.sh
@@ -674,10 +674,11 @@ function auth_template_and_removetmp(){
     removetmp
 }
 
-use_podman_registry() {
-  # return true if using the local registry and the backend is podman
+use_registry() {
+  check_registry=$1
+  # return true if using the local registry and the backend is quay
   if [[ ! -z "${MIRROR_IMAGES}" || $(env | grep "_LOCAL_IMAGE=")  || ! -z "${ENABLE_CBO_TEST:-}" || ! -z "${ENABLE_LOCAL_REGISTRY}" ]]; then
-     if [[ "${REGISTRY_BACKEND}" = "podman" ]]; then
+     if [[ ${check_registry} == "" ]] || [[ ${check_registry} == "${REGISTRY_BACKEND}" ]]; then
         return 0
      fi
   fi


### PR DESCRIPTION
This is a follow-up to https://github.com/openshift-metal3/dev-scripts/pull/1472 to get the auth set up properly when using the quay registry backend.