### PR TITLE
NO-ISSUE: ISOBuilder

### DIFF
--- a/agent/01_agent_requirements.sh
+++ b/agent/01_agent_requirements.sh
@@ -66,8 +66,6 @@ if [[ "${AGENT_E2E_TEST_BOOT_MODE}" == "ISO_NO_REGISTRY" ]]; then
     
    early_deploy_validation
 
-   write_pull_secret
-
    # Extract an updated client tools from the release image
    extract_oc "${OPENSHIFT_RELEASE_IMAGE}"
 


### PR DESCRIPTION
Early calling `write_pull_secret` causes an error`root/private-mirror-ostest.json: No such file or directory`

As like all other agent jobs, it should be correctly called through the configure step (02_configure_host)