### PR TITLE
setup_podman_mirror_registry: expire mirror cert in 10 years

### DIFF
--- a/utils.sh
+++ b/utils.sh
@@ -506,7 +506,7 @@ EOF
         openssl req -x509 \
                 -key ${REGISTRY_DIR}/certs/${REGISTRY_KEY} \
                 -out  ${REGISTRY_DIR}/certs/${REGISTRY_CRT} \
-                -days 365 \
+                -days 3650 \
                 -config ${SSL_CONF} \
                 -extensions SAN
 


### PR DESCRIPTION
For openshift cert rotation we need to have a mirror certificate valid for more than a year. This updates registry crt validity to 10 years