### PR TITLE
CORS-3462: extract static openshift-installer from 4.16

### DIFF
--- a/03_build_installer.sh
+++ b/03_build_installer.sh
@@ -20,7 +20,11 @@ function build_installer() {
   # Build installer
   pushd .
   cd $OPENSHIFT_INSTALL_PATH
-  TAGS="${OPENSHIFT_INSTALLER_BUILD_TAGS:-libvirt baremetal}" DEFAULT_ARCH=$(get_arch) hack/build.sh
+  local default_tags="libvirt baremetal"
+  if [[ "${FIPS_MODE:-false}" = "true" && "${FIPS_VALIDATE:-false}" = "true" ]]; then
+      default_tags="${default_tags} fipscapable"
+  fi
+  TAGS="${OPENSHIFT_INSTALLER_BUILD_TAGS:-${default_tags}}" DEFAULT_ARCH=$(get_arch) hack/build.sh
   popd
   # This is only needed in rhcos.sh for old versions which lack the
   # openshift-install coreos-print-stream-json option

--- a/03_build_installer.sh
+++ b/03_build_installer.sh
@@ -33,13 +33,18 @@ function build_installer() {
 }
 
 function extract_installer() {
-    local release_image
-    local outdir
+    local release_image="$1"
+    local outdir="$2"
+    local cmd
 
-    release_image="$1"
-    outdir="$2"
+    cmd="${OPENSHIFT_INSTALLER_CMD:-$(default_installer_cmd)}"
 
-    extract_command "${OPENSHIFT_INSTALLER_CMD:-openshift-baremetal-install}" "$1" "$2"
+    extract_command "${cmd}" "${release_image}" "${outdir}"
+
+    local target="openshift-install"
+    if [ "${cmd}" != "${target}" ]; then
+        mv "${outdir}/${cmd}" "${outdir}/${target}"
+    fi
 }
 
 early_deploy_validation

--- a/common.sh
+++ b/common.sh
@@ -206,7 +206,7 @@ if [ "${UPSTREAM_IRONIC:-false}" != "false" ] ; then
 fi
 
 if [ -z "$KNI_INSTALL_FROM_GIT" ]; then
-    export OPENSHIFT_INSTALLER=${OPENSHIFT_INSTALLER:-${OCP_DIR}/openshift-baremetal-install}
+    export OPENSHIFT_INSTALLER=${OPENSHIFT_INSTALLER:-${OCP_DIR}/openshift-install}
  else
     export OPENSHIFT_INSTALLER=${OPENSHIFT_INSTALLER:-$OPENSHIFT_INSTALL_PATH/bin/openshift-install}
 

--- a/utils.sh
+++ b/utils.sh
@@ -5,7 +5,7 @@ set -o pipefail
 source release_info.sh
 
 function default_installer_cmd() {
-    if is_lower_version "$(openshift_version "${OCP_DIR}")" "4.16"; then
+    if is_lower_version "$(openshift_version "${OCP_DIR}")" "4.16" || [[ "${FIPS_MODE:-false}" = "true" && "${FIPS_VALIDATE:-false}" = "true" ]]; then
         printf "openshift-baremetal-install"
     else
         printf "openshift-install"

--- a/utils.sh
+++ b/utils.sh
@@ -4,6 +4,10 @@ set -o pipefail
 
 source release_info.sh
 
+function default_installer_cmd() {
+    printf "openshift-baremetal-install"
+}
+
 function retry_with_timeout() {
   retries=$1
   timeout_duration=$2
@@ -458,7 +462,7 @@ function setup_legacy_release_mirror {
     #To ensure that you use the correct images for the version of OpenShift Container Platform that you selected,
     #you must extract the installation program from the mirrored content:
     if [ -z "$KNI_INSTALL_FROM_GIT" ]; then
-      local installer="${OPENSHIFT_INSTALLER_CMD:-openshift-baremetal-install}"
+      local installer="${OPENSHIFT_INSTALLER_CMD:-$(default_installer_cmd)}"
 
       EXTRACT_DIR=$(mktemp --tmpdir -d "mirror-installer--XXXXXXXXXX")
       _tmpfiles="$_tmpfiles $EXTRACT_DIR"

--- a/utils.sh
+++ b/utils.sh
@@ -5,7 +5,11 @@ set -o pipefail
 source release_info.sh
 
 function default_installer_cmd() {
-    printf "openshift-baremetal-install"
+    if is_lower_version "$(openshift_version "${OCP_DIR}")" "4.16"; then
+        printf "openshift-baremetal-install"
+    else
+        printf "openshift-install"
+    fi
 }
 
 function retry_with_timeout() {


### PR DESCRIPTION
With https://github.com/openshift/installer/pull/8161, the baremetal installer is now part of the regular installer which is now statically linked.

Using the static binary has the advantage of working on both CS8 and CS9 VMs and is a necessary step for moving the Installer images to a RHEL9 base.