### PR TITLE
Change the go version variable name.

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -100,7 +100,7 @@ sudo dnf -y install jq
 sudo python -m pip install yq
 yq -iy '.[3].dnf.nobest = "true"' ${METAL3_DEV_ENV_PATH}/vm-setup/roles/packages_installation/tasks/centos_required_packages.yml
 
-GOVERSION=${GOVERSION:-1.20}
+GO_VERSION=${GO_VERSION:-1.20}
 
 GOARCH=$(uname -m)
 if [[ $GOARCH == "aarch64" ]]; then
@@ -122,7 +122,7 @@ ansible-galaxy collection install --upgrade ansible.netcommon ansible.posix ansi
 ANSIBLE_FORCE_COLOR=true ansible-playbook \
   -e "working_dir=$WORKING_DIR" \
   -e "virthost=$HOSTNAME" \
-  -e "go_version=$GOVERSION" \
+  -e "go_version=$GO_VERSION" \
   -e "GOARCH=$GOARCH" \
   $ALMA_PYTHON_OVERRIDE \
   -i vm-setup/inventory.ini \

--- a/config_example.sh
+++ b/config_example.sh
@@ -143,6 +143,11 @@ set -x
 #
 #export MAO_BRANCH="mao-fix"
 
+# Go version
+# The version of go to be installed. The default value is 1.20
+#
+#export GO_VERSION="1.21.6"
+
 ################################################################################
 ## General Settings
 ##


### PR DESCRIPTION
In this PR, we change the variable `GOVERSION` to `GO_VERSION` to prevent encountering failures due to mismatched value format.

If `go` is exists and we execute `make`, then `GOVERSION=go<version>` is format of the value being set. However, `install-package-playbook.yml` expects the value to be only the `version` instead of the prefix `go`.

Fixes #1639 