### PR TITLE
fix for the incorrectly formatted

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -137,7 +137,7 @@ pushd ${METAL3_DEV_ENV_PATH}
 ansible-galaxy install -r vm-setup/requirements.yml
 # Let's temporarily pin these collections to the latest compatible with ansible-2.15
 #ansible-galaxy collection install --upgrade ansible.netcommon ansible.posix ansible.utils community.general
-ansible-galaxy collection install 'ansible.netcommon<=7.2.0' ansible.posix 'ansible.utils<=5.1.2' community.general
+ansible-galaxy collection install 'ansible.netcommon:<=7.2.0' ansible.posix 'ansible.utils:<=5.1.2' community.general
 ANSIBLE_FORCE_COLOR=true ansible-playbook \
   -e "working_dir=$WORKING_DIR" \
   -e "virthost=$HOSTNAME" \


### PR DESCRIPTION
base on https://github.com/openshift-metal3/dev-scripts/pull/1747,  Found the following error 

```
ansible-galaxy collection install 'ansible.netcommon<=7.2.0' ansible.posix 'ansible.utils<=5.1.2' community.general

ERROR! Neither the collection requirement entry key 'name', nor 'source' point to a concrete resolvable collection artifact. Also 'name' is not an FQCN. A valid collection name must be in the format <namespace>.<collection>. Please make sure that the namespace and the collection name contain characters from [a-zA-Z0-9_] only.
```