### PR TITLE
AGENT-500: Add configurable step to oc-mirror to generate tarfile

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -77,6 +77,9 @@ export MIRROR_IMAGES=${MIRROR_IMAGES:-}
 # identify the command used to mirror images, either 'oc-adm' or 'oc-mirror'
 export MIRROR_COMMAND=${MIRROR_COMMAND:-oc-adm}
 
+# mirror images for installation in restricted network
+export OC_MIRROR_TO_FILE=${OC_MIRROR_TO_FILE:-}
+
 # file containing auths for oc-mirror
 export DOCKER_CONFIG_FILE=${DOCKER_CONFIG_FILE:-$HOME/.docker/config.json}
 

--- a/config_example.sh
+++ b/config_example.sh
@@ -567,6 +567,12 @@ set -x
 # Default: oc-adm
 #export MIRROR_COMMAND=oc-adm
 
+# OC_MIRROR_TO_FILE -
+# When MIRROR_IMAGES is true and MIRROR_COMMAND is oc-mirror, it this is set it
+# cause the mirror to be generated in a 2-step process - first the contents of
+# the mirror is stored in a tarfile and then the tarfile is published to the registry
+# Default is unset
+
 # When the MIRROR_COMMAND is set to 'oc-mirror' the auths for the mirror will be added
 # to DOCKER_CONFIG_FILE or an UNAUTHORIZED error will result.
 # An example entry in this file is:

--- a/config_example.sh
+++ b/config_example.sh
@@ -568,8 +568,8 @@ set -x
 #export MIRROR_COMMAND=oc-adm
 
 # OC_MIRROR_TO_FILE -
-# When MIRROR_IMAGES is true and MIRROR_COMMAND is oc-mirror, it this is set it
-# cause the mirror to be generated in a 2-step process - first the contents of
+# When MIRROR_IMAGES is true and MIRROR_COMMAND is oc-mirror, if this is set it
+# will cause the mirror to be generated in a 2-step process. First the contents of
 # the mirror is stored in a tarfile and then the tarfile is published to the registry
 # Default is unset
 

