### PR TITLE
Mirror manifest lists and use authfile explicitly

### DIFF
--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -204,6 +204,7 @@ if [ ! -f "${CACHED_MACHINE_OS_BOOTSTRAP_IMAGE}" ]; then
 fi
 
 # cached images to the bootstrap VM
+sudo -E podman pull --authfile "${PULL_SECRET_FILE}" "${IRONIC_IMAGE}" || echo "WARNING: Could not pull latest $IRONIC_IMAGE; will try to use cached images instead"
 sudo podman run -d --net host --privileged --name httpd-${PROVISIONING_NETWORK_NAME} --pod ironic-pod \
      --env PROVISIONING_INTERFACE=${PROVISIONING_NETWORK_NAME} \
      -v $IRONIC_DATA_DIR:/shared --entrypoint /bin/runhttpd ${IRONIC_IMAGE}

--- a/utils.sh
+++ b/utils.sh
@@ -434,6 +434,7 @@ function setup_legacy_release_mirror {
 
     oc adm release mirror \
        --insecure=true \
+       --keep-manifest-list=true \
         -a ${PULL_SECRET_FILE}  \
         --from ${OPENSHIFT_RELEASE_IMAGE} \
         --to-release-image ${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/local-release-image:${OPENSHIFT_RELEASE_TAG} \


### PR DESCRIPTION
We have observed that in specific environments (e.g. CI with IPv6-only)
there are missing default credentials for the local registry hosted at
`virthost.ostest.test.metalkube.org:5000` what causes errors like

```
Trying to pull [...]
Error: initializing source docker://virthost.ostest.test [...]
[...] /localimages/local-release-image: authentication required
```

In order to fix that, we are trying to explicitly pull the image with
`--authfile` so that the subsequent `podman run` has the image already
available.

---

We have also noticed that when release image constains manifest list but
the list contains only a single image, then `oc adm release mirror`
unpacks the list causing digests of the images to change. In order to
prevent that, we are explicitly requesting that manifest lists are kept
without unpacking.

This should solve the problem of inconsistency between results returned
by `oc adm release info` and `oc adm release mirror`.