### PR TITLE
Pin collections to latest ansible 2.15 compatible versions

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -135,7 +135,9 @@ sudo python -m pip install ansible=="${ANSIBLE_VERSION}"
 
 pushd ${METAL3_DEV_ENV_PATH}
 ansible-galaxy install -r vm-setup/requirements.yml
-ansible-galaxy collection install --upgrade ansible.netcommon ansible.posix ansible.utils community.general
+# Let's temporarily pin these collections to the latest compatible with ansible-2.15
+#ansible-galaxy collection install --upgrade ansible.netcommon ansible.posix ansible.utils community.general
+ansible-galaxy collection install 'ansible.netcommon<=7.2.0' ansible.posix 'ansible.utils<=5.1.2' community.general
 ANSIBLE_FORCE_COLOR=true ansible-playbook \
   -e "working_dir=$WORKING_DIR" \
   -e "virthost=$HOSTNAME" \


### PR DESCRIPTION
ansible.utils just released a new version that is incompatible with ansible-2.15 (ansible-collections/ansible.utils@7059201) and this results in:

```
    TASK [common : Show networks data for debugging (common role)] *****************
    task path: /home/dev-scripts/metal3-dev-env/vm-setup/roles/common/tasks/main.yml:42
    [WARNING]: Collection ansible.netcommon does not support Ansible version
    2.15.12
    [WARNING]: Collection ansible.utils does not support Ansible version 2.15.12
    redirecting (type: filter) ansible.builtin.nthhost to ansible.netcommon.nthhost
    redirecting (type: filter) ansible.builtin.nthhost to ansible.netcommon.nthhost
```

this is a proposal to pin these collections until we can upgrade to 2.16.