### PR TITLE
AGENT-963: make target to remove extraworker nodes from cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ agent: agent_requirements requirements configure agent_build_installer agent_pre
 
 # Deploy cluster with agent installer flow and adds nodes after initial install
 # Requires at least 1 extra worker node to be configured with disk size at least 100Gß
-agent_plus_add_node: agent agent_add_node
+agent_plus_add_node: agent agent_add_extraworker_nodes
 
 agent_requirements:
 	./agent/01_agent_requirements.sh
@@ -37,8 +37,11 @@ agent_gather:
 agent_tests:
 	./agent/agent_tests.sh
 
-agent_add_node:
-	./agent/07_agent_add_node.sh
+agent_add_extraworker_nodes:
+	./agent/07_agent_add_extraworker_nodes.sh
+
+agent_remove_extraworker_nodes:
+	./agent/agent_remove_all_extraworker_nodes.sh
 
 agent_post_install_validation:
 	./agent/agent_post_install_validation.sh

--- a/agent/07_agent_add_extraworker_nodes.sh
+++ b/agent/07_agent_add_extraworker_nodes.sh
@@ -1,4 +1,25 @@
 #!/usr/bin/env bash
+#
+# This scripts adds extraworker nodes to the cluster.
+# The number of extraworker nodes is defined through
+# NUM_EXTRA_WORKERS.
+#
+# The nodes can be added either through booting with
+# ISO or through the network using PXE if
+# AGENT_E2E_TEST_BOOT_MODE=PXE.
+#
+# The ISO or PXE artifacts are generated using
+#   oc adm node-image create
+#
+# After the nodes are booted, their installation progress
+# is monitored through
+#   oc adm node-image monitor
+#
+# To remove the nodes added by this script from the
+# cluster, use agent_remove_node.sh or run
+#   make agent_remove_node
+#
+
 set -euxo pipefail
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
@@ -54,7 +75,7 @@ case "${AGENT_E2E_TEST_BOOT_MODE}" in
     # Copy the generated PXE artifacts in the tftp server location
     # The local http server should be running and was started by
     # day 1 installtion.
-    cp $OCP_DIR/add-node//boot-artifacts/* ${PXE_SERVER_DIR}
+    cp $OCP_DIR/add-node//boot-artifacts/* ${BOOT_SERVER_DIR}
 
     agent_pxe_boot extraworker $NUM_EXTRA_WORKERS
     ;;

--- a/agent/agent_remove_all_extraworker_nodes.sh
+++ b/agent/agent_remove_all_extraworker_nodes.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# This script removes extraworker nodes from the cluster.
+#
+# Each node is first cordoned or marked as unschedulable.
+# The node is then drained and deleted from the cluster.
+# The VM is then shutdown.
+#
+# To refresh the VM so that it can be reused to add
+# a new node, its disk is reinitialized to be empty
+# and the agent ISO mounted as a cdrom is removed.
+#
+# In this way, one can repeated run
+#
+#   make agent_add_node
+#   make agent_remove_node
+#
+# to add and remove extraworker nodes. This provides
+# an easy way to test adding nodes during day 2.
+#
+
+set -euo pipefail
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+
+source $SCRIPTDIR/common.sh
+
+export KUBECONFIG=$OCP_DIR/auth/kubeconfig
+
+for (( n=0; n<${NUM_EXTRA_WORKERS}; n++ ))
+do
+    node="extraworker-${n}"
+    nodeLibvirt="${CLUSTER_NAME}_extraworker_${n}"
+    oc adm cordon "$node" || true
+    oc adm drain "$node" --force --ignore-daemonsets || true
+    oc delete node "$node" || true
+    sudo virsh destroy "$nodeLibvirt" || true
+
+    sleep 5s
+
+    sudo qemu-img create -f qcow2 "/opt/dev-scripts/pool/${nodeLibvirt}.qcow2" 100G || true
+    sudo virt-xml "$nodeLibvirt" --remove-device --disk target=sdc || true
+done
+ 


### PR DESCRIPTION
Adds a new target to remove all extraworker nodes:

make agent_remove_node

The nodes are deleted from the cluster. The VM is then shutdown and its disk reinitialized to be empty. Any agent ISO attached as /dev/sdc is also removed.

The extraworker nodes can be added back to the cluster by running:

make agent_add_node

They can be repeated added and removed using these two make targets.