### PR TITLE
OCPQE-19493: Update image with equinix.cloud collection

### DIFF
--- a/images/Dockerfile.ci
+++ b/images/Dockerfile.ci
@@ -20,8 +20,8 @@ RUN if grep "platform:el8" /etc/os-release ; then \
 RUN if grep "platform:el9" /etc/os-release ; then \
     INSTALL_PKGS="ansible-core python3.11-pip nss_wrapper" && \
     dnf install --disablerepo=epel -y $INSTALL_PKGS && \
-    pip3.11 install packet-python && \
-    ansible-galaxy collection install "community.general" "ansible.posix" && \
+    pip3.11 install -r https://raw.githubusercontent.com/equinix-labs/ansible-collection-equinix/main/requirements.txt && \
+    ansible-galaxy collection install "community.general" "ansible.posix" "equinix.cloud" && \
     dnf clean all && \
     rm -rf /var/cache/dnf/* && \
     chmod -R g+rwx /output ; \


### PR DESCRIPTION
'facility' was deprecated from Dec 1, 2023. This PR update is to use [equinix.cloud ansible
collection](https://deploy.equinix.com/labs/ansible-collection-equinix/) to enable use of 'metro'.