### PR TITLE
OPNET-200: Add support for ipv6-primary dual stack

### DIFF
--- a/config_example.sh
+++ b/config_example.sh
@@ -193,9 +193,10 @@ set -x
 # single-stack cluster on dual-stack hosts.
 
 # IP_STACK -
-# IP stack for the cluster.
+# IP stack for the cluster. "v4v6" is ipv4-primary dual stack, "v6v4" is
+# ipv6-primary dual stack.
 # Default: "v6"
-# Choices: "v4", "v6", "v4v6"
+# Choices: "v4", "v6", "v4v6", "v6v4"
 #
 #export IP_STACK=v4
 

--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -100,10 +100,9 @@ EOF
   fi
 
   if [ -n "${ENABLE_BOOTSTRAP_STATIC_IP}" ]; then
-    if [[ "${IP_STACK}" = "v6" ]]; then
+    if [[ "${IP_STACK}" = "v6" || "${IP_STACK}" = "v6v4" ]]; then
       BOOTSTRAP_IP=$(nth_ip $EXTERNAL_SUBNET_V6 $((idx + 9)))
     else
-      # Note we assume v4 for dual-stack v4v6 since it's the primary network
       BOOTSTRAP_IP=$(nth_ip $EXTERNAL_SUBNET_V4 $((idx + 9)))
     fi
 cat <<EOF
@@ -224,6 +223,20 @@ cat <<EOF
   serviceNetwork:
   - ${SERVICE_SUBNET_V4}
   - ${SERVICE_SUBNET_V6}
+EOF
+  elif [[ "${IP_STACK}" == "v6v4" ]]; then
+cat <<EOF
+  machineNetwork:
+  - cidr: ${EXTERNAL_SUBNET_V6}
+  - cidr: ${EXTERNAL_SUBNET_V4}
+  clusterNetwork:
+  - cidr: ${CLUSTER_SUBNET_V6}
+    hostPrefix: ${CLUSTER_HOST_PREFIX_V6}
+  - cidr: ${CLUSTER_SUBNET_V4}
+    hostPrefix: ${CLUSTER_HOST_PREFIX_V4}
+  serviceNetwork:
+  - ${SERVICE_SUBNET_V6}
+  - ${SERVICE_SUBNET_V4}
 EOF
   else
     echo "Unexpected IP_STACK value: '${IP_STACK}'"


### PR DESCRIPTION
Adds a new value "v6v4" for IP_STACK to allow deployment of clusters with ipv6 as the primary address family.