### PR TITLE
Update dev-script CI image

### DIFF
--- a/images/Dockerfile.ci
+++ b/images/Dockerfile.ci
@@ -1,9 +1,13 @@
 # This Dockerfile builds the image used by the e2e-metal-ipi test steps in the OpenShift CI.
 # For more details about the test see https://steps.svc.ci.openshift.org/job/openshift-baremetal-operator-master-e2e-metal-ipi
 
-FROM registry.ci.openshift.org/openshift/release:golang-1.14
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.19-openshift-4.13
+
 ENV HOME /output
-RUN INSTALL_PKGS="ansible python-pip nss_wrapper" && \
+
+# For RHEL7
+RUN if [ ! -e /usr/bin/dnf ]; then \
+    INSTALL_PKGS="ansible python-pip nss_wrapper" && \
     yum install -y $INSTALL_PKGS && \
     pip install packet-python && \
     ansible-galaxy collection install "community.general:4.8.1" && \
@@ -13,4 +17,16 @@ RUN INSTALL_PKGS="ansible python-pip nss_wrapper" && \
 # TODO: Remove once OpenShift CI will be upgraded to 4.2 (see https://access.redhat.com/articles/4859371)
     chmod g+w /etc/passwd && \
     echo 'echo default:x:$(id -u):$(id -g):Default Application User:/output:/sbin/nologin\ >> /etc/passwd' > /output/fix_uid.sh && \
-    chmod g+rwx /output/fix_uid.sh
+    chmod g+rwx /output/fix_uid.sh ; \
+    fi
+
+# For RHEL8
+RUN if [ -e /usr/bin/dnf ]; then \
+    INSTALL_PKGS="ansible python3-pip nss_wrapper" && \
+    dnf install --disablerepo=epel -y $INSTALL_PKGS && \
+    pip3 install packet-python && \
+    ansible-galaxy collection install "community.general:4.8.1" && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf/* && \
+    chmod -R g+rwx /output ; \
+    fi


### PR DESCRIPTION
We temporarily need to support both RHEL 7 and 8
as we can't change the ci-operator image build to switch
to rhel a new image in lockstep. Once the switch over is done
we can remove the RHEL7 support.

This should allow use to eventually remove the NSS_WRAPPER_PASSWD
hack in baremetalds-packet-setup-commands.sh