### PR TITLE
agent: Use string for ApplianceConfig.ocpRelease.version

### DIFF
--- a/agent/roles/manifests/templates/appliance-config_yaml.j2
+++ b/agent/roles/manifests/templates/appliance-config_yaml.j2
@@ -1,7 +1,7 @@
 apiVersion: v1beta1
 kind: ApplianceConfig
 ocpRelease:
-  version: {{ version }}
+  version: "{{ version }}"
   url: {{ image }} 
 diskSizeGB: 200
 pullSecret: {{ pull_secret_contents }}


### PR DESCRIPTION
Since 'version' is not wrapped with quotes, it's parsed as float. E.g. instead of '4.20', '4.2'.
Hence, recent 4.20 jobs fails with:
```
failed to load asset "Appliance Config": invalid Appliance Config configuration: ocpRelease.version: Invalid value: "4.2": OCP release version must be at least 4.14
```

See: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_appliance/379/pull-ci-openshift-appliance-master-e2e-sno-dualstack-dhcp/1918945229772165120