### PR TITLE
Always mirror with --keep-manifest-list=true

### DIFF
--- a/utils.sh
+++ b/utils.sh
@@ -440,15 +440,8 @@ function setup_legacy_release_mirror {
         mkdir $REGISTRY_DIR
     fi
 
-    # Explicitly request that manifest lists arn't unpacked (causing digests of the images to change)
-    # Not supported by oc <= 4.10
-    OCEXTRAPARAMS=
-    if echo -e "4.11\n$(oc version -o json | jq .releaseClientVersion -r)" | sort -V -C ; then
-        OCEXTRAPARAMS="--keep-manifest-list=true"
-    fi
-
     oc adm release mirror \
-        --insecure=true $OCEXTRAPARAMS \
+        --insecure=true --keep-manifest-list=true \
         -a ${PULL_SECRET_FILE}  \
         --from ${OPENSHIFT_RELEASE_IMAGE} \
         --to-release-image ${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}/localimages/local-release-image:${OPENSHIFT_RELEASE_TAG} \


### PR DESCRIPTION
The code to conditionaly add --keep-manifest-list=true to the mirror command was added for a now unsupported version of OC. Remove it as it doesn't always work e.g. if the .releaseClientVersion doesn't follow the 4.XX... format.

4.15.0-0.nightly-2024-..-.....
vs
0.0.1-0.test-2024-....-latest