### PR TITLE
OCPBUGS-42528: Day 2 iso name changed to node.x86_64.iso

### DIFF
--- a/agent/07_agent_add_node.sh
+++ b/agent/07_agent_add_node.sh
@@ -35,7 +35,7 @@ oc adm node-image create --dir "$OCP_DIR/add-node/"
 
 for (( n=0; n<${NUM_EXTRA_WORKERS}; n++ ))
 do
-    sudo virt-xml "${CLUSTER_NAME}_extraworker_${n}" --add-device --disk "$OCP_DIR/add-node/node.iso,device=cdrom,target.dev=sdc"
+    sudo virt-xml "${CLUSTER_NAME}_extraworker_${n}" --add-device --disk "$OCP_DIR/add-node/node.x86_64.iso,device=cdrom,target.dev=sdc"
     sudo virt-xml "${CLUSTER_NAME}_extraworker_${n}" --edit target=sda --disk="boot_order=1"
     sudo virt-xml "${CLUSTER_NAME}_extraworker_${n}" --edit target=sdc --disk="boot_order=2" --start
 done


### PR DESCRIPTION
A bug fix to oc changed the filename of the generated node ISO to include the architecture. Previously the name was node.iso. Because the default architecture used in devscripts is x86_64/amd64, the name is now node.x86_64.iso.

Depends on https://github.com/openshift/oc/pull/1887