### PR TITLE
Allow pushing custom image names when preparing a release

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -211,7 +211,7 @@ if [ -z "$KNI_INSTALL_FROM_GIT" ]; then
     export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="${OPENSHIFT_RELEASE_IMAGE}"
 fi
 
-if env | grep -q "_LOCAL_IMAGE=" ; then
+if env | grep -q "_LOCAL_IMAGE=\|_LOCAL_REPO=" ; then
     export MIRROR_IMAGES=true
 fi
 


### PR DESCRIPTION
In some cases it may be useful to provide a custom image name - rather than using the folder name as a default - when preparing a local release.
This is particularly useful for the agent-based installer, since the same repo may be used to produce (more than one) different images shipped in the release payload (having their own name).

Also, enabling automatically local registry when using custom images also for the agent workflow