### PR TITLE
Mount nfs with noac

### DIFF
--- a/06_create_cluster.sh
+++ b/06_create_cluster.sh
@@ -50,6 +50,8 @@ spec:
     path: /opt/dev-scripts/nfsshare/1
     server: $LOCAL_REGISTRY_DNS_NAME
     readOnly: false
+  mountOptions:
+    - noac
 EOF
     oc patch configs.imageregistry.operator.openshift.io \
         cluster --type merge --patch '{"spec":{"storage":{"pvc":{"claim":""}},"managementState":"Managed","replicas": 2}}'


### PR DESCRIPTION
Disable client caching of file attributes and force the writes to become synchronous making local changes to a file become visible on the server immediately.