### PR TITLE
Revert "OCPBUGS-15056: Use v4 network for v4-primary dual stack (#1534)"

### DIFF
--- a/vm_setup_vars.yml
+++ b/vm_setup_vars.yml
@@ -40,9 +40,6 @@ dns_dualstackhost:
   - ip: "{{ baremetal_network_cidr_v6 | nthhost(5) }}"
     hostnames:
       - "api"
-  - ip: "{{ baremetal_network_cidr_v6 | nthhost(1) }}"
-    hostnames:
-      - "virthost"
 
 dns_extrahosts:
   - ip: "{{ baremetal_network_cidr | nthhost(5) }}"


### PR DESCRIPTION
This reverts commit d96ef53d6ba06300f2e7c5c42db2e6907153ec96.

The revert is done to prevent duplicate DNS records in ostestbm network.
E.g.
```
[2023-11-23 13:42:15]   <dns>
[2023-11-23 13:42:15]     <forwarder domain='apps.ostest.test.metalkube.org' addr='127.0.0.1'/>
[2023-11-23 13:42:15]     <host ip='fd2e:6f44:5dd8:c956::5'>
[2023-11-23 13:42:15]       <hostname>api</hostname>
[2023-11-23 13:42:15]     </host>
[2023-11-23 13:42:15]     <host ip='fd2e:6f44:5dd8:c956::2'>
[2023-11-23 13:42:15]       <hostname>ns1</hostname>
[2023-11-23 13:42:15]     </host>
[2023-11-23 13:42:15]     <host ip='fd2e:6f44:5dd8:c956::1'>
[2023-11-23 13:42:15]       <hostname>virthost</hostname>
[2023-11-23 13:42:15]     </host>
[2023-11-23 13:42:15]     <host ip='fd2e:6f44:5dd8:c956::5'>
[2023-11-23 13:42:15]       <hostname>api</hostname>
[2023-11-23 13:42:15]     </host>
[2023-11-23 13:42:15]     <host ip='fd2e:6f44:5dd8:c956::1'>
[2023-11-23 13:42:15]       <hostname>virthost</hostname>
[2023-11-23 13:42:15]     </host>
[2023-11-23 13:42:15]   </dns>
```