### PR TITLE
agent: optionally disable automation services

### DIFF
--- a/agent/06_agent_create_cluster.sh
+++ b/agent/06_agent_create_cluster.sh
@@ -72,6 +72,21 @@ function force_mirror_disconnect() {
 
 }
 
+function disable_automated_installation() {
+  local agent_iso_abs_path="$(realpath "${OCP_DIR}/agent.$(uname -p).iso")"
+  local ign_temp_path="$(mktemp --directory)"
+  _tmpfiles="$_tmpfiles $ign_temp_path"
+  echo "Extracting ISO ignition..."
+  podman run --privileged --rm -v /run/udev:/run/udev -v "${agent_iso_abs_path}:/data/agent.iso" -w /data  quay.io/coreos/coreos-installer:release iso ignition show agent.iso > "${ign_temp_path}/iso.ign"
+
+  echo "disabling automated installation systemd services..."
+  jq --compact-output --argjson filterlist '["apply-host-config.service", "create-cluster-and-infraenv.service", "install-status.service", "set-hostname.service", "start-cluster-installation.service"]' \
+    'walk( . as $i | if type == "object" and has("enabled") and any($filterlist[]; . == $i.name) then .enabled = false else . end)' < "${ign_temp_path}/iso.ign" > "${ign_temp_path}/disabled_automation.ign"
+
+  echo "Embedding merged ignition..."
+  podman run --privileged --rm -v /run/udev:/run/udev -v "${agent_iso_abs_path}:/data/agent.iso" -v "${ign_temp_path}/disabled_automation.ign:/data/disabled_automation.ign" -w /data  quay.io/coreos/coreos-installer:release iso ignition embed -f -i disabled_automation.ign agent.iso
+}
+
 function enable_assisted_service_ui() {
   if [[ "${IP_STACK}" = "v6" ]]; then
        echo "In a disconnected environment the assisted-installer GUI cannot be enabled"
@@ -148,6 +163,9 @@ function mce_complete_deployment() {
 }
 
 create_image
+if [[ "${AGENT_DISABLE_AUTOMATED:-}" == "true" ]]; then
+  disable_automated_installation
+fi
 
 attach_agent_iso master $NUM_MASTERS
 attach_agent_iso worker $NUM_WORKERS

--- a/config_example.sh
+++ b/config_example.sh
@@ -671,3 +671,8 @@ set -x
 # Set the following value to true to supply ZTP manifests to the installer. By default the install-config.yaml/agent-config.yaml
 # will be used as input to the installer.
 # export AGENT_USE_ZTP_MANIFESTS=false
+
+# Uncomment and set the following value to "true" to disable the automated
+# deployment systemd services of the Agent based installation. This is
+# particularly useful for WebUI development.
+# export AGENT_DISABLE_AUTOMATED=false


### PR DESCRIPTION
When developing the WebUI for the agent based installation, it is useful to disable the services that automatically grab the manifests in the ISO and create and start the installation by talking to the REST API. This PR adds a new setting named AGENT_DISABLED_AUTOMATED that when set to true will prevent those services from running.

Signed-off-by: Antoni Segura Puimedon <antoni@redhat.com>