### PR TITLE
Relax pinned versions to use breaking ones as upper limits

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -137,7 +137,7 @@ pushd ${METAL3_DEV_ENV_PATH}
 ansible-galaxy install -r vm-setup/requirements.yml
 # Let's temporarily pin these collections to the latest compatible with ansible-2.15
 #ansible-galaxy collection install --upgrade ansible.netcommon ansible.posix ansible.utils community.general
-ansible-galaxy collection install 'ansible.netcommon<=7.2.0' ansible.posix 'ansible.utils<=5.1.2' community.general
+ansible-galaxy collection install 'ansible.netcommon<8.0.0' ansible.posix 'ansible.utils<6.0.0' community.general
 ANSIBLE_FORCE_COLOR=true ansible-playbook \
   -e "working_dir=$WORKING_DIR" \
   -e "virthost=$HOSTNAME" \


### PR DESCRIPTION
Let's use ansible.utils<6.0.0 and ansible.netcommon<8.0.0 as ceiling so we can benefit from minor releases / bug fixes.