### PR TITLE
Rename ipxeBaseURL to bootArtifactsBaseURL

### DIFF
--- a/agent/roles/manifests/templates/agent-config_bond_yaml.j2
+++ b/agent/roles/manifests/templates/agent-config_bond_yaml.j2
@@ -14,7 +14,7 @@ rendezvousIP: {{ ips[0] }}
 rendezvousIP: {{ ipsv6[0] }}
 {% endif %}
 {% if boot_mode == "PXE" %}
-ipxeBaseURL: {{ pxe_server_url }}
+bootArtifactsBaseURL: {{ pxe_server_url }}
 {% endif %}
 hosts:
 {% for hostname in hostnames %}

--- a/agent/roles/manifests/templates/agent-config_yaml.j2
+++ b/agent/roles/manifests/templates/agent-config_yaml.j2
@@ -15,7 +15,7 @@ rendezvousIP: {{ ips[0] }}
 rendezvousIP: {{ ipsv6[0] }}
 {% endif %}
 {% if boot_mode == "PXE" %}
-ipxeBaseURL: {{ pxe_server_url }}
+bootArtifactsBaseURL: {{ pxe_server_url }}
 {% endif %}
 {% if networking_mode != "DHCP" or agent_nmstate_dhcp == 'true' %}
 hosts:


### PR DESCRIPTION
https://github.com/openshift/installer/pull/7450 renamed `ipxeBaseURL` to more generic `bootArtifactsBaseURL`. 
This PR fixes it in dev-scripts.