### PR TITLE
OCPBUGS-20097: Extract oc RHEL8 binary from release explicitly

### DIFF
--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -29,6 +29,10 @@ function extract_command() {
 
     oc adm release extract --registry-config "${PULL_SECRET_FILE}" --command=$cmd --to "${extract_dir}" ${release_image}
 
+    if [[ $cmd == "oc.rhel8" ]]; then
+      cmd="oc"
+    fi
+
     mv "${extract_dir}/${cmd}" "${outdir}"
 }
 
@@ -36,7 +40,9 @@ function extract_command() {
 function extract_oc() {
     extract_dir=$(mktemp --tmpdir -d "installer--XXXXXXXXXX")
     _tmpfiles="$_tmpfiles $extract_dir"
-    extract_command oc "$1" "${extract_dir}"
+    if ! extract_command oc.rhel8 "$1" "${extract_dir}"; then
+      extract_command oc "$1" "${extract_dir}"
+    fi
     sudo mv "${extract_dir}/oc" /usr/local/bin
 }
 


### PR DESCRIPTION
In the course of bumping oc's base image to RHEL9, it is needed that the environments bases on RHEL 8 (at least for now) to use oc RHEL8 binary. This PR enables that when the dev-scripts is also bumped to RHEL9, it will be an easy change to use oc.rhel9 explicitly.

This PR changes the extraction of oc to oc.rhel8 which exists in 4.15 and 4.16 release payloads and fall backs to default oc for older releases.