### PR TITLE
opm: fallback to upstream opm on failures

### DIFF
--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -124,8 +124,14 @@ if [ ! -z "${MIRROR_IMAGES}" ]; then
         _tmpfiles="$_tmpfiles $OLM_DIR"
 
         pushd $OLM_DIR
-        curl -O https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/${VERSION}.0/opm-linux.tar.gz
-        tar xf opm-linux.tar.gz
+        curl -O https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/${VERSION}.0/opm-linux.tar.gz && \
+          tar xf opm-linux.tar.gz && \
+          ./opm version || \
+          {
+            echo "downloading latest upstream OPM client";
+            curl -L "https://github.com/operator-framework/operator-registry/releases/latest/download/linux-$(uname -m | sed 's/aarch64/arm64/;s/x86_64/amd64/')-opm" -o opm;
+            chmod +x opm; ./opm version;
+          }
         sudo mv -f opm /usr/local/bin
         popd
 


### PR DESCRIPTION
fallback to statically linked latest upstream
release of the opm binary if it cannot be downloaded from mirror.openshift.com (
https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/4.16.0/opm-linux.tar.gz is still not there) or if the downloaded binary cannot be executed (on OCP 4.15 and greater is linked only for RHEL9, see: https://issues.redhat.com/browse/OPRUN-3221 ).