### PR TITLE
Added support for disconnected environments

### DIFF
--- a/config_example.sh
+++ b/config_example.sh
@@ -619,6 +619,14 @@ set -x
 #
 # export INSTALLER_PROXY=true
 
+# DISCONNECTED_ENV -
+# Blocks all outgoing traffic by using 'route' forward mode.
+# This is useful when a fully disconnected environment should be tested.
+# E.g. on openshift-appliance flow (https://github.com/openshift/appliance)
+# Default: ""
+#
+export DISCONNECTED_ENV=true
+
 ################################################################################
 ## Assisted Deployment
 ##

--- a/vm_setup_vars.yml
+++ b/vm_setup_vars.yml
@@ -64,7 +64,7 @@ provisioning_network:
 external_network:
   - name: "{{ baremetal_network_name }}"
     bridge: "{{ baremetal_network_name }}"
-    forward_mode: "{{ 'bridge' if lookup('env', 'MANAGE_BR_BRIDGE') == 'n' else 'nat' if not lookup('env', 'INSTALLER_PROXY') else 'route'}}"
+    forward_mode: "{{ 'bridge' if lookup('env', 'MANAGE_BR_BRIDGE') == 'n' else 'nat' if not (lookup('env', 'INSTALLER_PROXY') or lookup('env', 'DISCONNECTED_ENV')) else 'route'}}"
     address_v4: "{{ baremetal_network_cidr_v4|nthhost(1)|default('', true) }}"
     netmask_v4: "{{ baremetal_network_cidr_v4|ipaddr('netmask') }}"
     address_v6: "{{ baremetal_network_cidr_v6|nthhost(1)|default('', true) }}"


### PR DESCRIPTION
Added a DISCONNECTED_ENV flag for blocking all outgoing traffic by using 'route' forward mode.
This is useful when a fully disconnected environment should be tested. E.g. on openshift-appliance flow (https://github.com/openshift/appliance)