### PR TITLE
OCPBUGS-22417: Include extra manifests when building configImage

### DIFF
--- a/agent/05_agent_configure.sh
+++ b/agent/05_agent_configure.sh
@@ -94,7 +94,6 @@ function get_static_ips_and_macs() {
 
 function generate_extra_cluster_manifests() {
 
-  EXTRA_MANIFESTS_PATH="${OCP_DIR}/openshift"
   mkdir -p ${EXTRA_MANIFESTS_PATH}
 
 cat > "${EXTRA_MANIFESTS_PATH}/agent-test.yaml" << EOF

--- a/agent/06_agent_create_cluster.sh
+++ b/agent/06_agent_create_cluster.sh
@@ -68,6 +68,11 @@ function create_factory_image() {
 
 function create_config_image() {
 
+    # Copy any extra manifests
+    if [ -d "${asset_dir}/openshift" ]; then
+        cp -r "${asset_dir}/openshift" "${config_image_dir}"
+    fi
+
     "${openshift_install}" --log-level=debug --dir="${config_image_dir}" agent create config-image
 
     # Copy the auth files to OCP_DIR so wait-for command can access it

--- a/agent/06_agent_create_cluster.sh
+++ b/agent/06_agent_create_cluster.sh
@@ -69,8 +69,8 @@ function create_factory_image() {
 function create_config_image() {
 
     # Copy any extra manifests
-    if [ -d "${asset_dir}/openshift" ]; then
-        cp -r "${asset_dir}/openshift" "${config_image_dir}"
+    if [ -d $EXTRA_MANIFESTS_PATH ]; then
+        cp -r $EXTRA_MANIFESTS_PATH "${config_image_dir}"
     fi
 
     "${openshift_install}" --log-level=debug --dir="${config_image_dir}" agent create config-image

--- a/agent/common.sh
+++ b/agent/common.sh
@@ -21,6 +21,9 @@ export APPLIANCE_IMAGE=${APPLIANCE_IMAGE:-"quay.io/edge-infrastructure/openshift
 # Override command name in case of extraction
 export OPENSHIFT_INSTALLER_CMD="openshift-install"
 
+# Location of extra manifests
+export EXTRA_MANIFESTS_PATH="${OCP_DIR}/openshift"
+
 # Set required config vars for PXE boot mode
 if [[ "${AGENT_E2E_TEST_BOOT_MODE}" == "PXE" ]]; then
   export PXE_SERVER_DIR=${WORKING_DIR}/boot-artifacts


### PR DESCRIPTION
When building the configImage, the extra manifests were not being added to the directory where it was built.