### PR TITLE
Move registry cleanup back to realclean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ ocp_run:
 gather:
 	./must_gather.sh
 
-clean: ocp_cleanup ironic_cleanup proxy_cleanup host_cleanup assisted_deployment_cleanup agent_cleanup registry_cleanup oc_mirror_cleanup
+clean: ocp_cleanup ironic_cleanup proxy_cleanup host_cleanup assisted_deployment_cleanup agent_cleanup oc_mirror_cleanup
 
 assisted_deployment_cleanup:
 	./assisted_deployment.sh delete_all
@@ -70,7 +70,7 @@ ironic_cleanup:
 host_cleanup:
 	./host_cleanup.sh
 
-realclean: clean cache_cleanup workingdir_cleanup podman_cleanup
+realclean: clean cache_cleanup workingdir_cleanup podman_cleanup registry_cleanup
 
 cache_cleanup:
 	./cache_cleanup.sh


### PR DESCRIPTION
Removing the registry in regular clean does bad things to the developer workflow because while iterating on changes the entire release has to be re-mirrored each time. Those who want to wipe their entire environment between runs have the realclean option available.