### PR TITLE
Allow overriding OPENSHIFT_RELEASE_TAG

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -172,7 +172,7 @@ if [[ -z "$OPENSHIFT_CI" ]]; then
   export OPENSHIFT_VERSION=${OPENSHIFT_VERSION:-$(echo $OPENSHIFT_RELEASE_IMAGE | sed "s/.*:\([[:digit:]]\.[[:digit:]]*\).*/\1/")}
 fi
 
-export OPENSHIFT_RELEASE_TAG=$(echo $OPENSHIFT_RELEASE_IMAGE | sed -E 's/[[:alnum:]\/.-]*(release|okd).*://')
+export OPENSHIFT_RELEASE_TAG=${OPENSHIFT_RELEASE_TAG:-$(echo $OPENSHIFT_RELEASE_IMAGE | sed -E 's/[[:alnum:]\/.-]*(release|okd).*://')}
 
 # Use "ipmi" for 4.3 as it didn't support redfish, for other versions
 # use "redfish", unless its CI where we use "mixed"

--- a/config_example.sh
+++ b/config_example.sh
@@ -54,6 +54,13 @@ set -x
 # export OPENSHIFT_RELEASE_IMAGE=registry.ci.openshift.org/origin/release:4.15.0-0.okd-2023-08-29-101209
 # Default: Undefined
 
+# OPENSHIFT_RELEASE_TAG -
+# Define a specific release tag to use. Only required if OPENSHIFT_RELEASE_IMAGE
+# does not come from registry.ci.openshift.org (e.g. a custom payload on quay).
+# For example:
+# export OPENSHIFT_RELEASE_TAG=4.15.0-0.okd-2023-08-29-101209-custom
+# Default: defined from OPENSHIFT_RELEASE_IMAGE
+
 # OPENSHIFT_VERSION -
 # Set the Openshift version. If unset defaults to $OPENSHIFT_RELEASE_STREAM.
 # NOTE: Do not use for arm64, instead override OPENSHIFT_RELEASE_IMAGE


### PR DESCRIPTION
The current auto-detection logic does not work at all when quay.io
images are used (a custom payload).
