### PR TITLE
remove restart network service step

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -221,7 +221,6 @@ if [ "$MANAGE_INT_BRIDGE" == "y" ]; then
               grep -q BOOTPROTO /etc/sysconfig/network-scripts/ifcfg-${BAREMETAL_NETWORK_NAME} || (echo -e "\nBOOTPROTO=dhcp\n" | sudo tee -a /etc/sysconfig/network-scripts/ifcfg-${BAREMETAL_NETWORK_NAME})
           fi
       fi
-      sudo systemctl restart $NET_SERVICE
     fi
 fi
 


### PR DESCRIPTION
seems no need restart network service when INT_IF is specified and ipv6 enabled .  After remove this line.  I can deploy ipv6 dual stack with specified INT_IF