### PR TITLE
AGENT-1194: Fix premature oc extraction

### DIFF
--- a/agent/01_agent_requirements.sh
+++ b/agent/01_agent_requirements.sh
@@ -14,13 +14,6 @@ source $SCRIPTDIR/validation.sh
 
 early_deploy_validation
 
-function clone_agent_installer_utils() {
-  # Clone repo, if not already present
-  if [[ ! -d $OPENSHIFT_AGENT_INSTALER_UTILS_PATH ]]; then
-    sync_repo_and_patch go/src/github.com/openshift/agent-installer-utils https://github.com/openshift/agent-installer-utils.git
-  fi
-}
-
 if [[ -z ${AGENT_E2E_TEST_SCENARIO} ]]; then
     printf "\nAGENT_E2E_TEST_SCENARIO is missing or empty. Did you forget to set the AGENT_E2E_TEST_SCENARIO env var in the config_<USER>.sh file?"
     invalidAgentValue
@@ -63,6 +56,4 @@ fi
 
 if [[ "${AGENT_E2E_TEST_BOOT_MODE}" == "ISO_NO_REGISTRY" ]]; then
    sudo dnf -y install xorriso coreos-installer syslinux skopeo
-
-   clone_agent_installer_utils
 fi

--- a/agent/01_agent_requirements.sh
+++ b/agent/01_agent_requirements.sh
@@ -66,8 +66,5 @@ if [[ "${AGENT_E2E_TEST_BOOT_MODE}" == "ISO_NO_REGISTRY" ]]; then
     
    early_deploy_validation
 
-   # Extract an updated client tools from the release image
-   extract_oc "${OPENSHIFT_RELEASE_IMAGE}"
-
    clone_agent_installer_utils
 fi

--- a/agent/01_agent_requirements.sh
+++ b/agent/01_agent_requirements.sh
@@ -63,8 +63,6 @@ fi
 
 if [[ "${AGENT_E2E_TEST_BOOT_MODE}" == "ISO_NO_REGISTRY" ]]; then
    sudo dnf -y install xorriso coreos-installer syslinux skopeo
-    
-   early_deploy_validation
 
    clone_agent_installer_utils
 fi

--- a/agent/06_agent_create_cluster.sh
+++ b/agent/06_agent_create_cluster.sh
@@ -83,6 +83,10 @@ function create_config_image() {
 }
 
 function create_agent_iso_no_registry() {
+  # Clone agent-installer-utils
+  if [[ ! -d $OPENSHIFT_AGENT_INSTALER_UTILS_PATH ]]; then
+    sync_repo_and_patch go/src/github.com/openshift/agent-installer-utils https://github.com/openshift/agent-installer-utils.git
+  fi
   # Create agent ISO without registry a.k.a. OVE ISO
   local asset_dir=${1}
   pushd .


### PR DESCRIPTION
The `01_agent_requirements.sh` tries to extract `oc` binary much before its installed via `01_install_requirements.sh` causing the CI job to fail with `oc: command not found` error. This worked locally because we have `oc` installed.

Also, moved git clone agent-installer-utils into a more logical place `agent/06_agent_create_cluster.sh`