### PR TITLE
AGENT-337: When using ZTP manifests, support both VIP and VIPs

### DIFF
--- a/agent/roles/manifests/templates/agent-cluster-install_yaml.j2
+++ b/agent/roles/manifests/templates/agent-cluster-install_yaml.j2
@@ -6,7 +6,17 @@ metadata:
 spec:
 {% if (platform_type != "none") and (platform_type != "external") %}
   apiVIP: {{ api_vip }} 
+  apiVIPs:
+{% set a_vips = api_vips.split(',') %}
+{% for api_vip in a_vips %}
+    - {{ api_vip }}
+{% endfor %}
   ingressVIP: {{ ingress_vip }} 
+  ingressVIPs:
+{% set i_vips = ingress_vips.split(',') %}
+{% for ingress_vip in i_vips %}
+    - {{ ingress_vip }}
+{% endfor %}
 {% endif %}
   clusterDeploymentRef:
     name: {{ cluster_name }}


### PR DESCRIPTION
In agent_cluster_install.yaml, include VIPS in addition to VIP to be compatible with the assisted-service change.
https://github.com/openshift/assisted-service/pull/5501