### PR TITLE
METAL-754: Switch testing container image to RHEL9

### DIFF
--- a/images/Dockerfile.ci
+++ b/images/Dockerfile.ci
@@ -1,28 +1,24 @@
 # This Dockerfile builds the image used by the e2e-metal-ipi test steps in the OpenShift CI.
 # For more details about the test see https://steps.svc.ci.openshift.org/job/openshift-baremetal-operator-master-e2e-metal-ipi
 
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.19-openshift-4.13
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-openshift-4.15
 
 ENV HOME /output
 
-# For RHEL7
-RUN if [ ! -e /usr/bin/dnf ]; then \
-    INSTALL_PKGS="ansible python-pip nss_wrapper" && \
-    yum install -y $INSTALL_PKGS && \
-    pip install packet-python && \
+# For RHEL8
+RUN if grep "platform:el8" /etc/os-release ; then \
+    INSTALL_PKGS="ansible python3-pip nss_wrapper" && \
+    dnf install --disablerepo=epel -y $INSTALL_PKGS && \
+    pip3 install packet-python && \
     ansible-galaxy collection install "community.general:4.8.1" && \
-    yum clean all && \
-    rm -rf /var/cache/yum/* && \
-    chmod -R g+rwx /output && \
-# TODO: Remove once OpenShift CI will be upgraded to 4.2 (see https://access.redhat.com/articles/4859371)
-    chmod g+w /etc/passwd && \
-    echo 'echo default:x:$(id -u):$(id -g):Default Application User:/output:/sbin/nologin\ >> /etc/passwd' > /output/fix_uid.sh && \
-    chmod g+rwx /output/fix_uid.sh ; \
+    dnf clean all && \
+    rm -rf /var/cache/dnf/* && \
+    chmod -R g+rwx /output ; \
     fi
 
-# For RHEL8
-RUN if [ -e /usr/bin/dnf ]; then \
-    INSTALL_PKGS="ansible python3-pip nss_wrapper" && \
+# For RHEL9
+RUN if grep "platform:el9" /etc/os-release ; then \
+    INSTALL_PKGS="ansible-core python3-pip nss_wrapper" && \
     dnf install --disablerepo=epel -y $INSTALL_PKGS && \
     pip3 install packet-python && \
     ansible-galaxy collection install "community.general:4.8.1" && \


### PR DESCRIPTION
We also need to maintain RHEL8 support as prow
uses RHEL8 as a base image. Once merged we can
switch the base image (in the release repo) to
rhel9 and remove rhel8 support.

We're moving to RHEL9 now in order to take advantage of curl's new "--retry-all-errors" flag. This will allow us to retry when the ofcir-acquire ci step
fails to contact ofcir.

Also remove RHEL7 support, it hasn't been needed
since February.