### PR TITLE
Added `-L` flag to curl command

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -162,6 +162,6 @@ if sudo systemctl is-active docker-distribution.service; then
   sudo systemctl disable --now docker-distribution.service
 fi
 
-retry_with_timeout 5 60 "curl $OPENSHIFT_CLIENT_TOOLS_URL | sudo tar -U -C /usr/local/bin -xzf -"
+retry_with_timeout 5 60 "curl -L $OPENSHIFT_CLIENT_TOOLS_URL | sudo tar -U -C /usr/local/bin -xzf -"
 sudo chmod +x /usr/local/bin/oc
 oc version --client -o json


### PR DESCRIPTION
Trying a deployment I reached this error while downloading oc client:

```
   gzip: stdin: unexpected end of file
    tar: Child returned status 1
    tar: Error is not recoverable: exiting now
    +(utils.sh:22): retry_with_timeout(): exit_code=2
    +(utils.sh:23): retry_with_timeout(): ((  exit_code == 0  ))
    +(utils.sh:20): retry_with_timeout(): for _ in $(seq "$retries")
    +(utils.sh:21): retry_with_timeout(): exit_code=0
    +(utils.sh:22): retry_with_timeout(): timeout 60 bash -c 'curl https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz | sudo tar -U -C /usr/local/bin -xzf -'
      % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                     Dload  Upload   Total   Spent    Left  Speed
      0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  
    gzip: stdin: unexpected end of file
    tar: Child returned status 1
    tar: Error is not recoverable: exiting now
    +(utils.sh:22): retry_with_timeout(): exit_code=2
    +(utils.sh:23): retry_with_timeout(): ((  exit_code == 0  ))
    +(utils.sh:28): retry_with_timeout(): return 2
    +(./01_install_requirements.sh:1): removetmp
    +(utils.sh:862): removetmp(): '[' -n ' /tmp/test-token--Akii0gciHA' ']'
    +(utils.sh:862): removetmp(): rm -rf /tmp/test-token--Akii0gciHA
  stdout_lines: <omitted>
```

Trying to troubleshooting manually, it seems that the problem came from the missing redirection:

Failing command:
```
$ curl  https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz | sudo tar -U -C /var/tmp -xvzf -
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0

gzip: stdin: unexpected end of file
tar: Child returned status 1
tar: Error is not recoverable: exiting now

```

Headers retrieved from curl:

```
$ curl -I https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz
HTTP/2 307 
content-length: 0
location: https://2209d6dda25891dee55b086a469130de.r2.cloudflarestorage.com/art-srv-enterprise/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz?response-content-disposition=attachment%3B%20filename%3D%22openshift-client-linux.tar.gz%22&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=36cc88a3d563d343cfdd69cbe5af624a%2F20240718%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240718T165702Z&X-Amz-Expires=1200&X-Amz-SignedHeaders=host&X-Amz-Signature=e704677c86c5d4959d5f5be1638623ee09162038064e19abba7f6b3e35c1ecdd
server: CloudFront
date: Thu, 18 Jul 2024 16:57:02 GMT
x-cache: LambdaGeneratedResponse from cloudfront
via: 1.1 0d0af2eea2f20e46e2262385b289cbae.cloudfront.net (CloudFront)
x-amz-cf-pop: TLV50-C2
x-amz-cf-id: E5hU4jBCg70lVlL1E_DCzwrhQCGNTLePRyv0S-ynNw0vwkLGHaGwyA==
```

Adding `-L` to curl command should solve the issue. (I've added `-v` to tar and silenced the curl output with `-s`)
```
$ curl -sL https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz | sudo tar -U -C /var/tmp -xvzf -
README.md
oc
kubectl
```
Signed-off-by: Roberto Alfieri <ralfieri@redhat.com>
