### PR TITLE
AGENT-603: Support 'create pxe-files' command for ABI

### DIFF
--- a/agent/06_agent_create_cluster.sh
+++ b/agent/06_agent_create_cluster.sh
@@ -15,14 +15,14 @@ source $SCRIPTDIR/agent/common.sh
 early_deploy_validation
 
 function create_pxe_files() {
-    local asset_dir="${1:-${OCP_DIR}}"
-    local openshift_install="$(realpath "${OCP_DIR}/openshift-install")"
+    local asset_dir=${1}
+    local openshift_install=${2}
     "${openshift_install}" --dir="${asset_dir}" --log-level=debug agent create pxe-files
 }
 
 function create_image() {
-    local asset_dir="${1:-${OCP_DIR}}"
-    local openshift_install="$(realpath "${OCP_DIR}/openshift-install")"
+    local asset_dir=${1}
+    local openshift_install=${2}
     "${openshift_install}" --dir="${asset_dir}" --log-level=debug agent create image
 }
 
@@ -168,11 +168,13 @@ function mce_complete_deployment() {
   mce_prepare_postinstallation_manifests ${mceManifests}
   mce_apply_postinstallation_manifests ${mceManifests}
 }
+asset_dir="${1:-${OCP_DIR}}"
+openshift_install="$(realpath "${OCP_DIR}/openshift-install")"
 
 if [[ "${BOOT_MODE}" == "PXE" ]]; then
-  create_pxe_files
+  create_pxe_files ${asset_dir} ${openshift_install}
 else
-  create_image
+  create_image ${asset_dir} ${openshift_install}
   if [[ "${AGENT_DISABLE_AUTOMATED:-}" == "true" ]]; then
     disable_automated_installation
   fi

