### PR TITLE
OCPBUGS-20404: Add a dummy interface to IPv6 bridge (#1442)

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -247,10 +247,13 @@ if [ "$MANAGE_BR_BRIDGE" == "y" ] ; then
     fi
 fi
 
-# The IPv6 bridge interface will remain in DOWN state with NO-CARRIER unless an interface is added,
+# IPv6 bridge interfaces will remain in DOWN state with NO-CARRIER unless an interface is added,
 # so add a dummy interface to ensure the bridge comes up
 if [[ -n "${EXTERNAL_SUBNET_V6}" ]] && [ ! "$INT_IF" ]; then
     sudo ip link add name bm-ipv6-dummy up master ${BAREMETAL_NETWORK_NAME} type dummy || true
+fi
+if [[ "${PROVISIONING_NETWORK}" =~ : ]] && [ ! "$PRO_IF" ] ; then
+    sudo ip link add name pro-ipv6-dummy up master ${PROVISIONING_NETWORK_NAME} type dummy || true
 fi
 
 IPTABLES=iptables

--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -46,6 +46,9 @@ fi
 if [ "$MANAGE_PRO_BRIDGE" == "y" ]; then
     sudo ifdown ${PROVISIONING_NETWORK_NAME} || true
     sudo ip link delete ${PROVISIONING_NETWORK_NAME} || true
+    if [[ -d /sys/class/net/pro-ipv6-dummy ]]; then
+       sudo ip link delete pro-ipv6-dummy || true
+    fi
     sudo rm -f /etc/sysconfig/network-scripts/ifcfg-${PROVISIONING_NETWORK_NAME}
 fi
 # Leaving this around causes issues when the host is rebooted


### PR DESCRIPTION
In order to ensure that the IPv6 bridge interface comes up add a dummy interface.
We did the BM interface long ago but never did the provisioning interface.