### PR TITLE
Fix upgrade from CS8 compatibility

### DIFF
--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -51,7 +51,7 @@ for interface in ${PROVISIONING_NETWORK_NAME} ${BAREMETAL_NETWORK_NAME} ${PRO_IF
 done
 
 if [ "${IF_FOUND:-}" == "true" ]; then
-  systemctl restart network.service || true
+  sudo systemctl restart network.service
 fi
 
 # There was a bug in this file, it may need to be recreated.


### PR DESCRIPTION
systemctl requires sudo to run
also removing the || true to avoid covering hidden errors, the network service should always be present before the migration and if any ifcfg file is there