### PR TITLE
Set net.ipv6.conf.all.accept_ra=2 for all topologies

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -63,17 +63,15 @@ if [[ "${NODES_PLATFORM}" == "baremetal" ]] && [ -n "$NODES_FILE" ] ; then
     set -x
 fi
 
-if [[ "${HOST_IP_STACK}" != "v4" ]]; then
-  # TODO - move this to metal3-dev-env.
-  # This is to address the following error:
-  #   "msg": "internal error: Check the host setup: enabling IPv6 forwarding with RA routes without accept_ra set to 2 is likely to cause routes loss. Interfaces to look at: eno2"
-  # This comes from libvirt when trying to create the ostestbm network.
-  for n in /proc/sys/net/ipv6/conf/* ; do
-    if [ -f $n/accept_ra ]; then
-      sudo sysctl -w net/ipv6/conf/$(basename $n)/accept_ra=2
-    fi
-  done
-fi
+# TODO - move this to metal3-dev-env.
+# This is to address the following error:
+#   "msg": "internal error: Check the host setup: enabling IPv6 forwarding with RA routes without accept_ra set to 2 is likely to cause routes loss. Interfaces to look at: eno2"
+# This comes from libvirt when trying to create the ostestbm network.
+for n in /proc/sys/net/ipv6/conf/* ; do
+  if [ -f $n/accept_ra ]; then
+    sudo sysctl -w net/ipv6/conf/$(basename $n)/accept_ra=2
+  fi
+done
 
 export ANSIBLE_FORCE_COLOR=true
 


### PR DESCRIPTION
In specific scenarios we deploy dual-stack NICs even if the host is configured as IPv4 stack (e.g. when testing multi NIC with nmstate). In this situation we forgot to set accept_ra what causes deployment to fail.

With this change we will set accept_ra no matter the topology of the cluster so that we can have all types of VMs created.