### PR TITLE
OCPBUGS-19676: Allow agent VSphere installs by simulating VMWare host

### DIFF
--- a/agent/05_agent_configure.sh
+++ b/agent/05_agent_configure.sh
@@ -374,8 +374,10 @@ EOF
   fi
 }
 
-# Change the domain manufacturer and product to ensure validations pass when using external platform
-function set_oci() {
+# Change the domain manufacturer to ensure validations pass when using specific platforms
+function set_device_mfg() {
+
+    platform=${3}
 
     tmpdomain=$(mktemp --tmpdir "virt-domain--XXXXXXXXXX")
     _tmpfiles="$_tmpfiles $tmpdomain"
@@ -384,13 +386,26 @@ function set_oci() {
     do
         name=${CLUSTER_NAME}_${1}_${n}
         sudo virsh dumpxml ${name} > ${tmpdomain}
-        sed -i '/\/os>/a\
+
+        if [[ "${platform}" == "external" ]]; then
+          sed -i '/\/os>/a\
  <sysinfo type="smbios">\
    <system>\
      <entry name="manufacturer">OracleCloud.com</entry>\
      <entry name="product">OCI</entry>\
    </system>\
  </sysinfo>' ${tmpdomain}
+        elif [[ "${platform}" == "vsphere" ]]; then
+          sed -i '/\/os>/a\
+ <sysinfo type="smbios">\
+   <system>\
+     <entry name="manufacturer">VMware, Inc.</entry>\
+   </system>\
+ </sysinfo>' ${tmpdomain}
+        else
+          echo "Invalid platform ${platform} for manufacturer override"
+          exit 1
+	fi
 
         sed -i '/\<os>/a\
  <smbios mode="sysinfo"/>' ${tmpdomain}
@@ -435,9 +450,9 @@ else
   configure_dnsmasq ${ip} ""
 fi
 
-if [[ "${AGENT_PLATFORM_TYPE}" == "external" ]]; then
-  set_oci master $NUM_MASTERS
-  set_oci worker $NUM_WORKERS
+if [[ "${AGENT_PLATFORM_TYPE}" == "external" ]] || [[ "${AGENT_PLATFORM_TYPE}" == "vsphere" ]]; then
+  set_device_mfg master $NUM_MASTERS ${AGENT_PLATFORM_TYPE}
+  set_device_mfg worker $NUM_WORKERS ${AGENT_PLATFORM_TYPE}
 fi
 
 generate_cluster_manifests

--- a/agent/roles/manifests/templates/install-config_yaml.j2
+++ b/agent/roles/manifests/templates/install-config_yaml.j2
@@ -53,6 +53,20 @@ platform:
 {% elif (platform_type == "external") %}
   external:
     platformName: oci
+{% elif (platform_type == "vsphere") %}
+  vsphere:
+{% set macs = agent_nodes_macs.split(',') %}
+{% set hostnames = agent_nodes_hostnames.split(',') %}
+    apiVIPs:
+{% set a_vips = api_vips.split(',') %}
+{% for api_vip in a_vips %}
+      - {{ api_vip }}
+{% endfor %}
+    ingressVIPs:
+{% set i_vips = ingress_vips.split(',') %}
+{% for ingress_vip in i_vips %}
+      - {{ ingress_vip }}
+{% endfor %}
 {% endif %}
 pullSecret: {{ pull_secret_contents }}
 sshKey: {{ ssh_pub_key }} 


### PR DESCRIPTION
When the platform type is "vsphere", set the host's manufacturer to VMWare in order to pass the assisted-service validations and allow the installation to proceed.