### PR TITLE
Enable libvirt proxy local socket

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -21,7 +21,7 @@ early_deploy_validation
 manage_libvirtd() {
   case ${DISTRO} in
       centos9|rhel9|rocky9)
-          for i in qemu network nodedev nwfilter secret storage interface; do
+          for i in qemu interface network nodedev nwfilter secret storage proxy; do
               sudo systemctl enable --now virt${i}d.socket
               sudo systemctl enable --now virt${i}d-ro.socket
               sudo systemctl enable --now virt${i}d-admin.socket


### PR DESCRIPTION
We have observed the below error in some of our deployments.

```
2023-11-23 15:20:02 level=error msg=Error: failed to dial libvirt: dial unix /var/run/libvirt/libvirt-sock: connect: no such file or directory
```

Using this patch, we are able to proceed when the above error is observed. Newer deployments with this patch have been successful.