### PR TITLE
Add the api-int name to the additional static hosts for the libvirt/dnsmasq's dns resolution

### DIFF
--- a/vm_setup_vars.yml
+++ b/vm_setup_vars.yml
@@ -40,11 +40,13 @@ dns_dualstackhost:
   - ip: "{{ baremetal_network_cidr_v6 | nthhost(5) }}"
     hostnames:
       - "api"
+      - "api-int"
 
 dns_extrahosts:
   - ip: "{{ baremetal_network_cidr | nthhost(5) }}"
     hostnames:
       - "api"
+      - "api-int"
   - ip: "{{ baremetal_network_cidr | nthhost(2) }}"
     hostnames:
       - "ns1"


### PR DESCRIPTION
api-int.$CLUSTER_NAME should be referred to as the name for reaching the api and the machine-config-server internally by the cluster's hosts. This PR adds the api-int alias for the API VIP for the libvirt's network/dnsmasq configuration of the additional hosts resolution.