--- a/oc_mirror.sh
+++ b/oc_mirror.sh
@@ -84,10 +84,12 @@ function set_full_imageset() {
    # Create imageset with all images from releaseImage
    imageset=$1
 
+   latest_release=$(oc-mirror list releases --channel candidate-${OPENSHIFT_RELEASE_STREAM}| tail -n1)
+
    cat > "${imageset}" << EOF
 apiVersion: mirror.openshift.io/v1alpha2
 kind: ImageSetConfiguration
-archiveSize: 24
+archiveSize: 16
 storageConfig:
   local:
     path: metadata
@@ -97,6 +99,8 @@ mirror:
       - "amd64"
     channels:
       - name: candidate-${OPENSHIFT_RELEASE_STREAM}
+        minVersion: $latest_release
+        maxVersion: $latest_release
         type: ocp
   additionalImages:
   - name: registry.redhat.io/ubi8/ubi:latest

--- a/oc_mirror.sh
+++ b/oc_mirror.sh
@@ -49,11 +49,8 @@ function setup_quay_mirror_registry() {
    popd
 }
 
-# Set up a mirror using the 'oc mirror' command
-# The backend registry can be either 'podman' or 'quay'
-function setup_oc_mirror() {
-
-   update_docker_config
+# Mirror the upstream channel directly to the local registry
+function mirror_to_mirror_publish() {
 
    # Create imageset containing the local URL and the OCP release to mirror
    tmpimageset=$(mktemp --tmpdir "imageset--XXXXXXXXXX")
@@ -80,4 +77,116 @@ EOF
    oc mirror --dest-skip-tls --config ${tmpimageset} docker://${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}
    popd
 
+}
+
+function set_bootstrap_imageset() {
+
+   # Create imageset only with images needed for bootstrap
+   imageset=$1
+
+   mapfile -t release_images < <( oc adm release info quay.io/openshift-release-dev/ocp-release:${OPENSHIFT_RELEASE_TAG} -o json | jq -r '.references.spec.tags[] | .name + " " + .from.name' )
+
+cat > "${imageset}" << EOF
+kind: ImageSetConfiguration
+apiVersion: mirror.openshift.io/v1alpha2
+archiveSize: 2
+storageConfig:
+  local:
+    path: metadata
+mirror:
+  platform:
+    architectures:
+      - "amd64"
+    channels:
+      - name: candidate-${OPENSHIFT_RELEASE_STREAM}
+        type: ocp
+  additionalImages:
+    - name: registry.redhat.io/ubi8/ubi:latest
+  blockedImages:
+EOF
+
+for image_info in "${release_images[@]}"; do
+        read -r image_name image_ref <<< $image_info
+        case "$image_name" in agent-installer-api-server | must-gather | hyperkube | cloud-credential-operator | cluster-policy-controller | agent-installer-orchestrator | pod | cluster-config-operator | cluster-etcd-operator | cluster-kube-controller-manager-operator | cluster-kube-scheduler-operator | agent-installer-node-agent | machine-config-operator | etcd | cluster-bootstrap | cluster-ingress-operator | cluster-kube-apiserver-operator | baremetal-installer | keepalived-ipfailover | baremetal-runtimecfg | coredns)
+                        >&2 echo "Not blocking $image_name";;
+                *)
+                        >&2 echo "Blocking $image_name"
+                        cat >> "${imageset}" <<EOF
+    - name: "$image_ref"
+EOF
+                        ;;
+        esac
+done
+
+}
+
+function set_full_imageset() {
+
+   # Create imageset with all images from releaseImage
+   imageset=$1
+
+   cat > "${imageset}" << EOF
+apiVersion: mirror.openshift.io/v1alpha2
+kind: ImageSetConfiguration
+archiveSize: 16
+storageConfig:
+  local:
+    path: metadata
+mirror:
+  platform:
+    architectures:
+      - "amd64"
+    channels:
+      - name: candidate-${OPENSHIFT_RELEASE_STREAM}
+        type: ocp
+  additionalImages:
+  - name: registry.redhat.io/ubi8/ubi:latest
+EOF
+
+}
+
+# Use the oc-mirror command to generate a tar file of the release image
+function mirror_to_file() {
+
+   config=${1}
+
+   pushd ${WORKING_DIR}
+   oc_mirror_dir=$(mktemp --tmpdir -d "oc-mirror-files--XXXXXXXXXX")
+   _tmpfiles="$_tmpfiles $oc_mirror_dir"
+   oc-mirror --config ${config} file://${oc_mirror_dir} --ignore-history
+   archive_file="$(ls ${oc_mirror_dir}/mirror_seq*)"
+   popd
+
+}
+
+function publish_image() {
+
+   pushd ${WORKING_DIR}
+   oc-mirror --from $archive_file docker://${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT} --skip-metadata-check
+   popd
+
+}
+
+# function publish_bootstrap_image() {
+#
+# }
+
+# Set up a mirror using the 'oc mirror' command
+# The backend registry can be either 'podman' or 'quay'
+function setup_oc_mirror() {
+
+   update_docker_config
+
+   if [ -z "${OC_MIRROR_TO_FILE}" ]; then
+       mirror_to_mirror_publish
+   else
+       tmpimageset=$(mktemp --tmpdir "imageset--XXXXXXXXXX")
+       _tmpfiles="$_tmpfiles $tmpimageset"
+
+       set_full_imageset $tmpimageset
+
+       mirror_to_file $tmpimageset
+
+       publish_image
+   fi
 }


### PR DESCRIPTION
Add the ability to use oc-mirror to create a mirror registry by generating a tarfile first and then publishing the tarfile to the registry. The can be used to test a common use case for disconnected installs.