### PR TITLE
OCPBUGS-16912: Agent use nmstateconfig for DHCP tests

### DIFF
--- a/agent/common.sh
+++ b/agent/common.sh
@@ -4,6 +4,7 @@ set -euxo pipefail
 source network.sh
 
 export AGENT_STATIC_IP_NODE0_ONLY=${AGENT_STATIC_IP_NODE0_ONLY:-"false"}
+export AGENT_NMSTATE_DHCP=${AGENT_NMSTATE_DHCP:-"false"}
 
 export AGENT_USE_ZTP_MANIFESTS=${AGENT_USE_ZTP_MANIFESTS:-"false"}
 

--- a/agent/roles/manifests/templates/agent-config_yaml.j2
+++ b/agent/roles/manifests/templates/agent-config_yaml.j2
@@ -17,6 +17,7 @@ rendezvousIP: {{ ipsv6[0] }}
 {% if boot_mode == "PXE" %}
 ipxeBaseURL: {{ pxe_server_url }}
 {% endif %}
+{% if networking_mode != "DHCP" or agent_nmstate_dhcp == 'true' %}
 hosts:
 {% for hostname in hostnames %}
     - hostname: {{ hostname }}
@@ -48,3 +49,4 @@ hosts:
     {{ net.route_dualstack(provisioning_host_external_ip, provisioning_host_external_ip_dualstack)|indent(4, True) }}
 {% endif %}
 {% endfor %}
+{% endif %}

--- a/agent/roles/manifests/templates/agent-config_yaml.j2
+++ b/agent/roles/manifests/templates/agent-config_yaml.j2
@@ -17,18 +17,17 @@ rendezvousIP: {{ ipsv6[0] }}
 {% if boot_mode == "PXE" %}
 ipxeBaseURL: {{ pxe_server_url }}
 {% endif %}
-{% if networking_mode != "DHCP" %}
 hosts:
 {% for hostname in hostnames %}
     - hostname: {{ hostname }}
       interfaces:
-        - name: eth0 
-          macAddress: {{ macs[loop.index0] }} 
+        - name: eth0
+          macAddress: {{ macs[loop.index0] }}
       networkConfig:
     {{ net.interfaces(macs[loop.index0])|indent(4, True) }}
 {% if ip_stack == "v4" %}
             ipv4:
-          {{ net.ip(ips[loop.index0], external_subnet_v4_prefixlen)|indent(4, True) }}
+          {{ net.ip(networking_mode, ips[loop.index0], external_subnet_v4_prefixlen)|indent(4, True) }}
 {% if "master-0" in hostname and "bad_dns" in test_cases %}
     {{ net.dns("192.168.123.1")|indent(4, True)  }}
 {% else %}
@@ -37,16 +36,15 @@ hosts:
     {{ net.route("0.0.0.0/0", provisioning_host_external_ip)|indent(4, True) }}
 {% elif ip_stack == "v6" %}
             ipv6:
-          {{ net.ip(ipsv6[loop.index0], external_subnet_v6_prefixlen)|indent(4, True) }}
+          {{ net.ip(networking_mode, ipsv6[loop.index0], external_subnet_v6_prefixlen)|indent(4, True) }}
     {{ net.dns(provisioning_host_external_ip)|indent(4, True) }}
     {{ net.route("::/0", provisioning_host_external_ip)|indent(4, True) }}
 {% else %}
             ipv4:
-          {{ net.ip(ips[loop.index0], external_subnet_v4_prefixlen)|indent(4, True) }}
+          {{ net.ip(networking_mode, ips[loop.index0], external_subnet_v4_prefixlen)|indent(4, True) }}
             ipv6:
-          {{ net.ip(ipsv6[loop.index0], external_subnet_v6_prefixlen)|indent(4, True) }}
+          {{ net.ip(networking_mode, ipsv6[loop.index0], external_subnet_v6_prefixlen)|indent(4, True) }}
     {{ net.dns_dualstack(provisioning_host_external_ip, provisioning_host_external_ip_dualstack)|indent(4, True) }}
     {{ net.route_dualstack(provisioning_host_external_ip, provisioning_host_external_ip_dualstack)|indent(4, True) }}
 {% endif %}
 {% endfor %}
-{% endif %}

--- a/agent/roles/manifests/templates/net_macros.yaml
+++ b/agent/roles/manifests/templates/net_macros.yaml
@@ -6,12 +6,21 @@
         mac-address: {{ mac }}
 {%- endmacro %}
 
-{% macro ip(ip, prefix) -%}
+{% macro ip(mode, ip, prefix) -%}
+{% if mode == "DHCP" -%}
+          {% if ip is ansible.utils.ipv6 %}autoconf: true
+          {% endif %}auto-dns: false
+          enabled: true
+          dhcp: true
+          auto-gateway: true
+          auto-routes: true
+{%- else -%}
           enabled: true
           address:
             - ip: {{ ip }}
               prefix-length: {{ prefix }}
           dhcp: false
+{%- endif -%}
 {%- endmacro %}
 
 {% macro dns(ext_ip) -%}

--- a/agent/roles/manifests/templates/nmstateconfig_yaml.j2
+++ b/agent/roles/manifests/templates/nmstateconfig_yaml.j2
@@ -17,19 +17,19 @@ spec:
     {{ net.interfaces(macs[loop.index0]) }}
 {% if ip_stack == "v4" %}
         ipv4:
