### PR TITLE
Fix undefined variable in cleanup

### DIFF
--- a/agent/cleanup.sh
+++ b/agent/cleanup.sh
@@ -21,7 +21,7 @@ if [[ "${AGENT_E2E_TEST_BOOT_MODE}" == "DISKIMAGE" ]]; then
     sudo podman rmi -f ${APPLIANCE_IMAGE} || true
 fi
 
-if [[ -d ${BOOT_SERVER_DIR} ]]; then
+if [[ -n ${BOOT_SERVER_DIR:-} && -d ${BOOT_SERVER_DIR} ]]; then
    sudo pkill agentpxeserver || true
    rm -rf ${BOOT_SERVER_DIR}
 fi


### PR DESCRIPTION
This variable is not always defined and it's currently causing make clean to fail in non-agent use cases.