### PR TITLE
AGENT-966: use oc from current release image

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -6,6 +6,7 @@ source logging.sh
 source common.sh
 source sanitychecks.sh
 source utils.sh
+source ocp_install_env.sh
 source validation.sh
 
 early_deploy_validation true
@@ -170,3 +171,8 @@ fi
 retry_with_timeout 5 60 "curl -L $OPENSHIFT_CLIENT_TOOLS_URL | sudo tar -U -C /usr/local/bin -xzf -"
 sudo chmod +x /usr/local/bin/oc
 oc version --client -o json
+
+if [ "${OPENSHIFT_CLIENT_FROM_RELEASE}" == "true" ]; then
+  extract_oc "${OPENSHIFT_RELEASE_IMAGE}"
+  oc version --client -o json
+fi

--- a/agent/07_agent_add_node.sh
+++ b/agent/07_agent_add_node.sh
@@ -31,7 +31,7 @@ if [ -f $OCP_DIR/add-node/node.iso ]; then
   rm -f $OCP_DIR/add-node/node.iso
 fi
 
-oc adm node-image create --dir "$OCP_DIR/add-node/"
+oc adm node-image create --dir "$OCP_DIR/add-node/" --registry-config "${PULL_SECRET_FILE}"
 
 for (( n=0; n<${NUM_EXTRA_WORKERS}; n++ ))
 do
@@ -52,4 +52,4 @@ set -ex
 
 source "${SCRIPTDIR}/${OCP_DIR}/add-node/extra-workers.env"
 EXTRA_WORKERS_IPS="${EXTRA_WORKERS_IPS%% }"
-oc adm node-image monitor --ip-addresses "${EXTRA_WORKERS_IPS// /,}"  --kubeconfig "$OCP_DIR/auth/kubeconfig"
+oc adm node-image monitor --ip-addresses "${EXTRA_WORKERS_IPS// /,}"  --kubeconfig "$OCP_DIR/auth/kubeconfig" --registry-config "${PULL_SECRET_FILE}"

--- a/common.sh
+++ b/common.sh
@@ -114,6 +114,10 @@ export KNI_INSTALL_FROM_GIT=${KNI_INSTALL_FROM_GIT:-}
 
 export OPENSHIFT_CLIENT_TOOLS_URL=https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz
 
+# Set this variable to extract and use oc from the current release image,
+# instead of using the one retrieved from $OPENSHIFT_CLIENT_TOOLS_URL
+export OPENSHIFT_CLIENT_FROM_RELEASE=${OPENSHIFT_CLIENT_FROM_RELEASE:-false}
+
 # Note: when changing defaults for OPENSHIFT_RELEASE_STREAM, make sure to update
 #       doc in config_example.sh
 export OPENSHIFT_RELEASE_TYPE=${OPENSHIFT_RELEASE_TYPE:-nightly}

--- a/config_example.sh
+++ b/config_example.sh
@@ -210,6 +210,11 @@ set -x
 # for the cluster image-registry
 # export PERSISTENT_IMAGEREG=true
 
+# OPENSHIFT_CLIENT_FROM_RELEASE
+# Default: false
+# Installs the oc cli tool from the currently configured OCP release image.
+# export OPENSHIFT_CLIENT_FROM_RELEASE=true
+
 ################################################################################
 ## Network Settings
 ##


### PR DESCRIPTION
This patch is required to test https://github.com/openshift/installer/pull/9066 

As a rule of thumb, node-joiner patches may require to update as well the related wrapping oc commands (which could be present in CI registries but not yet released to the usual mirror)