### PR TITLE
[wip] AGENT-611 Add support for unconfigured ignition

### DIFF
--- a/agent/common.sh
+++ b/agent/common.sh
@@ -27,3 +27,5 @@ function getReleaseImage() {
     fi
     echo ${releaseImage}
 }
+
+export AGENT_USE_APPLIANCE_MODEL=${AGENT_USE_APPLIANCE_MODEL:-"false"}

--- a/config_example.sh
+++ b/config_example.sh
@@ -693,3 +693,9 @@ set -x
 # As per https://libvirt.org/formatnetwork.html, the tftp element is not supported for IPv6 addresses, 
 # and can only be specified on a single IPv4 address per network
 # AGENT_E2E_TEST_BOOT_MODE=PXE
+
+# Uncomment the following line to deploy the cluster using the appliance model
+# The appliance model boots the host using the unconfigured ignition. It then mounts
+# the configuration ISO where its contents are copied over to the host. The cluster
+# installation is triggered when the /etc/assisted/rendezvous-host.env file is present.
+# export AGENT_USE_APPLIANCE_MODEL=false


### PR DESCRIPTION
Introduces AGENT_USE_APPLIANCE_MODEL environment variable. Setting this variable to true will generate an agent ISO containing the unconfigured ignition.

Depends on: https://github.com/openshift/installer/pull/7186