### PR TITLE
Restore metal3-dev-env file

### DIFF
--- a/ocp_cleanup.sh
+++ b/ocp_cleanup.sh
@@ -74,3 +74,6 @@ fi
 # Cleanup chrony configuration
 sudo sed -ie '/^allow /d' /etc/chrony.conf
 
+# Restore file after workaround
+cd ${METAL3_DEV_ENV_PATH}
+git checkout vm-setup/roles/packages_installation/tasks/centos_required_packages.yml


### PR DESCRIPTION
I'm finding after the change https://github.com/openshift-metal3/dev-scripts/pull/1573 to workaround the upgrade issue that running 'make clean; make agent' fails with the error:
```
+(utils.sh:294): sync_repo_and_patch(): git checkout main Already on 'main'
M	vm-setup/roles/packages_installation/tasks/centos_required_packages.yml Your branch is behind 'origin/main' by 454 commits, and can be fast-forwarded.
  (use "git pull" to update your local branch)
+(utils.sh:295): sync_repo_and_patch(): git fetch origin
+(utils.sh:296): sync_repo_and_patch(): git rebase origin/main
error: cannot rebase: You have unstaged changes.
error: Please commit or stash them.
+(utils.sh:1): sync_repo_and_patch(): removetmp
+(utils.sh:777): removetmp(): '[' -n ' /tmp/test-token--Zw8ebP1VUP' ']'
+(utils.sh:777): removetmp(): rm -rf /tmp/test-token--Zw8ebP1VUP
make: *** [Makefile:39: requirements] Error 1
```

This PR restores the file.