### PR TITLE
agent: use release 'url' in ApplianceConfig

### DIFF
--- a/agent/roles/manifests/templates/appliance-config_yaml.j2
+++ b/agent/roles/manifests/templates/appliance-config_yaml.j2
@@ -2,11 +2,8 @@ apiVersion: v1beta1
 kind: ApplianceConfig
 ocpRelease:
   version: {{ version }}
-  channel: candidate
-  cpuArchitecture: {{ ansible_architecture }}
+  url: {{ image }} 
 diskSizeGB: 200
 pullSecret: {{ pull_secret_contents }}
 sshKey: {{ ssh_pub_key }}
-imageRegistry:
-  uri: quay.io/libpod/registry:2.8
 userCorePass: core


### PR DESCRIPTION
The appliance now supports using a release image URL: https://github.com/openshift/appliance/pull/352
Hence, we can now use a nightly/ci release url in the ApplianceConfig template.
Also no need for 'imageRegistry' as the appliance now builds the registry internally: https://github.com/openshift/appliance/pull/349
