### PR TITLE
Fix unbound variable in agent/common.sh

### DIFF
--- a/agent/common.sh
+++ b/agent/common.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
+source network.sh
+
 export AGENT_STATIC_IP_NODE0_ONLY=${AGENT_STATIC_IP_NODE0_ONLY:-"false"}
 
 export AGENT_USE_ZTP_MANIFESTS=${AGENT_USE_ZTP_MANIFESTS:-"false"}


### PR DESCRIPTION
We need to source network.sh before referencing IP_STACK or it may be unset in the default case.