### PR TITLE
AGENT-698: Agent support for OCI platform

### DIFF
--- a/agent/roles/manifests/templates/agent-cluster-install_yaml.j2
+++ b/agent/roles/manifests/templates/agent-cluster-install_yaml.j2
@@ -4,7 +4,7 @@ metadata:
   name: test-agent-cluster-install
   namespace: {{ cluster_namespace }}
 spec:
-{% if num_masters != "1" %}
+{% if (platform_type != "none") and (platform_type != "external") %}
   apiVIP: {{ api_vip }} 
   ingressVIP: {{ ingress_vip }} 
 {% endif %}
@@ -43,8 +43,12 @@ spec:
     - cidr: {{ external_subnet_v6 }}
 {% endif %}
     networkType: {{ network_type }}
-{% if platform_type == "none" %}
+{% if (platform_type == "none") or (platform_type == "external") %}
     userManagedNetworking: true
+{% endif %}
+{% if (platform_type == "external") %}
+  external:
+    platformName: oci
 {% endif %}
   provisionRequirements:
     controlPlaneAgents: {{ num_masters }}

--- a/agent/roles/manifests/templates/install-config_yaml.j2
+++ b/agent/roles/manifests/templates/install-config_yaml.j2
@@ -49,6 +49,9 @@ networking:
 platform:
 {% if (platform_type == "none") %}
   none: {}
+{% elif (platform_type == "external") %}
+  external:
+    platformName: oci
 {% else %}
 {% set macs = agent_nodes_macs.split(',') %}
 {% set hostnames = agent_nodes_hostnames.split(',') %}


### PR DESCRIPTION
Initial support for the external OCI platform. This sets the libvirt domain manufacturer and product to allow the assisted-service validations for this platform to pass.

Requires https://github.com/openshift/assisted-service/pull/5438 and https://github.com/openshift/installer/pull/7442

In addition, this requires changes to either:
a) use a minimalISO instead of a fullISO in the agent-based-installer 
b) not require a mimimalISO in assisted-service