### PR TITLE
OCPBUGS-27189: Fix dependency issue

### DIFF
--- a/06_create_cluster.sh
+++ b/06_create_cluster.sh
@@ -5,6 +5,7 @@ set -e
 source logging.sh
 source common.sh
 source network.sh
+source ocp_install_env.sh
 source release_info.sh
 source utils.sh
 source rhcos.sh


### PR DESCRIPTION
The create_cluster function in utils.sh relies on the function override_openshift_sdn_deprecation defined in ocp_install_env.sh. Therefore latter must be sourced anywhere that create_cluster is used, and it should not have been removed from 06_create_cluster.sh by 41443197abc8a748e192ef87e1c4c3b74c693059.