### PR TITLE
appliance: copy disk images to WORKING_DIR

### DIFF
--- a/agent/01_agent_requirements.sh
+++ b/agent/01_agent_requirements.sh
@@ -57,3 +57,8 @@ fi
 if [[ "${AGENT_E2E_TEST_BOOT_MODE}" == "ISO_NO_REGISTRY" ]]; then
    sudo dnf -y install xorriso coreos-installer syslinux skopeo
 fi
+
+if [[ "${AGENT_E2E_TEST_BOOT_MODE}" == "DISKIMAGE" ]]; then
+   MIN_SPACE_REQUIRED=300
+   source $SCRIPTDIR/sanitychecks.sh
+fi

--- a/agent/06_agent_create_cluster.sh
+++ b/agent/06_agent_create_cluster.sh
@@ -170,7 +170,7 @@ function attach_appliance_diskimage() {
     set_file_acl
 
     local config_image_drive="sdd"
-    local appliance_disk_image="${OCP_DIR}/appliance.raw"
+    local appliance_disk_image="${WORKING_DIR}/appliance.raw"
 
     for (( n=0; n<${2}; n++ ))
     do


### PR DESCRIPTION
Copy appliance.raw files to /opt/dev-scripts in order to avoid storage exhaustion.