### PR TITLE
Fix DHCP network mode on agent-config.yaml

### DIFF
--- a/agent/roles/manifests/templates/agent-config_yaml.j2
+++ b/agent/roles/manifests/templates/agent-config_yaml.j2
@@ -13,7 +13,7 @@ rendezvousIP: {{ ips[0] }}
 {% if boot_mode == "PXE" %}
 ipxeBaseURL: {{ pxe_server_url }}
 {% endif %}
-{% if networking_mode != "dhcp" %}
+{% if networking_mode != "DHCP" %}
 hosts:
 {% for hostname in hostnames %}
     - hostname: {{ hostname }}


### PR DESCRIPTION
NETWORKING_MODE env var supports 'DHCP' value in upper-case. Hence, in order to support this network mode in agent-config template, changed to upper-case 'DHCP'.