### PR TITLE
AGENT-1108: Gather console screenshots as part of agent-gather

### DIFF
--- a/agent/06_agent_create_cluster.sh
+++ b/agent/06_agent_create_cluster.sh
@@ -300,6 +300,10 @@ function run_agent_test_cases() {
     local version="$(openshift_version ${OCP_DIR})"
     ./agent/e2e/agent-tui/test-fix-wrong-dns.sh $CLUSTER_NAME $PROVISIONING_HOST_EXTERNAL_IP $version
 
+    # Take screenshot of the console after fixing DNS to see if the agent_tui
+    # has exited.
+    sudo virsh screenshot $name "${OCP_DIR}/${name}_console_screenshot_after_dns_fix.ppm"
+
     echo "Finished fixing DNS through agent-tui"
   fi
 }

--- a/agent/gather.sh
+++ b/agent/gather.sh
@@ -21,3 +21,11 @@ do
     fi
 done < "${OCP_DIR}"/hosts
 
+num_screenshots=$(find "${OCP_DIR}" -type f -name "*.ppm" | wc -l)
+if [[ "$num_screenshots" -gt 0 ]]; then
+    archive_name="agent-gather-console-screenshots.tar.xz"
+    echo "Gathering console screenshots to $archive_name"
+    tar -cJf $archive_name ${OCP_DIR}/*.ppm
+else
+    echo "No console screenshots found. Skipping screenshot gather."
+fi


### PR DESCRIPTION
The screenshots can aid in diagnosing issues in agent-tui. Currently they are saved in $OCP_DIR but aren't being archived by agent-gather.

Adds a screenshot after the bad_dns fix is applied to verify the dns configuration was changed correctly.