### PR TITLE
Try to work around libvirt instability

### DIFF
--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -288,7 +288,8 @@ function generate_ocp_install_config() {
         exit 1
       fi
     fi
-
+    # Try to fix libvirt stability before running bootstrap VM
+    sudo systemctl restart virtproxyd.socket
     cat > "${outdir}/install-config.yaml" << EOF
 apiVersion: v1
 baseDomain: ${BASE_DOMAIN}


### PR DESCRIPTION
On CS9 and RHEL9+ hypervisor, libvirt isn't using a main daemon with all the sockets - it's using a modular daemon approach, and systemd socket activation.
This leads to issues where clients can't connect to libvirt services, because the exposed systemd socket isn't good for any reason.

Ensuring virtproxyd.socket is running at that point should help a bit, though it may be better to try to switch back to the "old" libvirt way or, at least, drop the socket activation nightmare.