### PR TITLE
appliance: added userCorePass to appliance-config

### DIFF
--- a/agent/roles/manifests/templates/appliance-config_yaml.j2
+++ b/agent/roles/manifests/templates/appliance-config_yaml.j2
@@ -9,3 +9,4 @@ pullSecret: {{ pull_secret_contents }}
 sshKey: {{ ssh_pub_key }}
 imageRegistry:
   uri: quay.io/libpod/registry:2.8
+userCorePass: core


### PR DESCRIPTION
Added a default 'userCorePass' to appliance-config.yaml file. This is useful for debug purposes (to login through console).