### PR TITLE
NO-JIRA: increase log level for day2 add nodes commands

### DIFF
--- a/agent/07_agent_add_node.sh
+++ b/agent/07_agent_add_node.sh
@@ -33,7 +33,7 @@ if [ -f $OCP_DIR/add-node/node.iso ]; then
   rm -f $OCP_DIR/add-node/node.iso
 fi
 
-oc adm node-image create --dir "$OCP_DIR/add-node/" --registry-config "${PULL_SECRET_FILE}"
+oc adm node-image create --dir "$OCP_DIR/add-node/" --registry-config "${PULL_SECRET_FILE}" --loglevel=2
 
 for (( n=0; n<${NUM_EXTRA_WORKERS}; n++ ))
 do
@@ -54,4 +54,4 @@ set -ex
 
 source "${SCRIPTDIR}/${OCP_DIR}/add-node/extra-workers.env"
 EXTRA_WORKERS_IPS="${EXTRA_WORKERS_IPS%% }"
-oc adm node-image monitor --ip-addresses "${EXTRA_WORKERS_IPS// /,}"  --kubeconfig "$OCP_DIR/auth/kubeconfig" --registry-config "${PULL_SECRET_FILE}"
+oc adm node-image monitor --ip-addresses "${EXTRA_WORKERS_IPS// /,}" --registry-config "${PULL_SECRET_FILE}" --loglevel=2


### PR DESCRIPTION
This patch increases the `oc adm node-image ...` commands loglevel to help troubleshooting CI jobs failures