### PR TITLE
Agent-613: Support imageDigestSources for oc adm release mirror

### DIFF
--- a/agent/05_agent_configure.sh
+++ b/agent/05_agent_configure.sh
@@ -176,9 +176,11 @@ function get_mirror_info {
     tmpmirrorinfo=$(mktemp --tmpdir "mirror--XXXXXXXXXX")
     _tmpfiles="$_tmpfiles $tmpmirrorinfo"
     if [[ ${MIRROR_COMMAND} == "oc-adm" ]]; then
-       sed -n '/imageContentSources/,/^ *$/p' ${MIRROR_LOG_FILE} | tail -n+2 > ${tmpmirrorinfo}
+       # Handle both ImageContentSources and ImageDigestSources in the output. In 4.14, `oc adm` was changed to
+       # output ImageDigestSources, while prior to that it was ImageContentSources
+       sed -n -E '/imageContentSources|imageDigestSources/,/^ *$/p' ${MIRROR_LOG_FILE} | tail -n+2 > ${tmpmirrorinfo}
     else
-       results_dir=$(grep ICSP /home/dev-scripts/.oc-mirror.log | grep -o 'oc-mirror[^;]*')
+       results_dir=$(grep ICSP ${WORKING_DIR}/.oc-mirror.log | grep -o 'oc-mirror[^;]*')
        sed -ne '/repository/,/---/p' ${WORKING_DIR}/${results_dir}/imageContentSourcePolicy.yaml > ${tmpmirrorinfo}
        sed -i '/repositoryDigestMirrors/d;/---/d' ${tmpmirrorinfo}
     fi


### PR DESCRIPTION
In 4.14 the `oc adm release mirror` command has been updated to output ImageDigestSources instead of ImageContentSources. Update the agent script to handle both.

See https://github.com/openshift/oc/pull/1341#issuecomment-1498475901 for the slightly different output.

Also there is a minor fix for inadvertent hardcoding of working dir.