### PR TITLE
Bump go_version to 1.19.4

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -105,7 +105,7 @@ ansible-galaxy collection install --upgrade ansible.netcommon ansible.posix ansi
 ANSIBLE_FORCE_COLOR=true ansible-playbook \
   -e "working_dir=$WORKING_DIR" \
   -e "virthost=$HOSTNAME" \
-  -e "go_version=1.18.3" \
+  -e "go_version=1.19.4" \
   -e "GOARCH=$GOARCH" \
   $ALMA_PYTHON_OVERRIDE \
   -i vm-setup/inventory.ini \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift-metal3/dev-scripts/metal3-templater
 
-go 1.17
+go 1.19
 
 require (
 	github.com/apparentlymart/go-cidr v1.1.0


### PR DESCRIPTION
updated golang version to match build containers
```sh
podman run registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.19-openshift-4.13 go version
go version go1.19.4 linux/amd64
```
Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>