### PR TITLE
AGENT-724: Deploy vSphere clusters with credentials

### DIFF
--- a/agent/06_agent_create_cluster.sh
+++ b/agent/06_agent_create_cluster.sh
@@ -219,6 +219,11 @@ function wait_for_cluster_ready() {
       exit 1
   fi
 
+  if [ "${AGENT_WAIT_FOR_INSTALL_COMPLETE}" == "false" ]; then
+      echo "Skipping agent wait-for install-complete"
+      exit 0
+  fi
+
   echo "Waiting for cluster ready... "
   "${openshift_install}" --dir="${dir}" --log-level=debug agent wait-for install-complete 2>&1 | grep --line-buffered -v 'password'
   if [ ${PIPESTATUS[0]} != 0 ]; then

--- a/agent/roles/manifests/tasks/install-config.yml
+++ b/agent/roles/manifests/tasks/install-config.yml
@@ -7,13 +7,19 @@
   template:
     src: "templates/install-config_yaml.j2"
     dest: "{{ install_path }}/install-config.yaml"
-  when: platform_type != "baremetal"
+  when: platform_type != "baremetal" and platform_type != "vsphere"
 
 - name: write the install-config.yaml
   template:
     src: "templates/install-config_baremetal_yaml.j2"
     dest: "{{ install_path }}/install-config.yaml"
   when: platform_type == "baremetal"
+
+- name: write the install-config.yaml
+  template:
+    src: "templates/install-config_vsphere_yaml.j2"
+    dest: "{{ install_path }}/install-config.yaml"
+  when: platform_type == "vsphere"
 
 - name: write the agent-config.yaml 
   template:

--- a/agent/roles/manifests/templates/install-config_vsphere_yaml.j2
+++ b/agent/roles/manifests/templates/install-config_vsphere_yaml.j2
@@ -1,0 +1,99 @@
+apiVersion: v1
+baseDomain: {{ base_domain }}
+compute:
+- hyperthreading: Enabled
+  name: worker
+  replicas: {{ num_workers }} 
+  architecture: {{ goCPUArchitecture }}
+controlPlane:
+  architecture: {{ goCPUArchitecture }}
+  hyperthreading: Enabled
+  name: master
+  replicas: {{ num_masters }} 
+fips: {{ fips_mode }}
+metadata:
+  name: {{ cluster_name }} 
+{% if boot_mode != "DISKIMAGE" %}
+  namespace: {{ cluster_namespace }}
+{% endif %}
+networking:
+{% if ip_stack == "v4" %}
+  clusterNetwork:
+  - cidr: {{ cluster_subnet_v4 }}
+    hostPrefix: {{ cluster_host_prefix_v4 }}
+  machineNetwork:
+  - cidr: {{ external_subnet_v4 }}
+  serviceNetwork:
+  - {{ service_subnet_v4 }}
+{% elif ip_stack == "v6" %}
+  clusterNetwork:
+  - cidr: {{ cluster_subnet_v6 }}
+    hostPrefix: {{ cluster_host_prefix_v6 }}
+  machineNetwork:
+  - cidr: {{ external_subnet_v6 }}
+  serviceNetwork:
+  - {{ service_subnet_v6 }}
+{% else %}
+  clusterNetwork:
+  - cidr: {{ cluster_subnet_v4 }}
+    hostPrefix: {{ cluster_host_prefix_v4 }}
+  - cidr: {{ cluster_subnet_v6 }}
+    hostPrefix: {{ cluster_host_prefix_v6 }}
+  machineNetwork:
+  - cidr: {{ external_subnet_v4 }}
+  - cidr: {{ external_subnet_v6 }}
+  serviceNetwork:
+  - {{ service_subnet_v4 }}
+  - {{ service_subnet_v6 }}
+{% endif %}
+  networkType: {{ network_type }} 
+platform:
+  vsphere:
+    vcenters:
+    - datacenters:
+      - testDatacenter
+      password: testPassword
+      server: vcenter.test.com
+      user: testUser@vcenter.test.com
+    failuredomains:
+    - name: test-failure-baseDomain
+      server: vcenter.test.com
+      region: testRegion
+      topology:
+        datacenter: testDatacenter
+        datastore: /testDatacenter/datastore/testDatastore
+        computeCluster: /testDatacenter/host/testClusters
+        folder: /testDatacenter/vm/testFolder
+        networks:
+        - testNetwork
+      zone: testZone
+    apiVIPs: 
+{% set a_vips = api_vips.split(',') %}
+{% for api_vip in a_vips %}
+      - {{ api_vip }}
+{% endfor %}
+    ingressVIPs:
+{% set i_vips = ingress_vips.split(',') %}
+{% for ingress_vip in i_vips %}
+      - {{ ingress_vip }}
+{% endfor %}
+pullSecret: {{ pull_secret_contents }}
+sshKey: {{ ssh_pub_key }} 
+{% if mirror_images %}
+imageContentSources:
+{{ image_content_sources }}
+{% if (mirror_command == "oc-mirror") and (agent_deploy_mce == "true") %}
+- mirrors:
+    - "{{ local_registry_dns_name }}:{{ local_registry_port }}/multicluster-engine"
+  source: "registry.redhat.io/multicluster-engine"
+- mirrors:
+    - "{{ local_registry_dns_name }}:{{ local_registry_port }}/rhel8"
+  source: "registry.redhat.io/rhel8"
+- mirrors:
+    - "{{ local_registry_dns_name }}:{{ local_registry_port }}/redhat"
+  source: "registry.redhat.io/redhat"
+{% endif %}
+additionalTrustBundle: {{ ca_bundle_crt }}
+{% elif enable_local_registry %}
+additionalTrustBundle: {{ registry_certificate }}
+{% endif %}

--- a/common.sh
+++ b/common.sh
@@ -373,6 +373,9 @@ export ENABLE_LOCAL_REGISTRY=${ENABLE_LOCAL_REGISTRY:-}
 # Defaults the DISABLE_MULTICAST variable
 export DISABLE_MULTICAST=${DISABLE_MULTICAST:-false}
 
+# Defaults the AGENT_WAIT_FOR_INSTALL_COMPLETE variable
+export AGENT_WAIT_FOR_INSTALL_COMPLETE=${AGENT_WAIT_FOR_INSTALL_COMPLETE:-true}
+
 # Agent specific configuration 
 
 function invalidAgentValue() {

--- a/config_example.sh
+++ b/config_example.sh
@@ -205,7 +205,6 @@ set -x
 # for the cluster image-registry
 # export PERSISTENT_IMAGEREG=true
 
-
 ################################################################################
 ## Network Settings
 ##
@@ -804,6 +803,13 @@ set -x
 # The default is 'false', in which case the hosts will be defined in
 # agent-config.yaml.
 # export AGENT_BM_HOSTS_IN_INSTALL_CONFIG=false
+
+# AGENT_WAIT_FOR_INSTALL_COMPLETE
+# Default: true
+#
+# Setting this to false skips the "wait-for install-complete" step.
+#
+# export AGENT_WAIT_FOR_INSTALL_COMPLETE=false
 
 # Image reference for OpenShift-based Appliance Builder.
 # See: https://github.com/openshift/appliance


### PR DESCRIPTION
Fake credentials are added to install-config.yaml for vSphere platform.

In combination with
https://github.com/openshift-metal3/dev-scripts/pull/1588, this patch allows testng of installer and assisted-service validations for the vSphere platform.

A complete install for vSphere using dev-scripts is currently not possible because the vSphere environment is partially simulated using libvirt VMs. Any cloud controller manager interactions with vSphere will fail in libvirt because there isn't an actual vSphere environment that is being exercised.

In this setup, only "agent wait-for bootstrap-complete" will succeed. For vSphere, "agent wait-for install-complete" will fail and is skipped.

Add these to config_<username>.sh script to test:
```
export AGENT_PLATFORM_TYPE=vsphere
export AGENT_TEST_CASES=skip_wait_for_install_complete
```