### PR TITLE
OCPBUGS-34581: Fix bad dns agent test for ocp 4.16

### DIFF
--- a/agent/06_agent_create_cluster.sh
+++ b/agent/06_agent_create_cluster.sh
@@ -291,7 +291,8 @@ function run_agent_test_cases() {
 
     echo "Fixing DNS through agent-tui"
     # call script to fix DNS IP address on master-0
-    ./agent/e2e/agent-tui/test-fix-wrong-dns.sh $CLUSTER_NAME $PROVISIONING_HOST_EXTERNAL_IP
+    local version="$(openshift_version ${OCP_DIR})"
+    ./agent/e2e/agent-tui/test-fix-wrong-dns.sh $CLUSTER_NAME $PROVISIONING_HOST_EXTERNAL_IP $version
 
     echo "Finished fixing DNS through agent-tui"
   fi

--- a/agent/e2e/agent-tui/test-fix-wrong-dns.sh
+++ b/agent/e2e/agent-tui/test-fix-wrong-dns.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
+source common.sh
+set +x
+
 CLUSTER_NAME=$1
 GOOD_DNS_IP=$2
+OCP_VERSION=$3
 
 ### utils function for sending various keys and/or text to the console
 
@@ -124,7 +128,15 @@ pressEnter "Reactivate 'enp2s0'"
 sleep 3
 pressTab "Goto <Back> button" 2
 pressEnter "Select '<Back>' button'"
-pressDown "Select Quit" 2
+
+# Since ocp 4.16, the nmtui has an additional menu entry "Radio" in the main panel
+# so it's necessary an additional step
+numStepsToQuit=2
+if ! is_lower_version "${OCP_VERSION}" "4.16"; then
+    numStepsToQuit=3
+fi
+pressDown "Select Quit" ${numStepsToQuit}
+
 pressEnter "Select 'Quit' menu item"
 pressEsc "Esc from network tree view"
 pressTab "Goto <Quit> button to exit agent-tui" 1


### PR DESCRIPTION
This patch fixes the failing `AGENT_TEST_CASES` `bad_dns` script. Since Openshift 4.16, the nmtui main panel shows an additional "Radio" entry, thus requiring an additional step for a proper selection.