### PR TITLE
agent: introduce openshift-appliance flow

### DIFF
--- a/agent/cleanup.sh
+++ b/agent/cleanup.sh
@@ -20,6 +20,11 @@ case "${AGENT_E2E_TEST_BOOT_MODE}" in
     sudo pkill agentpxeserver || true
     rm -rf ${WORKING_DIR}/pxe
     ;;
+  "DISKIMAGE" )
+    sudo rm -rf "${OCP_DIR}/cache"
+    sudo rm -rf "${OCP_DIR}/temp"
+    sudo podman rmi -f ${APPLIANCE_IMAGE} || true
+    ;;
 esac
 
 sudo podman rm -f extlb || true

--- a/agent/common.sh
+++ b/agent/common.sh
@@ -11,6 +11,10 @@ export AGENT_USE_APPLIANCE_MODEL=${AGENT_USE_APPLIANCE_MODEL:-"false"}
 export AGENT_APPLIANCE_HOTPLUG=${AGENT_APPLIANCE_HOTPLUG:-"false"}
 export AGENT_PLATFORM_TYPE=${AGENT_PLATFORM_TYPE:-"baremetal"}
 
+# Image reference for OpenShift-based Appliance Builder.
+# See: https://github.com/openshift/appliance
+export APPLIANCE_IMAGE=${APPLIANCE_IMAGE:-"quay.io/edge-infrastructure/openshift-appliance:latest"}
+
 # Override command name in case of extraction
 export OPENSHIFT_INSTALLER_CMD="openshift-install"
 

--- a/agent/roles/manifests/tasks/appliance.yml
+++ b/agent/roles/manifests/tasks/appliance.yml
@@ -1,0 +1,4 @@
+- name: write the appliance-config.yaml 
+  template:
+    src: "appliance-config_yaml.j2"
+    dest: "{{ install_path }}/appliance-config.yaml"

--- a/agent/roles/manifests/tasks/main.yml
+++ b/agent/roles/manifests/tasks/main.yml
@@ -25,3 +25,7 @@
 - name: Create ZTP based manifests
   import_tasks: ztp.yml
   when: agent_use_ztp_manifests == 'true'
+
+- name: Create appliance-config manifests
+  import_tasks: appliance.yml
+  when: boot_mode == 'DISKIMAGE'

--- a/agent/roles/manifests/templates/agent-config_yaml.j2
+++ b/agent/roles/manifests/templates/agent-config_yaml.j2
@@ -7,7 +7,7 @@
 {% set test_cases = agent_test_cases.split(',') %}
 apiVersion: v1alpha1
 metadata:
-  name: {{ cluster_name }} 
+  name: {{ cluster_name }}
   namespace: {{ cluster_namespace }}
 rendezvousIP: {{ ips[0] }} 
 {% if boot_mode == "PXE" %}

--- a/agent/roles/manifests/templates/appliance-config_yaml.j2
+++ b/agent/roles/manifests/templates/appliance-config_yaml.j2
@@ -1,0 +1,11 @@
+apiVersion: v1beta1
+kind: ApplianceConfig
+ocpRelease:
+  version: {{ version }}
+  channel: candidate
+  cpuArchitecture: {{ ansible_architecture }}
+diskSizeGB: 200
+pullSecret: {{ pull_secret_contents }}
+sshKey: {{ ssh_pub_key }}
+imageRegistry:
+  uri: quay.io/libpod/registry:2.8

--- a/agent/roles/manifests/templates/install-config_yaml.j2
+++ b/agent/roles/manifests/templates/install-config_yaml.j2
@@ -12,7 +12,9 @@ controlPlane:
   replicas: {{ num_masters }} 
 metadata:
   name: {{ cluster_name }} 
+{% if boot_mode != "DISKIMAGE" %}
   namespace: {{ cluster_namespace }}
+{% endif %}
 networking:
 {% if ip_stack == "v4" %}
   clusterNetwork:

--- a/common.sh
+++ b/common.sh
@@ -457,10 +457,15 @@ if [[ ! -z ${AGENT_E2E_TEST_SCENARIO} ]]; then
 fi
 
 if [[ ! -z ${AGENT_E2E_TEST_BOOT_MODE} ]]; then
-  if [[ $AGENT_E2E_TEST_BOOT_MODE != "ISO" && $AGENT_E2E_TEST_BOOT_MODE != "PXE" ]]; then
-      printf "Found invalid value \"$AGENT_E2E_TEST_BOOT_MODE\" for AGENT_E2E_TEST_BOOT_MODE. Supported values: ISO (default), PXE."
+  case "$AGENT_E2E_TEST_BOOT_MODE" in
+    "ISO" | "PXE" | "DISKIMAGE")
+      # Valid value
+      ;;
+    *)
+      printf "Found invalid value \"$AGENT_E2E_TEST_BOOT_MODE\" for AGENT_E2E_TEST_BOOT_MODE. Supported values: ISO (default), PXE, DISKIMAGE."
       exit 1
-  fi
+      ;;
+  esac
 fi
 
 # For IPv6 (default case) mirror images are used since quay doesn't support IPv6

--- a/config_example.sh
+++ b/config_example.sh
@@ -694,6 +694,7 @@ set -x
 # When set, the code internally sets the boot mode for the agents.
 # This config variable is used only by the agent based installer and is optional.
 # The default value for AGENT_E2E_TEST_BOOT_MODE is 'ISO'.
+# For the openshift-appliance flow, set the boot mode to 'DISKIMAGE'.
 # AGENT_E2E_TEST_BOOT_MODE=PXE
 
 # Uncomment and set the following value to "true" to enable a test scenario
@@ -733,3 +734,9 @@ set -x
 # haproxy is deployed as the load balancer, and the appropriate DNS records
 # are created.
 # export AGENT_PLATFORM_TYPE=none
+
+# Image reference for OpenShift-based Appliance Builder.
+# See: https://github.com/openshift/appliance
+# Default: "quay.io/edge-infrastructure/openshift-appliance:latest"
+#
+# export APPLIANCE_IMAGE="quay.io/edge-infrastructure/openshift-appliance:latest"


### PR DESCRIPTION
Added support for running the agent flow using the openshift-appliance[1] disk image.
To invoke the flow, use the following env var in config:
`export AGENT_E2E_TEST_BOOT_MODE=DISKIMAGE`
  
The appliance flow is as follows:
* Generate appliance-config.yaml[2]
  * Includes config required for building the appliance
* Build the appliance disk image using the container image defined in APPLIANCE_IMAGE env var
* Create the config-image ISO
* Clone the appliance disk image for every node
  * As each node needs a seperate disk for exclusive i/o
* Attach a cloned disk image to each node
* Attach the config-image ISO to all nodes
* Boot all machines from the disk image
  
Note: based on config-image support [PR](https://github.com/openshift-metal3/dev-scripts/pull/1533)

[1] https://github.com/openshift/appliance
[2] https://github.com/openshift/appliance/blob/master/docs/user-guide.md#set-appliance-config