--- a/agent/06_agent_create_cluster.sh
+++ b/agent/06_agent_create_cluster.sh
@@ -171,11 +171,11 @@ function mce_complete_deployment() {
 asset_dir="${1:-${OCP_DIR}}"
 openshift_install="$(realpath "${OCP_DIR}/openshift-install")"
 
-if [[ "${BOOT_MODE}" == "PXE" ]]; then
+if [[ "${AGENT_E2E_TEST_BOOT_MODE}" == "PXE" ]]; then
   create_pxe_files ${asset_dir} ${openshift_install}
 fi
 
-if [[ "${BOOT_MODE}" == "ISO" ]]; then
+if [[ "${AGENT_E2E_TEST_BOOT_MODE}" == "ISO" ]]; then
   create_image ${asset_dir} ${openshift_install}
 fi
 

--- a/agent/06_agent_create_cluster.sh
+++ b/agent/06_agent_create_cluster.sh
@@ -169,7 +169,7 @@ function mce_complete_deployment() {
   mce_apply_postinstallation_manifests ${mceManifests}
 }
 
-if [ ! -z "${BOOT_MODE}" ]; then
+if [[ "${BOOT_MODE}" == "PXE" ]]; then
   create_pxe_files
 else
   create_image

--- a/agent/README.md
+++ b/agent/README.md
@@ -6,7 +6,7 @@ using the agent-based installer approach.
 # Quickstart
 
 Use the following configuration in your `config_<user>.sh` to deploy a 
-compact cluster:
+compact cluster which is booted from an ISO:
 
     # Configure ipv4 environment
     export IP_STACK=v4

--- a/common.sh
+++ b/common.sh
@@ -392,9 +392,9 @@ if [[ ! -z ${AGENT_E2E_TEST_SCENARIO} ]]; then
   
   if [[ "$delimiterCount" == "2" ]]; then
     val=${arr[2]}
-    if [[ $val == "DHCP" ]]; then
+    if [[ "${val}" == "DHCP" ]]; then
       export NETWORKING_MODE=$val
-    elif [[ $val == "PXE" ]]; then
+    elif [[ "${val}" == "PXE" ]]; then
       export BOOT_MODE=$val
     else
       invalidAgentValue
@@ -405,10 +405,10 @@ if [[ ! -z ${AGENT_E2E_TEST_SCENARIO} ]]; then
     export NETWORKING_MODE=${arr[2]}
     export BOOT_MODE=${arr[3]}
   fi
-  if [[ $NETWORKING_MODE != "DHCP" && $NETWORKING_MODE != "" ]]; then
+  if [[ "${NETWORKING_MODE}" != "DHCP" && "${NETWORKING_MODE} != "" ]]; then
     invalidAgentValue
   fi
-  if [[ $BOOT_MODE != "PXE" && $BOOT_MODE != "" ]]; then
+  if [[ "${BOOT_MODE}" != "PXE" && "${BOOT_MODE}" != "" ]]; then
     invalidAgentValue
   fi
 

--- a/common.sh
+++ b/common.sh
@@ -376,7 +376,7 @@ function invalidAgentValue() {
 # Agent test scenario
 export AGENT_E2E_TEST_SCENARIO=${AGENT_E2E_TEST_SCENARIO:-}
 export NETWORKING_MODE=${NETWORKING_MODE:-}
-export BOOT_MODE=${BOOT_MODE:-}
+export BOOT_MODE=${BOOT_MODE:-"ISO"}
 
 # Enable MCE deployment
 export AGENT_DEPLOY_MCE=${AGENT_DEPLOY_MCE:-}
@@ -394,7 +394,7 @@ if [[ ! -z ${AGENT_E2E_TEST_SCENARIO} ]]; then
     val=${arr[2]}
     if [[ "${val}" == "DHCP" ]]; then
       export NETWORKING_MODE=$val
-    elif [[ "${val}" == "PXE" ]]; then
+    elif [[ "${val}" == "PXE" || "${val}" == "ISO"]]; then
       export BOOT_MODE=$val
     else
       invalidAgentValue
@@ -408,7 +408,7 @@ if [[ ! -z ${AGENT_E2E_TEST_SCENARIO} ]]; then
   if [[ "${NETWORKING_MODE}" != "DHCP" && "${NETWORKING_MODE}" != "" ]]; then
     invalidAgentValue
   fi
-  if [[ "${BOOT_MODE}" != "PXE" && "${BOOT_MODE}" != "" ]]; then
+  if [[ "${BOOT_MODE}" != "PXE" && "${BOOT_MODE}" != "ISO" ]]; then
     invalidAgentValue
   fi
 

--- a/common.sh
+++ b/common.sh
@@ -376,6 +376,7 @@ function invalidAgentValue() {
 # Agent test scenario
 export AGENT_E2E_TEST_SCENARIO=${AGENT_E2E_TEST_SCENARIO:-}
 export NETWORKING_MODE=${NETWORKING_MODE:-}
+export BOOT_MODE=${BOOT_MODE:-}
 
 # Enable MCE deployment
 export AGENT_DEPLOY_MCE=${AGENT_DEPLOY_MCE:-}
@@ -390,10 +391,25 @@ if [[ ! -z ${AGENT_E2E_TEST_SCENARIO} ]]; then
   export IP_STACK=$(echo ${arr[1]##*IP} | tr V v)
   
   if [[ "$delimiterCount" == "2" ]]; then
-    export NETWORKING_MODE=${arr[2]}
-    if [[ $NETWORKING_MODE != "DHCP" ]]; then
+    val=${arr[2]}
+    if [[ $val == "DHCP" ]]; then
+      export NETWORKING_MODE=$val
+    elif [[ $val == "PXE" ]]; then
+      export BOOT_MODE=$val
+    else
       invalidAgentValue
     fi
+  fi
+
+  if [[ "$delimiterCount" == "3" ]]; then
+    export NETWORKING_MODE=${arr[2]}
+    export BOOT_MODE=${arr[3]}
+  fi
+  if [[ $NETWORKING_MODE != "DHCP" && $NETWORKING_MODE != "" ]]; then
+    invalidAgentValue
+  fi
+  if [[ $BOOT_MODE != "PXE" && $BOOT_MODE != "" ]]; then
+    invalidAgentValue
   fi
 
   case "$SCENARIO" in

--- a/common.sh
+++ b/common.sh
@@ -405,7 +405,7 @@ if [[ ! -z ${AGENT_E2E_TEST_SCENARIO} ]]; then
     export NETWORKING_MODE=${arr[2]}
     export BOOT_MODE=${arr[3]}
   fi
-  if [[ "${NETWORKING_MODE}" != "DHCP" && "${NETWORKING_MODE} != "" ]]; then
+  if [[ "${NETWORKING_MODE}" != "DHCP" && "${NETWORKING_MODE}" != "" ]]; then
     invalidAgentValue
   fi
   if [[ "${BOOT_MODE}" != "PXE" && "${BOOT_MODE}" != "" ]]; then

--- a/common.sh
+++ b/common.sh
@@ -394,7 +394,7 @@ if [[ ! -z ${AGENT_E2E_TEST_SCENARIO} ]]; then
     val=${arr[2]}
     if [[ "${val}" == "DHCP" ]]; then
       export NETWORKING_MODE=$val
-    elif [[ "${val}" == "PXE" || "${val}" == "ISO"]]; then
+    elif [[ "${val}" == "PXE" || "${val}" == "ISO" ]]; then
       export BOOT_MODE=$val
     else
       invalidAgentValue

--- a/common.sh
+++ b/common.sh
@@ -376,7 +376,7 @@ function invalidAgentValue() {
 # Agent test scenario
 export AGENT_E2E_TEST_SCENARIO=${AGENT_E2E_TEST_SCENARIO:-}
 export NETWORKING_MODE=${NETWORKING_MODE:-}
-export BOOT_MODE=${BOOT_MODE:-"ISO"}
+export AGENT_E2E_TEST_BOOT_MODE=${AGENT_E2E_TEST_BOOT_MODE:-"ISO"}
 
 # Enable MCE deployment
 export AGENT_DEPLOY_MCE=${AGENT_DEPLOY_MCE:-}
@@ -391,26 +391,12 @@ if [[ ! -z ${AGENT_E2E_TEST_SCENARIO} ]]; then
   export IP_STACK=$(echo ${arr[1]##*IP} | tr V v)
   
   if [[ "$delimiterCount" == "2" ]]; then
-    val=${arr[2]}
-    if [[ "${val}" == "DHCP" ]]; then
-      export NETWORKING_MODE=$val
-    elif [[ "${val}" == "PXE" || "${val}" == "ISO" ]]; then
-      export BOOT_MODE=$val
-    else
+    export NETWORKING_MODE=${arr[2]}
+    if [[ $NETWORKING_MODE != "DHCP" ]]; then
       invalidAgentValue
     fi
   fi
 
-  if [[ "$delimiterCount" == "3" ]]; then
-    export NETWORKING_MODE=${arr[2]}
-    export BOOT_MODE=${arr[3]}
-  fi
-  if [[ "${NETWORKING_MODE}" != "DHCP" && "${NETWORKING_MODE}" != "" ]]; then
-    invalidAgentValue
-  fi
-  if [[ "${BOOT_MODE}" != "PXE" && "${BOOT_MODE}" != "ISO" ]]; then
-    invalidAgentValue
-  fi
 
   case "$SCENARIO" in
       "COMPACT" )
@@ -455,6 +441,18 @@ if [[ ! -z ${AGENT_E2E_TEST_SCENARIO} ]]; then
   if [[ $IP_STACK != 'v4' ]] && [[ $IP_STACK != 'v6' ]] && [[ $IP_STACK != 'v4v6' ]]; then
     echo "Invalid value $IP_STACK for IP stack, use 'V4', 'V6', or 'V4V6'."
     exit 1
+  fi
+fi
+
+if [[ ! -z ${AGENT_E2E_TEST_BOOT_MODE} ]]; then
+  if [[ $AGENT_E2E_TEST_BOOT_MODE == "PXE" && $IP_STACK != 'v4' ]]; then
+      echo "Invalid value $IP_STACK for IP stack, only use 'V4' when using AGENT_E2E_TEST_BOOT_MODE as $AGENT_E2E_TEST_BOOT_MODE."
+      exit 1
+  fi
+
+  if [[ $AGENT_E2E_TEST_BOOT_MODE != "ISO" && $AGENT_E2E_TEST_BOOT_MODE != "PXE" ]]; then
+      printf "Found invalid value \"$AGENT_E2E_TEST_BOOT_MODE\" for AGENT_E2E_TEST_BOOT_MODE. Supported values: ISO (default), PXE."
+      exit 1
   fi
 fi
 

--- a/config_example.sh
+++ b/config_example.sh
@@ -657,30 +657,18 @@ set -x
 # The boot mode for the agent machines can only be set to ISO or PXE.
 # For backward compatibility of CI jobs, the default boot mode is ISO.
 # The only supported values for AGENT_E2E_TEST_SCENARIO are 
-# - COMPACT_IPV4_ISO
-# - COMPACT_IPV6_ISO
-# - COMPACT_IPV4_PXE
-# - COMPACT_IPV6_PXE
-# - COMPACT_IPV4_DHCP_ISO
-# - COMPACT_IPV6_DHCP_ISO
-# - COMPACT_IPV4_DHCP_PXE
-# - COMPACT_IPV6_DHCP_PXE
-# - HA_IPV4_ISO
-# - HA_IPV6_ISO
-# - HA_IPV4_PXE
-# - HA_IPV6_PXE
-# - HA_IPV4_DHCP_ISO
-# - HA_IPV6 _DHCP_ISO
-# - HA_IPV4_DHCP_PXE
-# - HA_IPV6 _DHCP_PXE
-# - SNO_IPV4_ISO
-# - SNO_IPV6_ISO
-# - SNO_IPV4_PXE
-# - SNO_IPV6_PXE
-# - SNO_IPV4_DHCP_ISO
-# - SNO_IPV6_DHCP_ISO
-# - SNO_IPV4_DHCP_PXE
-# - SNO_IPV6_DHCP_PXE
+# - COMPACT_IPV4
+# - COMPACT_IPV6
+# - COMPACT_IPV4_DHCP
+# - COMPACT_IPV6_DHCP
+# - HA_IPV4
+# - HA_IPV6
+# - HA_IPV4_DHCP
+# - HA_IPV6 _DHCP
+# - SNO_IPV4
+# - SNO_IPV6
+# - SNO_IPV4_DHCP
+# - SNO_IPV6_DHCP
 # When set, the code internally sets other low level details such as disk size, memory, number of masters and workers,
 # cpu and ip stack.
 # This config variable is used only by the agent based installer and is required.
@@ -697,3 +685,9 @@ set -x
 # deployment systemd services of the Agent based installation. This is
 # particularly useful for WebUI development.
 # export AGENT_DISABLE_AUTOMATED=false
+
+# When set, the code internally sets the boot mode for the agents.
+# This config variable is used only by the agent based installer and is optional.
+# The default value for AGENT_E2E_TEST_BOOT_MODE is 'ISO'.
+# When set to 'PXE', the AGENT_E2E_TEST_SCENARIO can only be set to IPV4 scenarios 
+# AGENT_E2E_TEST_BOOT_MODE=PXE

--- a/config_example.sh
+++ b/config_example.sh
@@ -689,5 +689,7 @@ set -x
 # When set, the code internally sets the boot mode for the agents.
 # This config variable is used only by the agent based installer and is optional.
 # The default value for AGENT_E2E_TEST_BOOT_MODE is 'ISO'.
-# When set to 'PXE', the AGENT_E2E_TEST_SCENARIO can only be set to IPV4 scenarios 
+# When set to 'PXE', the AGENT_E2E_TEST_SCENARIO can only be set to IPV4 scenarios.
+# As per https://libvirt.org/formatnetwork.html, the tftp element is not supported for IPv6 addresses, 
+# and can only be specified on a single IPv4 address per network
 # AGENT_E2E_TEST_BOOT_MODE=PXE

--- a/config_example.sh
+++ b/config_example.sh
@@ -654,19 +654,33 @@ set -x
 
 # Set a single config variable AGENT_E2E_TEST_SCENARIO to create a cluster for the different scenarios 
 # i.e. Single Node Openshift(SNO), Highly Available (HA) or Compact cluster.
+# The boot mode for the agent machines can only be set to ISO or PXE.
+# For backward compatibility of CI jobs, the default boot mode is ISO.
 # The only supported values for AGENT_E2E_TEST_SCENARIO are 
-# - COMPACT_IPV4
-# - COMPACT_IPV6
-# - COMPACT_IPV4_DHCP
-# - COMPACT_IPV6_DHCP
-# - HA_IPV4
-# - HA_IPV6
-# - HA_IPV4_DHCP
-# - HA_IPV6 _DHCP
-# - SNO_IPV4
-# - SNO_IPV6
-# - SNO_IPV4_DHCP
-# - SNO_IPV6_DHCP
+# - COMPACT_IPV4_ISO
+# - COMPACT_IPV6_ISO
+# - COMPACT_IPV4_PXE
+# - COMPACT_IPV6_PXE
+# - COMPACT_IPV4_DHCP_ISO
+# - COMPACT_IPV6_DHCP_ISO
+# - COMPACT_IPV4_DHCP_PXE
+# - COMPACT_IPV6_DHCP_PXE
+# - HA_IPV4_ISO
+# - HA_IPV6_ISO
+# - HA_IPV4_PXE
+# - HA_IPV6_PXE
+# - HA_IPV4_DHCP_ISO
+# - HA_IPV6 _DHCP_ISO
+# - HA_IPV4_DHCP_PXE
+# - HA_IPV6 _DHCP_PXE
+# - SNO_IPV4_ISO
+# - SNO_IPV6_ISO
+# - SNO_IPV4_PXE
+# - SNO_IPV6_PXE
+# - SNO_IPV4_DHCP_ISO
+# - SNO_IPV6_DHCP_ISO
+# - SNO_IPV4_DHCP_PXE
+# - SNO_IPV6_DHCP_PXE
 # When set, the code internally sets other low level details such as disk size, memory, number of masters and workers,
 # cpu and ip stack.
 # This config variable is used only by the agent based installer and is required.


### PR DESCRIPTION
Generates pxe assets by running `./openshift-install agent create pxe-files` command. 
Set `AGENT_E2E_TEST_BOOT_MODE` to `PXE` along with `AGENT_E2E_TEST_SCENARIO` to `SNO_IPV4`, for example, to create an SNO cluster to be booted with PXE. The `AGENT_E2E_TEST_BOOT_MODE` can be set as `PXE` or `ISO`. `ISO` is the default boot mode.

To test, set `export INSTALLER_REPO_PR=7102` in config_<user\>.sh