### PR TITLE
METAL-1089: Enable CRB repo in RHEL9

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -87,6 +87,9 @@ case $DISTRO in
       sudo dnf config-manager --set-enabled crb
       sudo dnf -y install epel-release
     elif [[ $DISTRO == "rhel9" ]]; then
+      # NOTE(elfosardo): a valid RHEL subscription is needed to be able to
+      # enable the CRB repository
+      sudo subscription-manager repos --enable codeready-builder-for-rhel-9-$(arch)-rpms
       sudo dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
     fi
     sudo ln -s /usr/bin/python3 /usr/bin/python || true


### PR DESCRIPTION
Starting from RHEL9 some packages (e.g. libvirt-devel) have been moved to the CRB repo, which is not enabled by default. Add the proper command to enable it on RHEL9, noting that a valid subscription is needed for that.