### PR TITLE
appliance: ensure config-image is created once

### DIFF
--- a/agent/06_agent_create_cluster.sh
+++ b/agent/06_agent_create_cluster.sh
@@ -123,11 +123,6 @@ function attach_appliance_diskimage() {
     local config_image_drive="sdd"
     local appliance_disk_image="${OCP_DIR}/appliance.raw"
 
-    # Create the config ISO
-    mkdir -p ${config_image_dir}
-    cp ${asset_dir}/*.yaml ${config_image_dir}
-    create_config_image
-
     for (( n=0; n<${2}; n++ ))
     do
         name=${CLUSTER_NAME}_${1}_${n}
@@ -360,6 +355,11 @@ case "${AGENT_E2E_TEST_BOOT_MODE}" in
     ;;
 
   "DISKIMAGE" )
+    # Create the config ISO
+    mkdir -p ${config_image_dir}
+    cp ${asset_dir}/*.yaml ${config_image_dir}
+    create_config_image
+
     # Build disk image using openshift-appliance
     create_appliance ${asset_dir}
 


### PR DESCRIPTION
The config-image should be created only once (as the ISO is shared by all machines).
Hence, moved the config-image creation logic outside of the 'attach_appliance_diskimage' func.
I.e. Since this func is called twice (both for masters and workers).