### PR TITLE
Remove gpasswd command call

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -166,7 +166,6 @@ ZONE="\nZONE=libvirt"
 # Allow local non-root-user access to libvirt
 if ! id $USER | grep -q libvirt; then
   sudo usermod -a -G "libvirt" $USER
-  gpasswd -a "${USER}" libvirt
 fi
 
 # This method, defined in common.sh, will either ensure sockets are up'n'running


### PR DESCRIPTION
gpasswd does the same as the usermod call we have just before. It was
mostly a mix with the newgrp command, but it doesn't help either.

Since there's no way to reload the groups system wide without a logout
and login, we can't really do anything...
