### PR TITLE
Fix issue with OVMF_CODE.fd symlink

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -156,7 +156,7 @@ ansible-playbook \
 # NOTE(elfosardo): /usr/share/OVMF/OVMF_CODE.fd does not exist in the ovmf
 # package anymore, so we need to create a link to that until metal3-dev-env
 # fixes that, probably when switching to UEFI by default
-if ! [[ -f /usr/share/OVMF/OVMF_CODE.fd ]]; then
+if ! [[ -f /usr/share/OVMF/OVMF_CODE.fd || -L /usr/share/OVMF/OVMF_CODE.fd ]]; then
   sudo ln -s /usr/share/edk2/ovmf/OVMF_CODE.fd /usr/share/OVMF/
 fi
 


### PR DESCRIPTION
On subsequent runs this will fail because the link has already been created, but it still fails the -f test because it's a link not a file. Since we only care about existence and not the specific type of this file, let's just check for existence with -e instead.