### PR TITLE
OCPBUGS-36506: Fix config for disconnected cluster

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -111,6 +111,7 @@ if [[ ! -z "${INSTALLER_PROXY}" ]]; then
     --volume ${WORKING_DIR}/squid.conf:/etc/squid/squid.conf \
     --name ds-squid \
     --dns 127.0.0.1 \
+    --add-host=virthost.ostest.test.metalkube.org:$PROVISIONING_HOST_EXTERNAL_IP \
     quay.io/sameersbn/squid:latest
 fi
 

--- a/06_create_cluster.sh
+++ b/06_create_cluster.sh
@@ -17,6 +17,15 @@ if [[ ! -z "$INSTALLER_PROXY" ]]; then
   export HTTP_PROXY=${HTTP_PROXY}
   export HTTPS_PROXY=${HTTPS_PROXY}
   export NO_PROXY=${NO_PROXY}
+  # Update libvirt firewalld policy to allow the VM to connect to the proxy
+  sudo firewall-cmd --policy=libvirt-to-host --add-port=$INSTALLER_PROXY_PORT/tcp
+  # Allow ironic to talk directly to the virt BMC's without proxy
+  sudo firewall-cmd --policy=libvirt-to-host --add-port=8000/tcp
+  sudo firewall-cmd --policy=libvirt-to-host --add-port=6230-6240/udp
+  # And NFS if used
+  if [ "${PERSISTENT_IMAGEREG}" == true ] ; then
+    sudo firewall-cmd --policy=libvirt-to-host --add-port=2049/tcp
+  fi
 fi
 
 # Call openshift-installer to deploy the bootstrap node and masters

--- a/network.sh
+++ b/network.sh
@@ -204,7 +204,10 @@ if  [[ ! -z "${INSTALLER_PROXY:-}" ]]; then
 
   # When a local registry is enabled (usually in disconnected environments), let's add it to the no proxy list
   if [[ ! -z "${MIRROR_IMAGES}" && "${MIRROR_IMAGES,,}" != "false" ]] || [[ ! -z "${ENABLE_LOCAL_REGISTRY}" ]]; then
-    NO_PROXY=$NO_PROXY,$LOCAL_REGISTRY_DNS_NAME
+    # If INSTALLER_PROXY has been set, all traffic must go via the proxy (the bm network has no access)
+    if [[ ${INSTALLER_PROXY:-false} == "false" ]]; then
+      NO_PROXY=$NO_PROXY,$LOCAL_REGISTRY_DNS_NAME
+    fi
   fi
 fi
 


### PR DESCRIPTION
Ensure all but BMC traffic goes via the proxy