### PR TITLE
NO-ISSUE: Cleanup

### DIFF
--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -83,3 +83,6 @@ sudo pkill -f oc.*proxy
 
 # Remove image-reg nfsshare
 sudo rm -rf /etc/exports.d/dev-scripts.exports /opt/dev-scripts/nfsshare
+
+# Remove the authfile created in configure host
+rm -f ${REGISTRY_CREDS}


### PR DESCRIPTION
Cleanup the `$REGISTRY_CREDS` file created in the `02_configure_host.sh` file when cleaning up.

If not cleaned properly, there could be possible errors such as https://github.com/openshift-metal3/dev-scripts/pull/1753