### PR TITLE
AGENT-1134: Dev-scripts support to build OVE ISO

### DIFF
--- a/agent/03_agent_build_installer.sh
+++ b/agent/03_agent_build_installer.sh
@@ -8,6 +8,11 @@ source $SCRIPTDIR/logging.sh
 source $SCRIPTDIR/common.sh
 source $SCRIPTDIR/agent/common.sh
 
+# Temporarily skip building the agent installer in case of OVE ISO
+if [[ "${AGENT_E2E_TEST_BOOT_MODE}" == "ISO_NO_REGISTRY" ]]; then
+    exit 0
+fi
+
 # Override build tags
 export OPENSHIFT_INSTALLER_BUILD_TAGS=" "
 

--- a/agent/04_agent_prepare_release.sh
+++ b/agent/04_agent_prepare_release.sh
@@ -13,6 +13,11 @@ source $SCRIPTDIR/agent/common.sh
 source $SCRIPTDIR/ocp_install_env.sh
 source $SCRIPTDIR/oc_mirror.sh
 
+# Temporarily skip preparing the custom local release in case of OVE ISO
+if [[ "${AGENT_E2E_TEST_BOOT_MODE}" == "ISO_NO_REGISTRY" ]]; then
+    exit 0
+fi
+
 # To replace an image entry in the openshift release image, set <ENTRYNAME>_LOCAL_REPO so that:
 # - ENTRYNAME matches an uppercase version of the name in the release image with "-" converted to "_" 
 # - The var value must point to an already locally cloned repo

--- a/agent/05_agent_configure.sh
+++ b/agent/05_agent_configure.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euxo pipefail
+shopt -s nocasematch
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
@@ -14,6 +15,7 @@ source $SCRIPTDIR/agent/common.sh
 source $SCRIPTDIR/oc_mirror.sh
 
 early_deploy_validation
+mkdir -p $OCP_DIR
 
 export CLUSTER_NAMESPACE=${CLUSTER_NAMESPACE:-"cluster0"}
 
