### PR TITLE
CORS-3462: use static openshift-installer when possible

### DIFF
--- a/03_build_installer.sh
+++ b/03_build_installer.sh
@@ -39,7 +39,7 @@ function extract_installer() {
     release_image="$1"
     outdir="$2"
 
-    extract_command "${OPENSHIFT_INSTALLER_CMD:-openshift-baremetal-install}" "$1" "$2"
+    extract_command "${OPENSHIFT_INSTALLER_CMD:-${DEFAULT_OPENSHIFT_INSTALL_CMD}}" "$1" "$2"
 }
 
 early_deploy_validation

--- a/utils.sh
+++ b/utils.sh
@@ -458,7 +458,7 @@ function setup_legacy_release_mirror {
     #To ensure that you use the correct images for the version of OpenShift Container Platform that you selected,
     #you must extract the installation program from the mirrored content:
     if [ -z "$KNI_INSTALL_FROM_GIT" ]; then
-      local installer="${OPENSHIFT_INSTALLER_CMD:-openshift-baremetal-install}"
+      local installer="${OPENSHIFT_INSTALLER_CMD:-${DEFAULT_OPENSHIFT_INSTALL_CMD}}"
 
       EXTRACT_DIR=$(mktemp --tmpdir -d "mirror-installer--XXXXXXXXXX")
       _tmpfiles="$_tmpfiles $EXTRACT_DIR"


### PR DESCRIPTION
With https://github.com/openshift/installer/pull/8161, the baremetal installer is now part of the regular installer which is now statically linked.

Using the static binary has the advantage of working on both CS8 and CS9 VMs and is a necessary step for moving the Installer images to a RHEL9 base.