### PR TITLE
MGMT-16990: Make the go version installed configurable

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -101,6 +101,8 @@ sudo dnf -y install jq
 sudo python -m pip install yq
 yq -iy '.[3].dnf.nobest = "true"' ${METAL3_DEV_ENV_PATH}/vm-setup/roles/packages_installation/tasks/centos_required_packages.yml
 
+GOVERSION=${GOVERSION:-1.20}
+
 GOARCH=$(uname -m)
 if [[ $GOARCH == "aarch64" ]]; then
     GOARCH="arm64"
@@ -121,7 +123,7 @@ ansible-galaxy collection install --upgrade ansible.netcommon ansible.posix ansi
 ANSIBLE_FORCE_COLOR=true ansible-playbook \
   -e "working_dir=$WORKING_DIR" \
   -e "virthost=$HOSTNAME" \
-  -e "go_version=1.20" \
+  -e "go_version=$GOVERSION" \
   -e "GOARCH=$GOARCH" \
   $ALMA_PYTHON_OVERRIDE \
   -i vm-setup/inventory.ini \


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-16990
Hive has increased the minimum go version required to 1.21 which breaks the assisted-service CI jobs since the go version is pinned to 1.20.

This introduces a configurable `GOVERSION` variable to allow other versions to be specified and installed.

/cc @adriengentil 