### PR TITLE
Remove CI_TOKEN requirement for OKD deployments

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -335,3 +335,9 @@ if [[ ! -z "${BOND_PRIMARY_INTERFACE:-}" ]]; then
     setup_bond master $NUM_MASTERS
     setup_bond worker $NUM_WORKERS
 fi
+
+# We should have both virsh networks started by this point.
+# Let's do a quick validation here before moving to the next
+# stage
+sudo virsh net-list | grep ${PROVISIONING_NETWORK_NAME} || sudo virsh net-start ${PROVISIONING_NETWORK_NAME}
+sudo virsh net-list | grep ${BAREMETAL_NETWORK_NAME} || sudo virsh net-start ${BAREMETAL_NETWORK_NAME}

--- a/03_build_installer.sh
+++ b/03_build_installer.sh
@@ -62,3 +62,4 @@ else
   clone_installer
   build_installer
 fi
+

--- a/config_example.sh
+++ b/config_example.sh
@@ -40,10 +40,19 @@ set -x
 # Select a different release type from which to pull the latest image.
 # If using ga then set OPENSHIFT_VERSION to the required version.
 # Default: nightly
-# Choices: ci, nightly, ga
+# Choices: ci, nightly, ga, okd
 # NOTE: Do not use for arm64, instead override OPENSHIFT_RELEASE_IMAGE
+# NOTE: If set to okd, a OPENSHIFT_RELEASE_IMAGE is required. See the below
+# section on OPENSHIFT_RELEASE_IMAGE for an example.
 #
 #export OPENSHIFT_RELEASE_TYPE=nightly
+
+# OPENSHIFT_RELEASE_IMAGE -
+# Define a specific image to deploy the cluster from. If using OKD,
+# this can be set to an image from: https://amd64.origin.releases.ci.openshift.org
+# For example:
+# export OPENSHIFT_RELEASE_IMAGE=registry.ci.openshift.org/origin/release:4.15.0-0.okd-2023-08-29-101209
+# Default: Undefined
 
 # OPENSHIFT_VERSION -
 # Set the Openshift version. If unset defaults to $OPENSHIFT_RELEASE_STREAM.

--- a/utils.sh
+++ b/utils.sh
@@ -671,6 +671,9 @@ function verify_pull_secret() {
 }
 
 function write_pull_secret() {
+	if [ "${OPENSHIFT_RELEASE_TYPE}" == "okd" ]; then
+		return
+	fi
     if [ "${OPENSHIFT_CI}" == true ]; then
         # We don't need to fetch a personal pull secret with the
         # token, but we still need to merge what we're given with the

--- a/validation.sh
+++ b/validation.sh
@@ -55,7 +55,7 @@ function early_deploy_validation() {
 
     early_either_validation
 
-    if [ ! -s ${PERSONAL_PULL_SECRET} ]; then
+    if [ ! -s ${PERSONAL_PULL_SECRET} -a ${OPENSHIFT_RELEASE_TYPE} != "okd" ]; then
         error "${PERSONAL_PULL_SECRET} is missing or empty"
         if [ -n "${PULL_SECRET:-}" ]; then
             error "It looks like you are using the old PULL_SECRET variable."
@@ -67,7 +67,7 @@ function early_deploy_validation() {
         exit 1
     fi
 
-    if [ "${OPENSHIFT_CI}" != "true" -a ${#CI_TOKEN} = 0 ]; then
+    if [ "${OPENSHIFT_CI}" != "true" -a ${#CI_TOKEN} = 0 -a "${OPENSHIFT_RELEASE_TYPE}" != "okd" ]; then
         error "No valid CI_TOKEN set in ${CONFIG}"
         if [ -n "${PULL_SECRET:-}" ]; then
             error "It looks like you are using the old PULL_SECRET variable."


### PR DESCRIPTION
This change adds the ability to deploy OKD versions without requiring the CI_TOKEN. This improves the ability to automate deployments and makes dev-scripts accessible to a wider range of users from the community.