### PR TITLE
Restart NetworkManager after updating packages

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -39,6 +39,9 @@ sudo dnf -y clean all
 # Update to latest packages first
 sudo dnf -y upgrade --nobest
 
+# If NetworkManager was upgraded it needs to be restarted
+sudo systemctl restart NetworkManager
+
 # Install additional repos as needed for each OS version
 # shellcheck disable=SC1091
 source /etc/os-release


### PR DESCRIPTION
Package update doesn't restart NetworkManager resulting in a mismatch between Client and Server versions