### PR TITLE
Fix regression in agent installer with BMC verify_ca

### DIFF
--- a/agent/roles/manifests/templates/install-config_baremetal_yaml.j2
+++ b/agent/roles/manifests/templates/install-config_baremetal_yaml.j2
@@ -81,7 +81,11 @@ platform:
         address: {{ bmc_addresses[loop.index0] }}
         username: {{ bmc_usernames[loop.index0] }}
         password: {{ bmc_passwords[loop.index0] }}
-        disableCertificateVerification: {% if bmc_verify_cas[loop.index0] == "False" %}true{% else %}false{% endif %}
+{% if bmc_verify_cas[loop.index0] == "False" %}
+        disableCertificateVerification: true
+{% else %}
+        disableCertificateVerification: false
+{% endif %}
       networkConfig:
         interfaces:
       {{ net.interfaces("eth0", macs[loop.index0])|indent(4, True) }}


### PR DESCRIPTION
PR https://github.com/openshift-metal3/dev-scripts/pull/1757 introduced a formatting problem when using the agent-based installer with BMC configuration.