### PR TITLE
OCPEDGE-1645: fix: change node role arbiter logic

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -85,7 +85,7 @@ case $DISTRO in
     ;;
   "centos9"|"rhel9"|"almalinux9"|"rocky9")
     sudo dnf -y install python3-pip
-    if [[ $DISTRO == "centos9" || $DISTRO=="almalinux9" || $DISTRO == "rocky9" ]] ; then
+    if [[ $DISTRO == "centos9" || $DISTRO == "almalinux9" || $DISTRO == "rocky9" ]] ; then
       sudo dnf config-manager --set-enabled crb
       sudo dnf -y install epel-release
     elif [[ $DISTRO == "rhel9" ]]; then

--- a/utils.sh
+++ b/utils.sh
@@ -237,7 +237,7 @@ function node_map_to_install_config_hosts() {
       name=$(node_val ${idx} "name")
       mac=$(node_val ${idx} "ports[0].address")
       local node_role=$role
-      if [[ ! -z "${ENABLE_ARBITER:-}" && $name =~ "arbiter" && "$role" == "master" ]]; then
+      if [[ ! -z "${ENABLE_ARBITER:-}" && $idx -eq $(($num_hosts + $start_idx - 1)) && "$role" == "master" ]]; then
         node_role=arbiter
       fi
 


### PR DESCRIPTION
changed the node role to be applied on index count and not on name, in ci the host name can be anything so we need to trigger based off of the order.