### PR TITLE
NO-ISSUE: fix extra worker step

### DIFF
--- a/agent/05_agent_configure.sh
+++ b/agent/05_agent_configure.sh
@@ -336,7 +336,7 @@ function generate_cluster_manifests() {
 
 function write_extra_workers_ips() {
   # not required in case no additional workers were defined
-  if [ "${NUM_EXTRAWORKERS:-0}" -eq 0 ]; then
+  if [ "${NUM_EXTRA_WORKERS:-0}" -eq 0 ]; then
     return
   fi
 

--- a/agent/07_agent_add_extraworker_nodes.sh
+++ b/agent/07_agent_add_extraworker_nodes.sh
@@ -51,7 +51,7 @@ function approve_csrs() {
 }
 
 # not required in case no additional workers were defined
-if [ "${NUM_EXTRAWORKERS:-0}" -eq 0 ]; then
+if [ "${NUM_EXTRA_WORKERS:-0}" -eq 0 ]; then
   exit 0
 fi
 


### PR DESCRIPTION
This patch fixes the typo inserted in the previous commit [9f27423](https://github.com/openshift-metal3/dev-scripts/commit/9f274238c53f0882844487cc5eb94f2b66e0bf9e) preventing the execution of the step 07 as expected