### PR TITLE
metallb: Override external frr image

### DIFF
--- a/metallb/run_e2e.sh
+++ b/metallb/run_e2e.sh
@@ -2,6 +2,7 @@
 
 metallb_dir="$(dirname $(readlink -f $0))"
 source ${metallb_dir}/metallb_common.sh
+source ocp_install_env.sh
 
 export METALLB_REPO=${METALLB_REPO:-https://github.com/metallb/metallb.git}
 METALLB_BRANCH=${METALLB_BRANCH:-"main"}
@@ -52,7 +53,8 @@ pip3 install --user -r ./dev-env/requirements.txt
 export PATH=${PATH}:${HOME}/.local/bin
 export CONTAINER_RUNTIME=podman
 export RUN_FRR_CONTAINER_ON_HOST_NETWORK=true
+version=`openshift_version`
 inv e2etest --kubeconfig=$(readlink -f ../../ocp/ostest/auth/kubeconfig) \
 	--service-pod-port=8080 --system-namespaces="metallb-system" --skip-docker \
 	--ipv4-service-range=192.168.10.0/24 --ipv6-service-range=fc00:f853:0ccd:e799::/124 \
-	--skip="${SKIP}" --use-operator
+	--skip="${SKIP}" --use-operator --external_frr_image=quay.io/openshift/origin-metallb-frr:"$version"


### PR DESCRIPTION
This commit adds the --external_frr_image flag
into metallb `inv e2etest` command, thus
overrides the external containers` frr image.
This is required as we're facing e2e test failures with  FRR's BFD + echo test case, and to prevent
it we want to align the FRR version between
the speakers and the external container.