### PR TITLE
NO-ISSUE: Code restructure

### DIFF
--- a/agent/06_agent_create_cluster.sh
+++ b/agent/06_agent_create_cluster.sh
@@ -298,7 +298,7 @@ function run_agent_test_cases() {
     echo "Fixing DNS through agent-tui"
     # call script to fix DNS IP address on master-0
     local version="$(openshift_version ${OCP_DIR})"
-    ./agent/e2e/agent-tui/test-fix-wrong-dns.sh $CLUSTER_NAME $PROVISIONING_HOST_EXTERNAL_IP $version
+    ./agent/e2e/agent-tui/test-fix-wrong-dns.sh $PROVISIONING_HOST_EXTERNAL_IP $version
 
     echo "Finished fixing DNS through agent-tui"
   fi

--- a/agent/e2e/agent-tui/test-fix-wrong-dns.sh
+++ b/agent/e2e/agent-tui/test-fix-wrong-dns.sh
@@ -1,87 +1,13 @@
 #!/bin/bash
 
-source common.sh
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../.." && pwd )"
+
+source $SCRIPTDIR/common.sh
+source $SCRIPTDIR/agent/e2e/agent-tui/utils.sh
 set +x
 
-CLUSTER_NAME=$1
-GOOD_DNS_IP=$2
-OCP_VERSION=$3
-
-### utils function for sending various keys and/or text to the console
-
-function _pressKey() {
-  local keyCode=$@
-
-  name=${CLUSTER_NAME}_master_0
-  sudo virsh send-key $name $keyCode
-
-  # On some CI instances, the sequence of events appears to be too fast
-  # for the console refresh, leading the test in the wrong state.
-  # Let's add a small pause between one keypress event and the subsequent
-  sleep 1
-}
-
-function pressKey() {
-  local msg=$1
-  local keyCode=$2
-  local numReps=1
-
-  if [ ! -z "$3" ]; then
-    numReps=$3
-    echo "$msg ($numReps)"
-  else
-    echo $msg
-  fi	
-  
-  for i in $(seq 1 $numReps); do
-    _pressKey $keyCode
-  done
-}
-
-function pressEnter() {
-  pressKey "$1" KEY_ENTER "$2"
-}
-
-function pressTab() {
-  pressKey "$1" KEY_TAB "$2"
-}	
-
-function pressDown() {
-  pressKey "$1" KEY_DOWN "$2"
-}
-
-function pressBackspace() {
-  pressKey "$1" KEY_BACKSPACE "$2"
-}
-
-
-function pressEsc() {
-  pressKey "$1" KEY_ESC "$2"
-}
-
-function pressKeys(){
-  local msg=$1
-  local text=$2
-
-  echo $msg
-
-  local reNumber='[0-9]'
-  local reUpperText='[A-Z]'
-  for (( i=0; i<${#text}; i++ )); do
-    local c=${text:$i:1}
-
-    if [[ $c =~ ['a-z'] ]]; then
-      c=$(echo $c | tr '[:lower:]' '[:upper:]')
-    elif [[ $c =~ ['\.'] ]]; then
-      c="DOT"
-    elif [[ $c =~ [':'] ]]; then
-      c="LEFTSHIFT KEY_SEMICOLON"
-    fi
-
-    local keyCode="KEY_"$c
-    _pressKey $keyCode
-  done
-}
+GOOD_DNS_IP=$1
+OCP_VERSION=$2
 
 ### Prereq: create an agent ISO using an incorrect DNS address in the agent-config.yaml
 ### This can be done by setting AGENT_E2E_TEST_TUI_BAD_DNS to true in config_<user>.sh

--- a/agent/e2e/agent-tui/utils.sh
+++ b/agent/e2e/agent-tui/utils.sh
@@ -1,0 +1,76 @@
+
+### utils function for sending various keys and/or text to the console
+
+function _pressKey() {
+  local keyCode=$@
+
+  name=${CLUSTER_NAME}_master_0
+  sudo virsh send-key $name $keyCode
+
+  # On some CI instances, the sequence of events appears to be too fast
+  # for the console refresh, leading the test in the wrong state.
+  # Let's add a small pause between one keypress event and the subsequent
+  sleep 1
+}
+
+function pressKey() {
+  local msg=$1
+  local keyCode=$2
+  local numReps=1
+
+  if [ ! -z "$3" ]; then
+    numReps=$3
+    echo "$msg ($numReps)"
+  else
+    echo $msg
+  fi	
+  
+  for i in $(seq 1 $numReps); do
+    _pressKey $keyCode
+  done
+}
+
+function pressEnter() {
+  pressKey "$1" KEY_ENTER "$2"
+}
+
+function pressTab() {
+  pressKey "$1" KEY_TAB "$2"
+}	
+
+function pressDown() {
+  pressKey "$1" KEY_DOWN "$2"
+}
+
+function pressBackspace() {
+  pressKey "$1" KEY_BACKSPACE "$2"
+}
+
+
+function pressEsc() {
+  pressKey "$1" KEY_ESC "$2"
+}
+
+function pressKeys(){
+  local msg=$1
+  local text=$2
+
+  echo $msg
+
+  local reNumber='[0-9]'
+  local reUpperText='[A-Z]'
+  for (( i=0; i<${#text}; i++ )); do
+    local c=${text:$i:1}
+
+    if [[ $c =~ ['a-z'] ]]; then
+      c=$(echo $c | tr '[:lower:]' '[:upper:]')
+    elif [[ $c =~ ['\.'] ]]; then
+      c="DOT"
+    elif [[ $c =~ [':'] ]]; then
+      c="LEFTSHIFT KEY_SEMICOLON"
+    fi
+
+    local keyCode="KEY_"$c
+    _pressKey $keyCode
+  done
+}


### PR DESCRIPTION
- Moved utility functions ( to be reused for iso-builder) into agent/e2e/agent-tui/utils.sh
- No need to pass CLUSTER_NAME to test-fix-wrong-dns.sh as its a global var