### PR TITLE
NO-ISSUE: Renable xtrace for agent/06_agent_create_cluster.sh

### DIFF
--- a/agent/06_agent_create_cluster.sh
+++ b/agent/06_agent_create_cluster.sh
@@ -13,7 +13,6 @@ source $SCRIPTDIR/validation.sh
 source $SCRIPTDIR/release_info.sh
 source $SCRIPTDIR/agent/common.sh
 source $SCRIPTDIR/agent/iscsi_utils.sh
-source $SCRIPTDIR/agent/e2e/agent-tui/utils.sh
 
 early_deploy_validation
 

--- a/agent/common.sh
+++ b/agent/common.sh
@@ -79,3 +79,9 @@ export AGENT_ISOLATED_NETWORK=${AGENT_ISOLATED_NETWORK:-"false"}
 if [ "${AGENT_E2E_TEST_BOOT_MODE}" == "ISO_NO_REGISTRY" ] ; then
     export AGENT_ISOLATED_NETWORK=true
 fi
+
+function getRendezvousIP() {
+    node_zero_mac_address=$(sudo virsh domiflist ${AGENT_RENDEZVOUS_NODE_HOSTNAME} | awk '$3 == "ostestbm" {print $5}')
+    rendezvousIP=$(ip neigh | grep $node_zero_mac_address | awk '{print $1}')
+    echo $rendezvousIP
+}

--- a/agent/e2e/agent-tui/utils.sh
+++ b/agent/e2e/agent-tui/utils.sh
@@ -87,9 +87,3 @@ function pressKeys(){
     _pressKey $keyCode $node
   done
 }
-
-function getRendezvousIP() {
-    node_zero_mac_address=$(sudo virsh domiflist ${AGENT_RENDEZVOUS_NODE_HOSTNAME} | awk '$3 == "ostestbm" {print $5}')
-    rendezvousIP=$(ip neigh | grep $node_zero_mac_address | awk '{print $1}')
-    echo $rendezvousIP
-}


### PR DESCRIPTION
xtrace was inadvertently disabled in
https://github.com/openshift-metal3/dev-scripts/pull/1745

This patch moves the getRendezvousIP function out of e2e/agent-tui/utils.sh and into common.sh.

e2e/agent-tui/utils.sh contains "set +x" which disables xtrace.

06_agent_create_cluster.sh no longer sources e2e/agent-tui/util.sh so that it doesn't inherit the "set +x" call.