### PR TITLE
Update metal3-dev-env hash and remove  yet another hack

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -19,10 +19,7 @@ if [ -z "${METAL3_DEV_ENV}" ]; then
   # TODO -- come up with a plan for continuously updating this
   # Note we only do this in the case where METAL3_DEV_ENV is
   # unset, to enable developer testing of local checkouts
-  git reset 868665523cb10ce723bce48ea4e9b22edcd68f68 --hard
-
-  # Ref commit: 62be8305720509325000e89d2ca4d80b795421fb
-  sed -i 's/virt-rhel8.2.0/virt/' vm-setup/roles/libvirt/templates/baremetalvm.xml.j2
+  git reset 62be8305720509325000e89d2ca4d80b795421fb --hard
 
   popd
 fi


### PR DESCRIPTION
New hash is from commit
https://github.com/metal3-io/metal3-dev-env/commit/62be8305720509325000e89d2ca4d80b795421fb
that fixes an issue with bm vm xml libvirt template