### PR TITLE
Skip host FIPS validation in installer by default

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -126,6 +126,12 @@ if [[ "$OPENSHIFT_RELEASE_TYPE" == "ga" ]]; then
     export OPENSHIFT_RELEASE_STREAM=${OPENSHIFT_VERSION%.*}
 fi
 
+if [ "${FIPS_MODE:-false}" = "true" ]; then
+    if ! [ "${FIPS_VALIDATE:-false}" = "true" ]; then
+        export OPENSHIFT_INSTALL_SKIP_HOSTCRYPT_VALIDATION="true"
+    fi
+fi
+
 # DNS resolution for amd64.ocp.releases.ci.openshift.org fails
 # pretty regularly, so try a few times before giving up.
 function get_latest_ci_image() {


### PR DESCRIPTION
Since CI hosts do not run with FIPS mode enabled, disable checking for it in openshift-install by default. This setting can be overridden in the config by setting FIPS_VALIDATE=true.