-          {{ net.ip(ips[loop.index0], cluster_host_prefix_v4) }}
+          {{ net.ip(networking_mode, ips[loop.index0], cluster_host_prefix_v4) }}
     {{ net.dns(provisioning_host_external_ip) }}
     {{ net.route("0.0.0.0/0", provisioning_host_external_ip) }}
 {% elif ip_stack == "v6" %}
         ipv6:
-          {{ net.ip(ipsv6[loop.index0], cluster_host_prefix_v6) }}
+          {{ net.ip(networking_mode, ipsv6[loop.index0], cluster_host_prefix_v6) }}
     {{ net.dns(provisioning_host_external_ip) }}
     {{ net.route("::/0", provisioning_host_external_ip) }}
 {% else %}
         ipv4:
-          {{ net.ip(ips[loop.index0], cluster_host_prefix_v4) }}
+          {{ net.ip(networking_mode, ips[loop.index0], cluster_host_prefix_v4) }}
         ipv6:
-          {{ net.ip(ipsv6[loop.index0], cluster_host_prefix_v6) }}
+          {{ net.ip(networking_mode, ipsv6[loop.index0], cluster_host_prefix_v6) }}
     {{ net.dns_dualstack(provisioning_host_external_ip, provisioning_host_external_ip_dualstack) }}
     {{ net.route_dualstack(provisioning_host_external_ip, provisioning_host_external_ip_dualstack) }}
 {% endif %}

--- a/agent/roles/manifests/templates/nmstateconfig_yaml.j2
+++ b/agent/roles/manifests/templates/nmstateconfig_yaml.j2
@@ -17,19 +17,19 @@ spec:
     {{ net.interfaces(macs[loop.index0]) }}
 {% if ip_stack == "v4" %}
         ipv4:
-          {{ net.ip(networking_mode, ips[loop.index0], cluster_host_prefix_v4) }}
+          {{ net.ip(networking_mode, ips[loop.index0], external_subnet_v4_prefixlen) }}
     {{ net.dns(provisioning_host_external_ip) }}
     {{ net.route("0.0.0.0/0", provisioning_host_external_ip) }}
 {% elif ip_stack == "v6" %}
         ipv6:
-          {{ net.ip(networking_mode, ipsv6[loop.index0], cluster_host_prefix_v6) }}
+          {{ net.ip(networking_mode, ipsv6[loop.index0], external_subnet_v6_prefixlen) }}
     {{ net.dns(provisioning_host_external_ip) }}
     {{ net.route("::/0", provisioning_host_external_ip) }}
 {% else %}
         ipv4:
-          {{ net.ip(networking_mode, ips[loop.index0], cluster_host_prefix_v4) }}
+          {{ net.ip(networking_mode, ips[loop.index0], external_subnet_v4_prefixlen) }}
         ipv6:
-          {{ net.ip(networking_mode, ipsv6[loop.index0], cluster_host_prefix_v6) }}
+          {{ net.ip(networking_mode, ipsv6[loop.index0], external_subnet_v6_prefixlen) }}
     {{ net.dns_dualstack(provisioning_host_external_ip, provisioning_host_external_ip_dualstack) }}
     {{ net.route_dualstack(provisioning_host_external_ip, provisioning_host_external_ip_dualstack) }}
 {% endif %}

--- a/agent/roles/manifests/vars/main.yml
+++ b/agent/roles/manifests/vars/main.yml
@@ -1,4 +1,5 @@
 agent_deploy_mce: "{{ lookup('env', 'AGENT_DEPLOY_MCE') }}"
+agent_nmstate_dhcp: "{{ lookup('env', 'AGENT_NMSTATE_DHCP') }}"
 agent_nodes_macs: "{{ lookup('env', 'AGENT_NODES_MACS_STR') }}"
 agent_nodes_ips: "{{ lookup('env', 'AGENT_NODES_IPS_STR') }}"
 agent_nodes_ipsv6: "{{ lookup('env', 'AGENT_NODES_IPSV6_STR') }}"

--- a/config_example.sh
+++ b/config_example.sh
@@ -733,3 +733,9 @@ set -x
 # haproxy is deployed as the load balancer, and the appropriate DNS records
 # are created.
 # export AGENT_PLATFORM_TYPE=none
+
+# When set to 'true', configure the host settings in agent-config.yaml to
+# include the nmstate configuration when using DHCP.
+# The default is 'false', in which case the nmstate configuration will
+# not be included
+# export AGENT_NMSTATE_DHCP=false


### PR DESCRIPTION
The Agent IPV6_DCHCP test fails due to the address assigned via DHCPv6 not matching the rendezvousIP. The reason is that by default NetworkManager sends DHCPv6 Solicitations with a Client ID of DUID-UID (prefix=00:04, see https://datatracker.ietf.org/doc/html/rfc6355) containing a machine specific value. When using nmstateconfig for DHCP, the NetworkManager keyfiles are setup for each interface with dhcp-duid=ll (prefix=00:03, see https://datatracker.ietf.org/doc/html/rfc3315#section-9.4) which means that the DHCPv6 Solicitation is based on the mac address. This allows the DHCPv6 server to assign a deterministic address which can be set to match the rendezvousIP, e.g
https://github.com/metal3-io/metal3-dev-env/blob/main/vm-setup/roles/libvirt/templates/network.xml.j2#L93

Using the nmstateconfig is also recommended for IPv4 and is consistent with configurations we have seen from customers. For both cases the nmstate configs are used - https://nmstate.io/examples.html#dynamic-ip-configuration.

https://github.com/openshift-metal3/dev-scripts/pull/1555 is also needed and included here.