### PR TITLE
Remove unwanted $

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -90,7 +90,7 @@ case $DISTRO in
     elif [[ $DISTRO == "rhel9" ]]; then
       # NOTE(raukadah): If a system is subscribed to RHEL subscription then
       # sudo subscription-manager identity will return exit 0 else 1.
-      if $(sudo subscription-manager identity > /dev/null 2>&1); then
+      if sudo subscription-manager identity > /dev/null 2>&1; then
 	# NOTE(elfosardo): a valid RHEL subscription is needed to be able to
 	# enable the CRB repository
 	sudo subscription-manager repos --enable codeready-builder-for-rhel-9-$(arch)-rpms


### PR DESCRIPTION
The existing code works a bit accidentally, because the command output is ignored anyway. If there would be no output redirection to /dev/null, then the command would always fail with something like ~"Command not found: This system is not yet registered".

Details: https://www.shellcheck.net/wiki/SC2091