### PR TITLE
Do not run 'adm release extract' with KUBECONFIG set

### DIFF
--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -25,7 +25,12 @@ function extract_command() {
     extract_dir=$(mktemp --tmpdir -d "installer--XXXXXXXXXX")
     _tmpfiles="$_tmpfiles $extract_dir"
 
-    oc adm release extract --registry-config "${PULL_SECRET_FILE}" --command=$cmd --to "${extract_dir}" ${release_image}
+    local tmpconfig
+    tmpconfig=$KUBECONFIG
+    unset KUBECONFIG
+    oc adm release extract --registry-config "${PULL_SECRET_FILE}" \
+        --command=$cmd --to "${extract_dir}" ${release_image}
+    export KUBECONFIG="$tmpconfig"
 
     mv "${extract_dir}/${cmd}" "${outdir}"
 }

--- a/utils.sh
+++ b/utils.sh
@@ -434,9 +434,13 @@ function setup_legacy_release_mirror {
       EXTRACT_DIR=$(mktemp --tmpdir -d "mirror-installer--XXXXXXXXXX")
       _tmpfiles="$_tmpfiles $EXTRACT_DIR"
 
+      local tmpconfig
+      tmpconfig=$KUBECONFIG
+      unset KUBECONFIG
       oc adm release extract --registry-config "${PULL_SECRET_FILE}" \
         --command=$installer --to "${EXTRACT_DIR}" \
         "${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/${LOCAL_IMAGE_URL_SUFFIX}:${OPENSHIFT_RELEASE_TAG}"
+      export KUBECONFIG="$tmpconfig"
 
       mv -f "${EXTRACT_DIR}/$installer" ${OCP_DIR}
     fi


### PR DESCRIPTION
Presumably after https://github.com/openshift/oc/pull/1521, the command
fails if KUBECONFIG does not exist. Since the command is run before
the cluster is created, extracting always fails. Unset KUBECONFIG.
