### PR TITLE
Remove ipa-downloader leftovers

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -200,7 +200,6 @@ if [ "${UPSTREAM_IRONIC:-false}" != "false" ] ; then
     if is_lower_version $OPENSHIFT_VERSION 4.9; then
         export IRONIC_INSPECTOR_LOCAL_IMAGE=${IRONIC_INSPECTOR_LOCAL_IMAGE:-"quay.io/metal3-io/ironic-inspector:master"}
     fi
-    export IRONIC_IPA_DOWNLOADER_LOCAL_IMAGE=${IRONIC_IPA_DOWNLOADER_LOCAL_IMAGE:-"quay.io/metal3-io/ironic-ipa-downloader:master"}
     export IRONIC_STATIC_IP_MANAGER_LOCAL_IMAGE=${IRONIC_STATIC_IP_MANAGER_LOCAL_IMAGE:-"quay.io/metal3-io/static-ip-manager"}
     export BAREMETAL_OPERATOR_LOCAL_IMAGE=${BAREMETAL_OPERATOR_LOCAL_IMAGE:-"quay.io/metal3-io/baremetal-operator"}
 fi


### PR DESCRIPTION
The ironic-ipa-downloader container has been removed since OCP 4.10