### PR TITLE
CORS-2969: Don't default to OpenShiftSDN after deprecation

### DIFF
--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -6,7 +6,7 @@ source logging.sh
 source common.sh
 source network.sh
 source rhcos.sh
-source ocp_install_env.sh
+source release_info.sh
 source utils.sh
 source validation.sh
 

--- a/06_create_cluster.sh
+++ b/06_create_cluster.sh
@@ -5,8 +5,8 @@ set -e
 source logging.sh
 source common.sh
 source network.sh
+source release_info.sh
 source utils.sh
-source ocp_install_env.sh
 source rhcos.sh
 source validation.sh
 
@@ -94,8 +94,10 @@ fi
 if [[ ! -z "${ENABLE_METALLB}" ]]; then
 
 	if [[ -z ${METALLB_IMAGE_BASE} ]]; then
+                # This can use any image in the release, as we are dropping
+                # the hash
 		export METALLB_IMAGE_BASE=$(\
-			jq -r .references.spec.tags[0].from.name ${OCP_DIR}/release_info.json | sed -e 's/@.*$//g')
+			image_for cli | sed -e 's/@.*$//g')
 		export METALLB_IMAGE_TAG="metallb"
 		export FRR_IMAGE_TAG="metallb-frr"
 	fi

--- a/agent/03_agent_build_installer.sh
+++ b/agent/03_agent_build_installer.sh
@@ -6,7 +6,6 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 LOGDIR=${SCRIPTDIR}/logs
 source $SCRIPTDIR/logging.sh
 source $SCRIPTDIR/common.sh
-source $SCRIPTDIR/ocp_install_env.sh
 source $SCRIPTDIR/agent/common.sh
 
 # Override build tags

--- a/agent/05_agent_configure.sh
+++ b/agent/05_agent_configure.sh
@@ -7,10 +7,10 @@ LOGDIR=${SCRIPTDIR}/logs
 source $SCRIPTDIR/logging.sh
 source $SCRIPTDIR/common.sh
 source $SCRIPTDIR/network.sh
+source $SCRIPTDIR/release_info.sh
 source $SCRIPTDIR/utils.sh
 source $SCRIPTDIR/validation.sh
 source $SCRIPTDIR/agent/common.sh
-source $SCRIPTDIR/ocp_install_env.sh
 source $SCRIPTDIR/oc_mirror.sh
 
 early_deploy_validation

--- a/agent/06_agent_create_cluster.sh
+++ b/agent/06_agent_create_cluster.sh
@@ -9,7 +9,7 @@ source $SCRIPTDIR/common.sh
 source $SCRIPTDIR/network.sh
 source $SCRIPTDIR/utils.sh
 source $SCRIPTDIR/validation.sh
-source $SCRIPTDIR/ocp_install_env.sh
+source $SCRIPTDIR/release_info.sh
 source $SCRIPTDIR/agent/common.sh
 
 early_deploy_validation

--- a/generate_clouds_yaml.sh
+++ b/generate_clouds_yaml.sh
@@ -4,6 +4,5 @@ set -xe
 source common.sh
 source utils.sh
 source network.sh
-source ocp_install_env.sh
 
 generate_auth_template

