### PR TITLE
Run subscription-manager command when system is subscribed

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -88,9 +88,13 @@ case $DISTRO in
       sudo dnf config-manager --set-enabled crb
       sudo dnf -y install epel-release
     elif [[ $DISTRO == "rhel9" ]]; then
-      # NOTE(elfosardo): a valid RHEL subscription is needed to be able to
-      # enable the CRB repository
-      sudo subscription-manager repos --enable codeready-builder-for-rhel-9-$(arch)-rpms
+      # NOTE(raukadah): If a system is subscribed to RHEL subscription then
+      # sudo subscription-manager identity will return exit 0 else 1.
+      if $(sudo subscription-manager identity > /dev/null 2>&1); then
+	# NOTE(elfosardo): a valid RHEL subscription is needed to be able to
+	# enable the CRB repository
+	sudo subscription-manager repos --enable codeready-builder-for-rhel-9-$(arch)-rpms
+      fi
       sudo dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
     fi
     sudo ln -s /usr/bin/python3 /usr/bin/python || true


### PR DESCRIPTION
https://github.com/openshift-metal3/dev-scripts/pull/1674 enables CRB repos on RHEL using subscription-manager.

RHEL system might not be subscribed to subscription-manager. The system might be using custom repos to install libvirt-devel package. Then dev-scripts installation will fail.

In order to fix it. We can use subscription-manager identity command to check the system status. If a system is subscribed to subscription manager, then exit status will be 0 else 1.

Below is the example for the same:
A system is subscribed with subscription-manager:
```
[zuul@ospci-baremetal-01 ~]$ sudo subscription-manager identity
system identity: xxx
name: xxx
org name: xxx
org ID: xxx
[zuul@ospci-baremetal-01 ~]$ echo $?
0
```
A system with no subscrition:
```
[root@ospci-baremetal-02 ~]# subscription-manager identity
This system is not yet registered. Try 'subscription-manager register --help' for more information.
[root@ospci-baremetal-02 ~]# echo $?
1
```