### PR TITLE
OCPQE-24202: Temporary hack to update baremetalvm.xml.j2

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -20,6 +20,10 @@ if [ -z "${METAL3_DEV_ENV}" ]; then
   # Note we only do this in the case where METAL3_DEV_ENV is
   # unset, to enable developer testing of local checkouts
   git reset ac63b3dcd04796dcec6b71d4fedd4ad8e043688f --hard
+
+  # Ref commit: 62be8305720509325000e89d2ca4d80b795421fb
+  sed -i 's/virt-rhel8.2.0/virt/' vm-setup/roles/libvirt/templates/baremetalvm.xml.j2
+
   popd
 fi
 


### PR DESCRIPTION
metal3-dev-env is hard reset to an old commit hash to avoid disruption in testing. Adding a temporary workaround ( till fix in PR https://github.com/metal3-io/metal3-dev-env/pull/1442 is effective)