--- a/network.sh
+++ b/network.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source release_info.sh
+
 function nth_ip() {
   network=$1
   idx=$2
@@ -111,6 +113,11 @@ else
   exit 1
 fi
 
+function openshift_sdn_deprecated() {
+  # OpenShiftSDN is deprecated in 4.15 and later
+  printf '4.15\n%s\n' "$(openshift_version)" | sort -V -C
+}
+
 if [[ "$IP_STACK" = "v4" ]]
 then
   export CLUSTER_SUBNET_V4=${CLUSTER_SUBNET_V4:-"10.128.0.0/14"}
@@ -119,7 +126,11 @@ then
   export CLUSTER_HOST_PREFIX_V6=""
   export SERVICE_SUBNET_V4=${SERVICE_SUBNET_V4:-"172.30.0.0/16"}
   export SERVICE_SUBNET_V6=""
+if openshift_sdn_deprecated; then
+  export NETWORK_TYPE=${NETWORK_TYPE:-"OVNKubernetes"}
+else
   export NETWORK_TYPE=${NETWORK_TYPE:-"OpenShiftSDN"}
+fi
 elif [[ "$IP_STACK" = "v6" ]]; then
   export CLUSTER_SUBNET_V4=""
   export CLUSTER_SUBNET_V6=${CLUSTER_SUBNET_V6:-"fd01::/48"}

--- a/ocp_cleanup.sh
+++ b/ocp_cleanup.sh
@@ -4,7 +4,6 @@ set -x
 source logging.sh
 source common.sh
 source network.sh
-source ocp_install_env.sh
 source validation.sh
 
 early_cleanup_validation

--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -1,3 +1,5 @@
+source release_info.sh
+
 eval "$(go env)"
 
 function get_arch() {
@@ -36,27 +38,6 @@ function extract_oc() {
     _tmpfiles="$_tmpfiles $extract_dir"
     extract_command oc "$1" "${extract_dir}"
     sudo mv "${extract_dir}/oc" /usr/local/bin
-}
-
-function save_release_info() {
-    local release_image
-    local outdir
-
-    release_image="$1"
-    outdir="$2"
-
-    oc adm release info --registry-config "$PULL_SECRET_FILE" "$release_image" -o json > ${outdir}/release_info.json
-}
-
-# Gives e.g 4.7.0-0.nightly-2020-10-27-051128
-function openshift_release_version() {
-    jq -r ".metadata.version" ${OCP_DIR}/release_info.json
-}
-
-# Gives us e.g 4.7 because although OPENSHIFT_VERSION is set by users,
-# but is not set in CI
-function openshift_version() {
-    jq -r ".metadata.version" ${OCP_DIR}/release_info.json | grep -oP "\d\.\d+"
 }
 
 function extract_rhcos_json() {

--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -242,7 +242,7 @@ EOF
 function override_openshift_sdn_deprecation() {
   # OpenShiftSDN is deprecated in 4.15 and later; if the user explicitly requests it,
   # we will override this deprecation (but not if they just defaulted to it).
-  [[ "${ORIG_NETWORK_TYPE}" = "OpenShiftSDN" ]] && printf '4.15\n%s\n' "$(openshift_version)" | sort -V -C
+  [[ "${ORIG_NETWORK_TYPE}" = "OpenShiftSDN" ]] && openshift_sdn_deprecated
 }
 
 function cluster_os_image() {
@@ -278,7 +278,7 @@ function generate_ocp_install_config() {
 
     if override_openshift_sdn_deprecation; then
       # Claim we want OVNKubernetes in install-config; we will hack the generated
-      # manifests later.
+      # manifests later if OpenShiftSDN was explicitly requested.
       NETWORK_TYPE=OVNKubernetes
     fi
 

--- a/release_info.sh
+++ b/release_info.sh
@@ -1,0 +1,25 @@
+
+function save_release_info() {
+    local release_image
+    local outdir
+
+    release_image="$1"
+    outdir="$2"
+
+    oc adm release info --registry-config "$PULL_SECRET_FILE" "$release_image" -o json > ${outdir}/release_info.json
+}
+
+# Gives us e.g 4.7 because although OPENSHIFT_VERSION is set by users,
+# but is not set in CI
+function openshift_version() {
+    jq -r ".metadata.version" ${OCP_DIR}/release_info.json | grep -oP "\d\.\d+"
+}
+
+# Gives e.g 4.7.0-0.nightly-2020-10-27-051128
+function openshift_release_version() {
+    jq -r ".metadata.version" ${OCP_DIR}/release_info.json
+}
+
+function image_for() {
+    jq -r ".references.spec.tags[] | select(.name == \"$1\") | .from.name" ${OCP_DIR}/release_info.json
+}

--- a/utils.sh
+++ b/utils.sh
@@ -2,6 +2,8 @@
 
 set -o pipefail
 
+source release_info.sh
+
 function retry_with_timeout() {
   retries=$1
   timeout_duration=$2
@@ -808,11 +810,6 @@ function bootstrap_ip {
     echo "Unable to retrieve bootstrap IP with infinite leases enabled." 1>&2
   fi
 }
-
-function image_for() {
-    jq -r ".references.spec.tags[] | select(.name == \"$1\") | .from.name" ${OCP_DIR}/release_info.json
-}
-
 
 function wait_for_crd() {
   echo "Waiting for CRD ($1) to be defined"


### PR DESCRIPTION
OpenShiftSDN is being deprecated in 4.15, so switch the default to OVNKubernetes in the IPv4-only case (OVNk is already required for IPv6/dual-stack) to avoid installer failures.

This follows up on 8537fdd1e01fa07caa7f09ed03c6beafdacb9378, which sets OpenShiftSDN in the manifests (but not the install-config) iff it is *explicitly* requested.