### PR TITLE
NO-JIRA: skip the add nodes step if no additional workers are defined

### DIFF
--- a/agent/05_agent_configure.sh
+++ b/agent/05_agent_configure.sh
@@ -331,13 +331,18 @@ function generate_cluster_manifests() {
 }
 
 function write_extra_workers_ips() {
+  # not required in case no additional workers were defined
+  if [ "${NUM_EXTRAWORKERS:-0}" -eq 0 ]; then
+    return
+  fi
+
   # write extra worker IP addresses out to file, so that it can be used by 07_agent_add_node.sh
   if [[ "$IP_STACK" = "v6" ]]; then
     extra_workers_ips_space_delimited=$(printf '%s ' "${AGENT_EXTRA_WORKERS_IPSV6[@]}")
   else
     extra_workers_ips_space_delimited=$(printf '%s ' "${AGENT_EXTRA_WORKERS_IPS[@]}")
   fi
-  mkdir -p "${SCRIPTDIR}/${OCP_DIR}/add-node/"
+  
   echo "EXTRA_WORKERS_IPS=\"${extra_workers_ips_space_delimited}\"" > "${SCRIPTDIR}/${OCP_DIR}/add-node/extra-workers.env"
 }
 

--- a/agent/07_agent_add_extraworker_nodes.sh
+++ b/agent/07_agent_add_extraworker_nodes.sh
@@ -50,6 +50,11 @@ function approve_csrs() {
   done
 }
 
+# not required in case no additional workers were defined
+if [ "${NUM_EXTRAWORKERS:-0}" -eq 0 ]; then
+  exit 0
+fi
+
 # oc node-image commands are supported only in 4.17+
 if is_lower_version "$(openshift_version "${OCP_DIR}")" "4.17" ]]; then
   echo "Skipping extraworker add nodes step"    


### PR DESCRIPTION
This patch skips the 07 step in case no extra workers are present.
