### PR TITLE
NO-ISSUE: In Centos9/RHEL9 update install location for network tools

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -80,6 +80,9 @@ case $DISTRO in
     sudo update-alternatives --install /usr/bin/pip3 pip3 /usr/bin/pip3.9 1
     ;;
   "centos9"|"rhel9")
+    # In RHEL9/Centos9 ifup/ifdown there is no package called network-scripts
+    # ifup/ifdown are found in NetworkManager-initscripts-updown instead.    
+    sudo dnf install NetworkManager-initscripts-updown
     sudo dnf -y install python3-pip
     if [[ $DISTRO == "centos9" ]]; then
       sudo dnf config-manager --set-enabled crb


### PR DESCRIPTION
The network-tools package is no longer available in RHEL9. This package supplies ifup/ifdown. ifup/ifdown are now found in the package NetworkManager-initscripts-updown.

This PR aims to address that by installing the correct package on RHEL9/Centos9