### PR TITLE
Removing sourcing of the non-step network.sh script

### DIFF
--- a/agent/common.sh
+++ b/agent/common.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-source network.sh
-
 export AGENT_STATIC_IP_NODE0_ONLY=${AGENT_STATIC_IP_NODE0_ONLY:-"false"}
 
 export AGENT_USE_ZTP_MANIFESTS=${AGENT_USE_ZTP_MANIFESTS:-"false"}


### PR DESCRIPTION
Sourcing the non-step script `network.sh` within the non-step script `agent/common.sh` introduces a not explicit dependency that may produce unwanted side-effects.

In particular, since the `agent/common.sh` is source into the `agent/01_agent_requirements.sh` _before_ the generic `/01_install_requirements.sh`, all the functions in `network.sh` needing a specific software requirement - like ansible for [nth_ip](https://github.com/openshift-metal3/dev-scripts/blob/f4c1080455a3d1928b6ee675ec379de31ad703e5/network.sh#L7) - are going to fail.

The blocking issue was initially discovered by @danielerez while trying to activate the `INSTALLER_PROXY` config var, which requires the [PROVISIONING_HOST_EXTERNAL_IP](https://github.com/openshift-metal3/dev-scripts/blob/f4c1080455a3d1928b6ee675ec379de31ad703e5/network.sh#L154-L158) that may need the `nth_ip` function)
