### PR TITLE
Fix CVO overrides

### DIFF
--- a/start-mao.sh
+++ b/start-mao.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -xe
 
 # Tell the cluster-version-operator to resume managing the machine-api-operator
-oc patch clusterversion version --namespace openshift-cluster-version --type merge -p '{"spec":{"overrides":[{"kind":"Deployment","group":"apps/v1","name":"machine-api-operator","namespace":"openshift-machine-api","unmanaged":false}]}}'
+oc patch clusterversion version --namespace openshift-cluster-version --type merge -p '{"spec":{"overrides":[{"kind":"Deployment","group":"apps","name":"machine-api-operator","namespace":"openshift-machine-api","unmanaged":false}]}}'

--- a/stop-cbo.sh
+++ b/stop-cbo.sh
@@ -16,7 +16,7 @@ fi
 
 # Tell the cluster-version-operator to stop managing the
 # cluster-baremetal-operator and baremetalhost CRD
-oc patch clusterversion version --namespace openshift-cluster-version --type merge -p '{"spec":{"overrides":[{"kind":"Deployment","group":"apps/v1","name":"cluster-baremetal-operator","namespace":"openshift-machine-api","unmanaged":true},{"kind":"CustomResourceDefinition","group":"apiextensions.k8s.io/v1","name":"baremetalhosts.metal3.io","namespace":"","unmanaged":true}]}}'
+oc patch clusterversion version --namespace openshift-cluster-version --type merge -p '{"spec":{"overrides":[{"kind":"Deployment","group":"apps","name":"cluster-baremetal-operator","namespace":"openshift-machine-api","unmanaged":true},{"kind":"CustomResourceDefinition","group":"apiextensions.k8s.io","name":"baremetalhosts.metal3.io","namespace":"","unmanaged":true}]}}'
 
 # Stop any existing machine-api-operator
 oc scale deployment -n openshift-machine-api --replicas=0 cluster-baremetal-operator

--- a/stop-mao.sh
+++ b/stop-mao.sh
@@ -15,7 +15,7 @@ else
 fi
 
 # Tell the cluster-version-operator to stop managing the machine-api-operator
-oc patch clusterversion version --namespace openshift-cluster-version --type merge -p '{"spec":{"overrides":[{"kind":"Deployment","group":"apps/v1","name":"machine-api-operator","namespace":"openshift-machine-api","unmanaged":true}]}}'
+oc patch clusterversion version --namespace openshift-cluster-version --type merge -p '{"spec":{"overrides":[{"kind":"Deployment","group":"apps","name":"machine-api-operator","namespace":"openshift-machine-api","unmanaged":true}]}}'
 
 # Stop any existing machine-api-operator
 oc scale deployment -n openshift-machine-api --replicas=0 machine-api-operator


### PR DESCRIPTION
Prior to OCP 4.10, the 'group' field in the override was ignored.
Although "apps/v1" was the documented thing to pass, after
https://github.com/openshift/cluster-version-operator/pull/689 stopped ignoring the field, only
"apps" works.

My proposed fix for [OCPBUGS-15390](https://issues.redhat.com/browse/OCPBUGS-15390) is to
make both work, so we might as well switch to the one that works with
older releases.