### PR TITLE
NO-JIRA: revert #1706

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -6,7 +6,6 @@ source logging.sh
 source common.sh
 source sanitychecks.sh
 source utils.sh
-source ocp_install_env.sh
 source validation.sh
 
 early_deploy_validation true
@@ -171,8 +170,3 @@ fi
 retry_with_timeout 5 60 "curl -L $OPENSHIFT_CLIENT_TOOLS_URL | sudo tar -U -C /usr/local/bin -xzf -"
 sudo chmod +x /usr/local/bin/oc
 oc version --client -o json
-
-if [ "${OPENSHIFT_CLIENT_FROM_RELEASE}" == "true" ]; then
-  extract_oc "${OPENSHIFT_RELEASE_IMAGE}"
-  oc version --client -o json
-fi

--- a/agent/07_agent_add_node.sh
+++ b/agent/07_agent_add_node.sh
@@ -3,6 +3,8 @@ set -euxo pipefail
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
+LOGDIR=${SCRIPTDIR}/logs
+source $SCRIPTDIR/logging.sh
 source $SCRIPTDIR/common.sh
 source $SCRIPTDIR/network.sh
 source $SCRIPTDIR/ocp_install_env.sh

--- a/common.sh
+++ b/common.sh
@@ -114,10 +114,6 @@ export KNI_INSTALL_FROM_GIT=${KNI_INSTALL_FROM_GIT:-}
 
 export OPENSHIFT_CLIENT_TOOLS_URL=https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz
 
-# Set this variable to extract and use oc from the current release image,
-# instead of using the one retrieved from $OPENSHIFT_CLIENT_TOOLS_URL
-export OPENSHIFT_CLIENT_FROM_RELEASE=${OPENSHIFT_CLIENT_FROM_RELEASE:-false}
-
 # Note: when changing defaults for OPENSHIFT_RELEASE_STREAM, make sure to update
 #       doc in config_example.sh
 export OPENSHIFT_RELEASE_TYPE=${OPENSHIFT_RELEASE_TYPE:-nightly}

--- a/config_example.sh
+++ b/config_example.sh
@@ -210,11 +210,6 @@ set -x
 # for the cluster image-registry
 # export PERSISTENT_IMAGEREG=true
 
-# OPENSHIFT_CLIENT_FROM_RELEASE
-# Default: false
-# Installs the oc cli tool from the currently configured OCP release image.
-# export OPENSHIFT_CLIENT_FROM_RELEASE=true
-
 ################################################################################
 ## Network Settings
 ##


### PR DESCRIPTION
Reverting the previous patch as the `OPENSHIFT_CLIENT_FROM_RELEASE` was broken and not required (since step 03 already extracts the oc tool from the release image).

Also, adding missed statements for properly logging the new agent step 07 (for adding nodes)