### PR TITLE
AGENT-1127: Add ability to test operator configuration with ABI

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -409,6 +409,9 @@ export AGENT_BOOT_SERVER_PORT=${AGENT_BOOT_SERVER_PORT:-8089}
 # Enable MCE deployment
 export AGENT_DEPLOY_MCE=${AGENT_DEPLOY_MCE:-}
 
+# Test of agent operators
+export AGENT_OPERATORS=${AGENT_OPERATORS:-""}
+
 if [[ ! -z ${AGENT_E2E_TEST_SCENARIO} ]]; then
   IFS='_'
   read -a arr <<<"$AGENT_E2E_TEST_SCENARIO"
@@ -473,6 +476,10 @@ if [[ ! -z ${AGENT_E2E_TEST_SCENARIO} ]]; then
       *)
         invalidAgentValue
   esac
+
+  if [[ "$AGENT_OPERATORS" =~ "mtv" ]]; then
+     export MASTER_VCPU=9
+  fi
 
   if [ ! -z "${AGENT_DEPLOY_MCE}" ]; then
     # Assisted service will require at least two local volumes

--- a/config_example.sh
+++ b/config_example.sh
@@ -882,3 +882,11 @@ set -x
 # be used.
 #
 # export AGENT_ROOT_DEVICE_HINTS=""
+
+# AGENT_OPERATORS
+# Default: Undefined
+#
+# This takes a comma-separated list of operators to install which will be configured
+# when registering the assisted-service.
+#
+# export AGENT_OPERATORS=""


### PR DESCRIPTION
Add a new export - AGENT_OPERATORS - that can take a comma-separated list of operators. The operator list will be stored in a file and pushed to the rendezvous node when it is up so that it can be configured in assisted-service by the agent installer client.