### PR TITLE
AGENT-616: Create unconfigured ignition and config-image and mount to VM

### DIFF
--- a/agent/common.sh
+++ b/agent/common.sh
@@ -7,6 +7,9 @@ export AGENT_STATIC_IP_NODE0_ONLY=${AGENT_STATIC_IP_NODE0_ONLY:-"false"}
 
 export AGENT_USE_ZTP_MANIFESTS=${AGENT_USE_ZTP_MANIFESTS:-"false"}
 
+export AGENT_USE_APPLIANCE_MODEL=${AGENT_USE_APPLIANCE_MODEL:-"false"}
+export AGENT_APPLIANCE_HOTPLUG=${AGENT_APPLIANCE_HOTPLUG:-"false"}
+
 # Override command name in case of extraction
 export OPENSHIFT_INSTALLER_CMD="openshift-install"
 

--- a/config_example.sh
+++ b/config_example.sh
@@ -708,3 +708,15 @@ set -x
 # This test case is only supported when IP_STACK=v4.
 #
 # export AGENT_TEST_CASES='bad_dns'
+
+# Uncomment the following line to deploy the cluster using the appliance model
+# The appliance model boots the host using the unconfigured ignition. It then mounts
+# the configuration ISO where its contents are copied over to the host. The cluster
+# installation is triggered when the /etc/assisted/rendezvous-host.env file is present.
+# export AGENT_USE_APPLIANCE_MODEL=false
+
+# When the installation is done using the agent appliance the config-image can
+# be added either when creating the VM or after the host has booted with the unconfigured
+# ignition. This setting configures when the config-image is added, by default it will be
+# adding when creating the VM.
+# export AGENT_APPLIANCE_HOTPLUG=false


### PR DESCRIPTION
This provides a test for both https://issues.redhat.com/browse/AGENT-558 and https://issues.redhat.com/browse/AGENT-559. It runs the installer commands to create an unconfigured ignition and to create a config-image. It creates an ISO from the unconfigured ignition suitable for booting the VM. It also attaches the config-image to the VM which will be loaded when detected during system boot.

Also adds a new config setting `AGENT_APPLIANCE_HOTPLUG` that when set will configure the hosts using the unconfigured ignition and then pend for user input before creating the config-image and mounting it to the host. This emulates a situation where a user boots the host first before adding the config-image and continuing the installation. 