### PR TITLE
MGMT-16396: Install ansible.posix collection

### DIFF
--- a/images/Dockerfile.ci
+++ b/images/Dockerfile.ci
@@ -21,7 +21,7 @@ RUN if grep "platform:el9" /etc/os-release ; then \
     INSTALL_PKGS="ansible-core python3.11-pip nss_wrapper" && \
     dnf install --disablerepo=epel -y $INSTALL_PKGS && \
     pip3.11 install packet-python && \
-    ansible-galaxy collection install "community.general:4.8.1" && \
+    ansible-galaxy collection install "community.general" "ansible.posix" && \
     dnf clean all && \
     rm -rf /var/cache/dnf/* && \
     chmod -R g+rwx /output ; \


### PR DESCRIPTION
Install posix collection in order to use synchronize module. It was a
built-in module before.

Remove the constraint on general collection as it was pinned because
rhel 8 used a old version of ansible, which is not the case anymore with
rhel 9 (https://github.com/openshift-metal3/dev-scripts/pull/1399).
