### PR TITLE
AGENT-428: Add support for bonding with unique macs

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -320,3 +320,9 @@ if [ "${DISABLE_MULTICAST:-false}" == "true" ]; then
         sudo ebtables -A OUTPUT --pkttype-type multicast -p ip6 --ip6-dst ${dst} -j DROP
     done
 fi
+
+if [[ ! -z "${BOND_PRIMARY_INTERFACE:-}" ]]; then
+
+    setup_bond master $NUM_MASTERS
+    setup_bond worker $NUM_WORKERS
+fi

--- a/agent/05_agent_configure.sh
+++ b/agent/05_agent_configure.sh
@@ -83,11 +83,11 @@ function get_static_ips_and_macs() {
             add_dns_entry ${AGENT_NODES_IPSV6[i]} ${AGENT_NODES_HOSTNAMES[i]}
         fi
 
-        # Get the generated mac addresses or, in the case of a bond, the configured ones
+        # Get the generated mac addresses
         AGENT_NODES_MACS+=($(sudo virsh dumpxml $cluster_name | xmllint --xpath "string(//interface[descendant::source[@bridge = '${BAREMETAL_NETWORK_NAME}']]/mac/@address)" -))
-        if [[ ${BOND_CONFIG} != "none" ]]; then
+        if [[ ! -z "${BOND_PRIMARY_INTERFACE:-}" ]]; then
+	   # For a bond a separate mac is used on the 2nd interface
            mac1=${AGENT_NODES_MACS[-1]}
-           # increment to get next mac
            next=$(printf "%02x" $((${mac1##*:} + 1)))
            mac2="${mac1%:*}:$next"
            AGENT_NODES_MACS+=(${mac2})

--- a/agent/05_agent_configure.sh
+++ b/agent/05_agent_configure.sh
@@ -86,11 +86,8 @@ function get_static_ips_and_macs() {
         # Get the generated mac addresses
         AGENT_NODES_MACS+=($(sudo virsh dumpxml $cluster_name | xmllint --xpath "string(//interface[descendant::source[@bridge = '${BAREMETAL_NETWORK_NAME}']]/mac/@address)" -))
         if [[ ! -z "${BOND_PRIMARY_INTERFACE:-}" ]]; then
-	   # For a bond a separate mac is used on the 2nd interface
-           mac1=${AGENT_NODES_MACS[-1]}
-           next=$(printf "%02x" $((${mac1##*:} + 1)))
-           mac2="${mac1%:*}:$next"
-           AGENT_NODES_MACS+=(${mac2})
+	   # For a bond, a random mac is added for the 2nd interface
+	   AGENT_NODES_MACS+=($(sudo virsh domiflist ${cluster_name} | grep ${BAREMETAL_NETWORK_NAME} | grep -v ${AGENT_NODES_MACS[-1]} | awk '{print $5}'))
         fi
     done
 }

--- a/agent/common.sh
+++ b/agent/common.sh
@@ -9,6 +9,7 @@ export AGENT_USE_ZTP_MANIFESTS=${AGENT_USE_ZTP_MANIFESTS:-"false"}
 export AGENT_USE_APPLIANCE_MODEL=${AGENT_USE_APPLIANCE_MODEL:-"false"}
 export AGENT_APPLIANCE_HOTPLUG=${AGENT_APPLIANCE_HOTPLUG:-"false"}
 export AGENT_PLATFORM_TYPE=${AGENT_PLATFORM_TYPE:-"baremetal"}
+export AGENT_BOND_CONFIG=${AGENT_BOND_CONFIG:-"none"}
 
 # Image reference for OpenShift-based Appliance Builder.
 # See: https://github.com/openshift/appliance

--- a/agent/common.sh
+++ b/agent/common.sh
@@ -10,7 +10,7 @@ export AGENT_USE_APPLIANCE_MODEL=${AGENT_USE_APPLIANCE_MODEL:-"false"}
 export AGENT_APPLIANCE_HOTPLUG=${AGENT_APPLIANCE_HOTPLUG:-"false"}
 export AGENT_PLATFORM_TYPE=${AGENT_PLATFORM_TYPE:-"baremetal"}
 
-export BOND_CONFIG=${BOND_CONFIG:-"balance-rr"}
+export BOND_CONFIG=${BOND_CONFIG:-"none"}
 
 # Image reference for OpenShift-based Appliance Builder.
 # See: https://github.com/openshift/appliance

--- a/agent/common.sh
+++ b/agent/common.sh
@@ -9,7 +9,8 @@ export AGENT_USE_ZTP_MANIFESTS=${AGENT_USE_ZTP_MANIFESTS:-"false"}
 export AGENT_USE_APPLIANCE_MODEL=${AGENT_USE_APPLIANCE_MODEL:-"false"}
 export AGENT_APPLIANCE_HOTPLUG=${AGENT_APPLIANCE_HOTPLUG:-"false"}
 export AGENT_PLATFORM_TYPE=${AGENT_PLATFORM_TYPE:-"baremetal"}
-export AGENT_BOND_CONFIG=${AGENT_BOND_CONFIG:-"none"}
+
+export BOND_CONFIG=${BOND_CONFIG:-"none"}
 
 # Image reference for OpenShift-based Appliance Builder.
 # See: https://github.com/openshift/appliance

--- a/agent/common.sh
+++ b/agent/common.sh
@@ -10,7 +10,7 @@ export AGENT_USE_APPLIANCE_MODEL=${AGENT_USE_APPLIANCE_MODEL:-"false"}
 export AGENT_APPLIANCE_HOTPLUG=${AGENT_APPLIANCE_HOTPLUG:-"false"}
 export AGENT_PLATFORM_TYPE=${AGENT_PLATFORM_TYPE:-"baremetal"}
 
-export BOND_CONFIG=${BOND_CONFIG:-"none"}
+export BOND_CONFIG=${BOND_CONFIG:-"balance-rr"}
 
 # Image reference for OpenShift-based Appliance Builder.
 # See: https://github.com/openshift/appliance

--- a/agent/roles/manifests/tasks/install-config.yml
+++ b/agent/roles/manifests/tasks/install-config.yml
@@ -12,3 +12,10 @@
   template:
     src: "agent-config_yaml.j2"
     dest: "{{ install_path }}/agent-config.yaml"
+  when: agent_bond_config == 'none'
+
+- name: write the agent-config.yaml with nics in a bond
+  template:
+    src: "agent-config_bond_yaml.j2"
+    dest: "{{ install_path }}/agent-config.yaml"
+  when: agent_bond_config != 'none'

--- a/agent/roles/manifests/tasks/ztp.yml
+++ b/agent/roles/manifests/tasks/ztp.yml
@@ -33,6 +33,13 @@
   template:
     src: "nmstateconfig_yaml.j2"
     dest: "{{ manifests_path }}/nmstateconfig.yaml"
+  when: agent_bond_config == 'none'
+
+- name: Write nmstateconfig.yaml with nics in a bond
+  template:
+    src: "nmstateconfig_bond_yaml.j2"
+    dest: "{{ manifests_path }}/nmstateconfig.yaml"
+  when: agent_bond_config != 'none'
 
 - name: Get mirror settings
   set_fact:

--- a/agent/roles/manifests/templates/agent-config_bond_yaml.j2
+++ b/agent/roles/manifests/templates/agent-config_bond_yaml.j2
@@ -4,7 +4,6 @@
 {% set ipsv6 = agent_nodes_ipsv6.split(',') %}
 {% set macs = agent_nodes_macs.split(',') %}
 {% set hostnames = agent_nodes_hostnames.split(',') %}
-{% set test_cases = agent_test_cases.split(',') %}
 apiVersion: v1alpha1
 metadata:
   name: {{ cluster_name }}
@@ -17,37 +16,35 @@ rendezvousIP: {{ ipsv6[0] }}
 {% if boot_mode == "PXE" %}
 ipxeBaseURL: {{ pxe_server_url }}
 {% endif %}
-{% if networking_mode != "DHCP" or agent_nmstate_dhcp == 'true' %}
 hosts:
 {% for hostname in hostnames %}
     - hostname: {{ hostname }}
       interfaces:
         - name: eth0
-          macAddress: {{ macs[loop.index0] }}
+          macAddress: {{ macs[2*loop.index0] }}
+        - name: eth1
+          macAddress: {{ macs[2*loop.index0+1] }}
       networkConfig:
         interfaces:
-          {{ net.interfaces("eth0", macs[loop.index0]) }}
+          {{ net.interfaces("eth0", macs[2*loop.index0]) }}
+          {{ net.interfaces("eth1", macs[2*loop.index0+1]) }}
+          {{ net.bond("bond0", agent_bond_config) }}
 {% if ip_stack == "v4" %}
             ipv4:
           {{ net.ip(networking_mode, ips[loop.index0], external_subnet_v4_prefixlen)|indent(4, True) }}
-{% if "master-0" in hostname and "bad_dns" in test_cases %}
-    {{ net.dns("192.168.123.1")|indent(4, True)  }}
-{% else %}
     {{ net.dns(provisioning_host_external_ip)|indent(4, True)  }}
-{% endif %}
-    {{ net.route("eth0", "0.0.0.0/0", provisioning_host_external_ip)|indent(4, True) }}
+    {{ net.route("bond0", "0.0.0.0/0", provisioning_host_external_ip)|indent(4, True) }}
 {% elif ip_stack == "v6" %}
             ipv6:
           {{ net.ip(networking_mode, ipsv6[loop.index0], external_subnet_v6_prefixlen)|indent(4, True) }}
     {{ net.dns(provisioning_host_external_ip)|indent(4, True) }}
-    {{ net.route("eth0", "::/0", provisioning_host_external_ip)|indent(4, True) }}
+    {{ net.route("bond0", "::/0", provisioning_host_external_ip)|indent(4, True) }}
 {% else %}
             ipv4:
           {{ net.ip(networking_mode, ips[loop.index0], external_subnet_v4_prefixlen)|indent(4, True) }}
             ipv6:
           {{ net.ip(networking_mode, ipsv6[loop.index0], external_subnet_v6_prefixlen)|indent(4, True) }}
     {{ net.dns_dualstack(provisioning_host_external_ip, provisioning_host_external_ip_dualstack)|indent(4, True) }}
-    {{ net.route_dualstack("eth0", provisioning_host_external_ip, provisioning_host_external_ip_dualstack)|indent(4, True) }}
+    {{ net.route_dualstack("bond0", provisioning_host_external_ip, provisioning_host_external_ip_dualstack)|indent(4, True) }}
 {% endif %}
 {% endfor %}
-{% endif %}

--- a/agent/roles/manifests/templates/agent-config_bond_yaml.j2
+++ b/agent/roles/manifests/templates/agent-config_bond_yaml.j2
@@ -26,9 +26,9 @@ hosts:
           macAddress: {{ macs[2*loop.index0+1] }}
       networkConfig:
         interfaces:
-          {{ net.interfaces("eth0", macs[2*loop.index0]) }}
-          {{ net.interfaces("eth1", macs[2*loop.index0+1]) }}
-          {{ net.bond("bond0", agent_bond_config) }}
+      {{ net.interfaces("eth0", macs[2*loop.index0])|indent(4, True) }}
+      {{ net.interfaces("eth1", macs[2*loop.index0+1])|indent(4, True) }}
+      {{ net.bond("bond0", agent_bond_config)|indent(4, True) }}
 {% if ip_stack == "v4" %}
             ipv4:
           {{ net.ip(networking_mode, ips[loop.index0], external_subnet_v4_prefixlen)|indent(4, True) }}

--- a/agent/roles/manifests/templates/agent-config_yaml.j2
+++ b/agent/roles/manifests/templates/agent-config_yaml.j2
@@ -26,7 +26,7 @@ hosts:
           macAddress: {{ macs[loop.index0] }}
       networkConfig:
         interfaces:
-          {{ net.interfaces("eth0", macs[loop.index0]) }}
+      {{ net.interfaces("eth0", macs[loop.index0])|indent(4, True) }}
 {% if ip_stack == "v4" %}
             ipv4:
           {{ net.ip(networking_mode, ips[loop.index0], external_subnet_v4_prefixlen)|indent(4, True) }}

--- a/agent/roles/manifests/templates/net_macros.yaml
+++ b/agent/roles/manifests/templates/net_macros.yaml
@@ -1,9 +1,19 @@
-{% macro interfaces(mac) -%}
-    interfaces:
-      - name: eth0
-        type: ethernet
-        state: up
-        mac-address: {{ mac }}
+{% macro interfaces(name, mac) -%}
+       - name: {{ name }}
+            type: ethernet
+            state: up
+            mac-address: {{ mac }}
+{%- endmacro %}
+
+{% macro bond(name, mode) -%}
+       - name: {{ name }}
+            type: bond
+            state: up
+            link-aggregation:
+              mode: {{ mode }}
+              port:
+              - eth0
+              - eth1
 {%- endmacro %}
 
 {% macro ip(mode, ip, prefix) -%}
@@ -30,12 +40,12 @@
           - {{ ext_ip }}
 {%- endmacro %}
 
-{% macro route(dest, ext_ip) -%}
+{% macro route(interface, dest, ext_ip) -%}
     routes:
       config:
         - destination: {{ dest }} 
           next-hop-address: {{ ext_ip }}
-          next-hop-interface: eth0
+          next-hop-interface: {{ interface }}
           table-id: 254
 {%- endmacro %}
 
@@ -47,15 +57,15 @@
           - {{ dualstack_ext_ip }}
 {%- endmacro %}
 
-{% macro route_dualstack(ext_ip, dualstack_ext_ip) -%}
+{% macro route_dualstack(interface, ext_ip, dualstack_ext_ip) -%}
     routes:
       config:
         - destination: 0.0.0.0/0 
           next-hop-address: {{ ext_ip }}
-          next-hop-interface: eth0
+          next-hop-interface: {{ interface }}
           table-id: 254
         - destination: ::/0 
           next-hop-address: {{ dualstack_ext_ip }}
-          next-hop-interface: eth0
+          next-hop-interface: {{ interface }}
           table-id: 254
 {%- endmacro %}

--- a/agent/roles/manifests/templates/net_macros.yaml
+++ b/agent/roles/manifests/templates/net_macros.yaml
@@ -1,19 +1,19 @@
-{% macro interfaces(name, mac) -%}
-       - name: {{ name }}
-            type: ethernet
-            state: up
-            mac-address: {{ mac }}
+{%- macro interfaces(name, mac) -%}
+      - name: {{ name }}
+        type: ethernet
+        state: up
+        mac-address: {{ mac }}
 {%- endmacro %}
 
 {% macro bond(name, mode) -%}
-       - name: {{ name }}
-            type: bond
-            state: up
-            link-aggregation:
-              mode: {{ mode }}
-              port:
-              - eth0
-              - eth1
+      - name: {{ name }}
+        type: bond
+        state: up
+        link-aggregation:
+          mode: {{ mode }}
+          port:
+          - eth0
+          - eth1
 {%- endmacro %}
 
 {% macro ip(mode, ip, prefix) -%}

--- a/agent/roles/manifests/templates/nmstateconfig_bond_yaml.j2
+++ b/agent/roles/manifests/templates/nmstateconfig_bond_yaml.j2
@@ -15,27 +15,31 @@ metadata:
 spec:
   config:
     interfaces:
-      {{ net.interfaces("eth0", macs[loop.index0]) }}
+      {{ net.interfaces("eth0", macs[2*loop.index0]) }}
+      {{ net.interfaces("eth1", macs[2*loop.index0+1]) }}
+      {{ net.bond("bond0", agent_bond_config) }}
 {% if ip_stack == "v4" %}
         ipv4:
           {{ net.ip(networking_mode, ips[loop.index0], external_subnet_v4_prefixlen) }}
     {{ net.dns(provisioning_host_external_ip) }}
-    {{ net.route("eth0", "0.0.0.0/0", provisioning_host_external_ip) }}
+    {{ net.route("bond0", "0.0.0.0/0", provisioning_host_external_ip) }}
 {% elif ip_stack == "v6" %}
         ipv6:
           {{ net.ip(networking_mode, ipsv6[loop.index0], external_subnet_v6_prefixlen) }}
     {{ net.dns(provisioning_host_external_ip) }}
-    {{ net.route("eth0", "::/0", provisioning_host_external_ip) }}
+    {{ net.route("bond0", "::/0", provisioning_host_external_ip) }}
 {% else %}
         ipv4:
           {{ net.ip(networking_mode, ips[loop.index0], external_subnet_v4_prefixlen) }}
         ipv6:
           {{ net.ip(networking_mode, ipsv6[loop.index0], external_subnet_v6_prefixlen) }}
     {{ net.dns_dualstack(provisioning_host_external_ip, provisioning_host_external_ip_dualstack) }}
-    {{ net.route_dualstack("eth0", provisioning_host_external_ip, provisioning_host_external_ip_dualstack) }}
+    {{ net.route_dualstack("bond0", provisioning_host_external_ip, provisioning_host_external_ip_dualstack) }}
 {% endif %}
   interfaces:
     - name: "eth0"
-      macAddress: {{ macs[loop.index0] }} 
+      macAddress: {{ macs[2*loop.index0] }} 
+    - name: "eth1"
+      macAddress: {{ macs[2*loop.index0+1] }} 
 ---
 {% endfor %}

--- a/agent/roles/manifests/vars/main.yml
+++ b/agent/roles/manifests/vars/main.yml
@@ -1,3 +1,4 @@
+agent_bond_config: "{{ lookup('env', 'AGENT_BOND_CONFIG') }}"
 agent_deploy_mce: "{{ lookup('env', 'AGENT_DEPLOY_MCE') }}"
 agent_nmstate_dhcp: "{{ lookup('env', 'AGENT_NMSTATE_DHCP') }}"
 agent_nodes_macs: "{{ lookup('env', 'AGENT_NODES_MACS_STR') }}"

--- a/agent/roles/manifests/vars/main.yml
+++ b/agent/roles/manifests/vars/main.yml
@@ -1,4 +1,4 @@
-agent_bond_config: "{{ lookup('env', 'AGENT_BOND_CONFIG') }}"
+agent_bond_config: "{{ lookup('env', 'BOND_CONFIG') }}"
 agent_deploy_mce: "{{ lookup('env', 'AGENT_DEPLOY_MCE') }}"
 agent_nmstate_dhcp: "{{ lookup('env', 'AGENT_NMSTATE_DHCP') }}"
 agent_nodes_macs: "{{ lookup('env', 'AGENT_NODES_MACS_STR') }}"

--- a/config_example.sh
+++ b/config_example.sh
@@ -752,3 +752,9 @@ set -x
 # Default: "quay.io/edge-infrastructure/openshift-appliance:latest"
 #
 # export APPLIANCE_IMAGE="quay.io/edge-infrastructure/openshift-appliance:latest"
+
+# When not set to 'none', this setting is used to create a bond from 2 NICs and
+# set the bond mode to the value. The possible values are 'none', 'balance-rr',
+# 'active-backup', 'broadcast', 'balance-xor', 'balance-tlb', and 'balance-alb'.
+# By default no bond is created (value='none')
+# export AGENT_BOND_CONFIG=none

--- a/config_example.sh
+++ b/config_example.sh
@@ -656,6 +656,12 @@ set -x
 # More info here: https://github.com/openshift-metal3/dev-scripts/pull/1241#issuecomment-846067822
 # export BMO_WATCH_ALL_NAMESPACES="true"
 
+# When not set to 'none', this setting is used to configure the bonding mode.
+# For platforms that use nmstate configuration, the bond mode is set to the value.
+# The possible values are 'none', 'balance-rr', 'active-backup', 'broadcast', 'balance-xor',
+# 'balance-tlb', and 'balance-alb'.
+# export BOND_CONFIG=none
+
 ################################################################################
 ## Agent Deployment
 ##
@@ -752,9 +758,3 @@ set -x
 # Default: "quay.io/edge-infrastructure/openshift-appliance:latest"
 #
 # export APPLIANCE_IMAGE="quay.io/edge-infrastructure/openshift-appliance:latest"
-
-# When not set to 'none', this setting is used to create a bond from 2 NICs and
-# set the bond mode to the value. The possible values are 'none', 'balance-rr',
-# 'active-backup', 'broadcast', 'balance-xor', 'balance-tlb', and 'balance-alb'.
-# By default no bond is created (value='none')
-# export AGENT_BOND_CONFIG=none

--- a/config_example.sh
+++ b/config_example.sh
@@ -656,11 +656,11 @@ set -x
 # More info here: https://github.com/openshift-metal3/dev-scripts/pull/1241#issuecomment-846067822
 # export BMO_WATCH_ALL_NAMESPACES="true"
 
-# When not set to 'none', this setting is used to configure the bonding mode.
 # For platforms that use nmstate configuration, the bond mode is set to the value.
-# The possible values are 'none', 'balance-rr', 'active-backup', 'broadcast', 'balance-xor',
+# The possible values are 'balance-rr', 'active-backup', 'broadcast', 'balance-xor',
 # 'balance-tlb', and 'balance-alb'.
-# export BOND_CONFIG=none
+# The default is 'balance-rr'.
+# export BOND_CONFIG=balance-rr
 
 ################################################################################
 ## Agent Deployment

--- a/config_example.sh
+++ b/config_example.sh
@@ -659,8 +659,8 @@ set -x
 # For platforms that use nmstate configuration, the bond mode is set to the value.
 # The possible values are 'balance-rr', 'active-backup', 'broadcast', 'balance-xor',
 # 'balance-tlb', and 'balance-alb'.
-# The default is 'balance-rr'.
-# export BOND_CONFIG=balance-rr
+# The default is no bonding, so value is set to 'none'.
+# export BOND_CONFIG='none'
 
 ################################################################################
 ## Agent Deployment

--- a/network.sh
+++ b/network.sh
@@ -199,6 +199,10 @@ if [ -n "${NETWORK_CONFIG_FOLDER:-}" ]; then
   NETWORK_CONFIG_FOLDER="$(readlink -m $NETWORK_CONFIG_FOLDER)"
 fi
 
+if [[ ! -z "${BOND_CONFIG:-}" && "${BOND_CONFIG}" != 'none' ]]; then
+  BOND_PRIMARY_INTERFACE="eth0"
+fi
+
 function concat_parameters_with_vipsseparator() {
     # Description:
     #     Adds ${VIPS_SEPARATOR} between all given parameters.

--- a/utils.sh
+++ b/utils.sh
@@ -781,4 +781,22 @@ use_registry() {
   return 1
 }
 
+# Reconfigure the ostestm bridge setup and create a bond with unique addresses for both nics
+function setup_bond() {
+
+    macStr="00:${RANDOM:0-2}:${RANDOM:0-2}:${RANDOM:0-2}:${RANDOM:0-2}"
+
+    for (( n=0; n<${2}; n++ ))
+    do
+        name=${CLUSTER_NAME}_${1}_${n}
+        sudo virt-xml ${name} --remove-device --network bridge=${BAREMETAL_NETWORK_NAME},model=virtio
+        macByte=$(printf "%02x" $((2*n)))
+        mac1="${macStr}:${macByte}"
+        sudo virt-xml ${name} --add-device --network bridge=${BAREMETAL_NETWORK_NAME},model=virtio,mac="${mac1}"
+        macByte=$(printf "%02x" $((2*n + 1)))
+        mac2="${macStr}:${macByte}"
+        sudo virt-xml ${name} --add-device --network bridge=${BAREMETAL_NETWORK_NAME},model=virtio,mac="${mac2}"
+    done
+}
+
 trap removetmp EXIT


### PR DESCRIPTION
Add a new variable - BOND_CONFIG, that defines the bonding mode to be used with nmstate configuration when creating 2 nics in a bond. Use the existing variable - BOND_PRIMARY_INTERFACE to indicate that a bond should be created, a random mac will be generated for the 2nd interface so that the two bond interfaces have unique macs.

 Co-Authored-By: Richard Su <rwsu@redhat.com>