### PR TITLE
appliance: fix disk attach using virt-xml

### DIFF
--- a/agent/06_agent_create_cluster.sh
+++ b/agent/06_agent_create_cluster.sh
@@ -137,7 +137,7 @@ function attach_appliance_diskimage() {
         sudo cp "${appliance_disk_image}" "${disk_image}"
 
         # Attach the appliance disk image and the config ISO 
-        sudo virt-xml ${name} --remove-device --disk 1
+        sudo virt-xml ${name} --remove-device --disk all
         sudo virt-xml ${name} --add-device --disk "${disk_image}",device=disk,target.dev=sda
         sudo virt-xml ${name} --add-device --disk "${config_image_dir}/agentconfig.noarch.iso",device=cdrom,target.dev=${config_image_drive}
         


### PR DESCRIPTION
When running the appliance flow, virt-xml fails when trying to add a new disk with the following [error](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_installer/8487/pull-ci-openshift-installer-master-e2e-agent-compact-ipv4-appliance-diskimage/1802735980159963136#1:build-log.txt%3A17189):
```
+(./agent/06_agent_create_cluster.sh:141): attach_appliance_diskimage(): sudo virt-xml ostest_master_0 --add-device --disk ocp/ostest/appliance.raw_master_0,device=disk,target.dev=sda
ERROR    XML error: target 'sda' duplicated for disk sources '<null>' and '/root/dev-scripts/ocp/ostest/appliance.raw_master_0'
```

The error is raised since the first device in domain xml is an empty cdrom disk:
```
    <disk type='file' device='cdrom'>
      <driver name='qemu' type='raw'/>
      <target dev='sdb' bus='sata'/>
      <readonly/>
      <address type='drive' controller='0' bus='0' target='0' unit='1'/>
    </disk>
```

I.e. only the cdrom disk is removed before attaching the disk image, which is causing the aforementioned error.

Hence, removing 'all' disks (instead of the first one) using virt-xml before attaching the new disks.

Notes:
1. Depends on a fix on release for passing CI: https://github.com/openshift/release/pull/56820
2. Seems the was caused by ansible upgrade:
   * Failed by: https://github.com/openshift-metal3/dev-scripts/pull/1523
   * Fixed on revert: https://github.com/openshift-metal3/dev-scripts/commit/258ee3341819ea76cc9e05fe2a1e07ebd2788fd4
   * Failed again on upgrade: https://github.com/openshift-metal3/dev-scripts/pull/1672