### PR TITLE
AGENT-509: Warn if podman registry in use when configured for quay

### DIFF
--- a/oc_mirror.sh
+++ b/oc_mirror.sh
@@ -34,6 +34,11 @@ function update_docker_config() {
 
 function setup_quay_mirror_registry() {
 
+   if sudo podman container exists registry; then
+     echo "The podman registry is currently running and will cause a conflict with quay registry. Run \"registry_cleanup.sh\" to remove podman registry."
+     exit 1
+   fi
+
    mkdir -p ${WORKING_DIR}/quay-install
    pushd ${WORKING_DIR}/mirror-registry
    sudo ./mirror-registry install --quayHostname ${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT} --quayRoot ${WORKING_DIR}/quay-install/ --initUser ${REGISTRY_USER} --initPassword ${REGISTRY_PASS} --sslCheckSkip -v


### PR DESCRIPTION
If the quay registry backend is configured but the podman registry is still set up, the "mirror-registry" command will fail and it will be difficult to debug. Exit the command with instructions of how to remove the podman registry.