### PR TITLE
Don't restart NetworkManager unnecessarily

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -37,11 +37,16 @@ sudo sh -c "echo 'max_parallel_downloads=8' >> /etc/dnf/dnf.conf"
 # in the upgrade command,but this is more explicit and complete
 sudo dnf -y clean all
 
+old_version=$(sudo dnf info NetworkManager | grep Version | cut -d ':' -f 2)
+
 # Update to latest packages first
 sudo dnf -y upgrade --nobest
 
+new_version=$(sudo dnf info NetworkManager | grep Version | cut -d ':' -f 2)
 # If NetworkManager was upgraded it needs to be restarted
-sudo systemctl restart NetworkManager
+if [ "$old_version" != "$new_version" ]; then
+  sudo systemctl restart NetworkManager
+fi
 
 # Install additional repos as needed for each OS version
 # shellcheck disable=SC1091


### PR DESCRIPTION
Restarting NM breaks VPN connections, which are required to build images for some OpenShift projects, notably machine-config-operator. Forcing a NetworkManager restart every time we update the node, even when no changes to the NetworkManager package were made, causes problems when working on patches to MCO.

This change checks the NM version before and after the dnf update and only restarts NM if the version changed.