### PR TITLE
use -L (--location) for "curl openshift client" command

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -162,6 +162,6 @@ if sudo systemctl is-active docker-distribution.service; then
   sudo systemctl disable --now docker-distribution.service
 fi
 
-retry_with_timeout 5 60 "curl $OPENSHIFT_CLIENT_TOOLS_URL | sudo tar -U -C /usr/local/bin -xzf -"
+retry_with_timeout 5 60 "curl -L $OPENSHIFT_CLIENT_TOOLS_URL | sudo tar -U -C /usr/local/bin -xzf -"
 sudo chmod +x /usr/local/bin/oc
 oc version --client -o json


### PR DESCRIPTION
It happens that openshift-client tar.gz file URL returns http code 307 (temporary redirect) yet curl downloads 0bytes size file anyway causing the command to fail.

> GET /pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz HTTP/2
> Host: mirror.openshift.com
> User-Agent: curl/8.2.1
> Accept: */*
>
{ [5 bytes data]
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4): { [124 bytes data]
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0< HTTP/2 307

When curl run with -L (--location) it is able to fetch the correct file.