### PR TITLE
Increase memory for agent installer 4 and 5 node tests

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -430,14 +430,14 @@ if [[ ! -z ${AGENT_E2E_TEST_SCENARIO} ]]; then
           export NUM_MASTERS=5
           export MASTER_VCPU=4
           export MASTER_DISK=100
-          export MASTER_MEMORY=16384
+          export MASTER_MEMORY=24576
           export NUM_WORKERS=0
           ;;
       "4CONTROL" )
           export NUM_MASTERS=4
           export MASTER_VCPU=4
           export MASTER_DISK=100
-          export MASTER_MEMORY=16384
+          export MASTER_MEMORY=24576
           export NUM_WORKERS=0
           ;;
       "COMPACT" )


### PR DESCRIPTION
Increase the memory for these tests and they are failing in 4.19 with "no space left on device".