@@ -619,10 +621,11 @@ if [[ "${AGENT_PLATFORM_TYPE}" == "external" ]] || [[ "${AGENT_PLATFORM_TYPE}" =
   set_device_mfg worker $NUM_WORKERS ${AGENT_PLATFORM_TYPE} ${AGENT_PLATFORM_NAME}
 fi
 
-generate_cluster_manifests
+if [[ "${AGENT_E2E_TEST_BOOT_MODE}" != "ISO_NO_REGISTRY" ]] ; then
+  generate_cluster_manifests
 
-generate_extra_cluster_manifests
+  generate_extra_cluster_manifests
 
-write_extra_workers_ips
-
+  write_extra_workers_ips
+fi
 enable_isolated_baremetal_network

--- a/agent/agent_post_install_validation.sh
+++ b/agent/agent_post_install_validation.sh
@@ -5,6 +5,11 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
 source $SCRIPTDIR/common.sh
 
+# Temp code skip the execution flow as cluster is not really installed
+if [[ "${AGENT_E2E_TEST_BOOT_MODE}" == "ISO_NO_REGISTRY" ]]; then
+  exit 0
+fi
+
 installed_control_plane_nodes=$(oc get nodes --selector=node-role.kubernetes.io/master | grep -v AGE | wc -l)
 
 oc get nodes

--- a/agent/common.sh
+++ b/agent/common.sh
@@ -73,3 +73,9 @@ export AGENT_NODE0_IPSV6=${AGENT_NODE0_IPSV6:-}
 
 # Modifies the baremetal network to be fully isolated.
 export AGENT_ISOLATED_NETWORK=${AGENT_ISOLATED_NETWORK:-"false"}
+
+# Set isolated network to true for truely disconnected OVE env
+# in case of agent ISO with no registry 
+if [ "${AGENT_E2E_TEST_BOOT_MODE}" == "ISO_NO_REGISTRY" ] ; then
+    export AGENT_ISOLATED_NETWORK=true
+fi

--- a/agent/e2e/agent-tui/automate-no-registry-agent-tui.sh
+++ b/agent/e2e/agent-tui/automate-no-registry-agent-tui.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../../" && pwd )"
+source $SCRIPTDIR/common.sh
+source $SCRIPTDIR/agent/e2e/agent-tui/utils.sh
+
+set +x
+shopt -s nocasematch
+
+node_name=$1
+
+# The following commands sends key presses through "virsh send-key" to interact
+# with agent-tui
+if [[ "$node_name" == "${AGENT_RENDEZVOUS_NODE_HOSTNAME}" ]]; then
+    pressDown "Save Rendezvous IP" 1 "$node_name"
+    pressDown "This is the rendezvous node" 1 "$node_name"
+    pressEnter "This is the rendezvous node" "" "$node_name"
+    pressEnter "" "" "$node_name"
+    pressEnter "Continue" "" "$node_name"
+else
+    # Retrieves the rendezvousIP and automatically inputs it into the TUI text field
+    # on all other nodes to ensure proper cluster joining.
+    rendezvousIP=$(getRendezvousIP)
+
+    pressKeys "Entering IP address" "$rendezvousIP" "$node_name"
+    pressDown "Save Rendezvous IP" 1 "$node_name"
+    pressEnter "" "" "$node_name"
+    pressEnter "Save and Continue" "" "$node_name"
+fi

--- a/agent/e2e/agent-tui/test-fix-wrong-dns.sh
+++ b/agent/e2e/agent-tui/test-fix-wrong-dns.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../.." && pwd )"
-
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../../" && pwd )"
 source $SCRIPTDIR/common.sh
 source $SCRIPTDIR/agent/e2e/agent-tui/utils.sh
 set +x

--- a/config_example.sh
+++ b/config_example.sh
@@ -794,7 +794,27 @@ set -x
 # This config variable is used only by the agent based installer and is optional.
 # The default value for AGENT_E2E_TEST_BOOT_MODE is 'ISO'.
 # For the openshift-appliance flow, set the boot mode to 'DISKIMAGE'.
-# AGENT_E2E_TEST_BOOT_MODE=PXE
+# To generate PXE assets, set the boot mode to 'PXE'.
+# To generate an ISO that can be used in a disconnected environment 
+# without using a registry a.k.a. OVE ISO, set the boot mode to 'ISO_NO_REGISTRY'.
+# export AGENT_E2E_TEST_BOOT_MODE=ISO
+
+# AGENT_CLEANUP_ISO_BUILDER_CACHE_LOCAL_DEV is an optional environment variable used to trigger
+# cleanup of cached files and other artifacts during local development and is useful when
+# AGENT_E2E_TEST_BOOT_MODE is set to ISO_NO_REGISTRY.
+# AGENT_CLEANUP_ISO_BUILDER_CACHE_LOCAL_DEV is useful for reclaiming disk space when building agent OVE ISO locally
+# by deleting all the files from the working directory, example ocp/ostest/iso_builder except the generated OVE ISO.
+# Set to 'true' to enable the cleanup. 
+# Default behavior (unset or any value other than 'yes') is to skip cleanup.
+# Recommended to set to true for local dev/test purposes and unset in CI.
+# export AGENT_CLEANUP_ISO_BUILDER_CACHE_LOCAL_DEV=false
+
+# Specifies the hostname of the node that should be identified and set as the rendezvous node 
+# during the OVE cluster installation process. This node acts as the bootstrap node in the cluster.
+# Accepts only master nodes.
+# Defaults to "${CLUSTER_NAME}_master_0" where the default CLUSTER_NAME is ostest.
+# export AGENT_RENDEZVOUS_NODE_HOSTNAME="${CLUSTER_NAME:-ostest}_master_1"
+
 
 # Uncomment and set the following value to "true" to enable a test scenario
 # where the DNS is disabled on the hosts by setting its IP address to an incorrect value.

--- a/ocp_cleanup.sh
+++ b/ocp_cleanup.sh
@@ -15,7 +15,7 @@ fi
 if [ -d ${OCP_DIR} ]; then
     ${OCP_DIR}/openshift-install --dir ${OCP_DIR} --log-level=debug destroy bootstrap
     ${OCP_DIR}/openshift-install --dir ${OCP_DIR} --log-level=debug destroy cluster
-    rm -rf ${OCP_DIR}
+    sudo rm -rf "${OCP_DIR}"
 fi
 
 sudo rm -rf /etc/NetworkManager/dnsmasq.d/openshift-${CLUSTER_NAME}.conf


### PR DESCRIPTION
Dev-scripts support to build OVE ISO 

- Reuse **`make agent`** target (instead of introducing a new one)
- Build agent OVE ISO
- Boot up the required VMs
- Set custom rendezvous node (Use **`AGENT_RENDEZVOUS_NODE_HOSTNAME`**) and auto-configure rendezvousIP via TUI
- Take TUI screenshots during install flow
- Verify that the assisted install web UI is running and accessible
- Increase VCPU allocation for certain operators requiring more resources
- Install required dependencies
- Set isolated network to true for truly disconnected OVE env
- Temporarily skip common steps not relevant for OVE ISO installs
- Temporarily skip generating unused manifests and config files
- Reclaim disk space by cleaning up cache and unnecessary files 
(Use `**AGENT_CLEANUP_ISO_BUILDER_CACHE_LOCAL_DEV**` for **local/dev testing only to save the diskspace**) **Not recommended for CI**
----
To test, set as below

   ```
    export AGENT_E2E_TEST_BOOT_MODE=ISO_NO_REGISTRY
    export AGENT_E2E_TEST_SCENARIO=COMPACT_IPV4
    export AGENT_RENDEZVOUS_NODE_HOSTNAME="${CLUSTER_NAME:-ostest}_master_1"
    export AGENT_CLEANUP_ISO_BUILDER_CACHE_LOCAL_DEV=true

    make agent
```

 ISO will be created at
    `ocp/ostest/iso_builder/<OCP_VERSION>/ove/output/agent-ove.x86_64.iso`