### PR TITLE
Bring down bm interface before virsh bring it back up

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -234,6 +234,7 @@ fi
 # restart the libvirt network so it applies an ip to the bridge
 if [ "$MANAGE_BR_BRIDGE" == "y" ] ; then
     sudo virsh net-destroy ${BAREMETAL_NETWORK_NAME}
+    sudo ifdown ${BAREMETAL_NETWORK_NAME} || true
     sudo virsh net-start ${BAREMETAL_NETWORK_NAME}
     if [ "$INT_IF" ]; then #Need to bring UP the NIC after destroying the libvirt network
         sudo ifup $INT_IF


### PR DESCRIPTION
If the BM interface is up the virsh command can't activate it, it fails with the error:
error: error creating bridge interface ostestbm: File exists

Bring the BM bridge down before virsh brings it back up