### PR TITLE
AGENT-1193: Custom openshift-install can be used by appliance

### DIFF
--- a/agent/03_agent_build_installer.sh
+++ b/agent/03_agent_build_installer.sh
@@ -8,11 +8,6 @@ source $SCRIPTDIR/logging.sh
 source $SCRIPTDIR/common.sh
 source $SCRIPTDIR/agent/common.sh
 
-# Temporarily skip building the agent installer in case of OVE ISO
-if [[ "${AGENT_E2E_TEST_BOOT_MODE}" == "ISO_NO_REGISTRY" ]]; then
-    exit 0
-fi
-
 # Override build tags
 export OPENSHIFT_INSTALLER_BUILD_TAGS=" "
 

--- a/agent/06_agent_create_cluster.sh
+++ b/agent/06_agent_create_cluster.sh
@@ -17,6 +17,14 @@ source $SCRIPTDIR/agent/e2e/agent-tui/utils.sh
 
 early_deploy_validation
 
+# The OCP version used in agent-installer-utils/tools/iso_builder/hack/helper.sh.
+# https://github.com/openshift/agent-installer-utils/blob/6422958144e27dbbe31c7fe98b514d43c988bcfb/tools/iso_builder/hack/helper.sh#L90
+# It is slightly different than OPENSHIFT_VERSION.
+# dev-scripts may need to create the working directory for the appliance if a custom openshift-install
+# binary is built. The same version string is used to be consistent with what is passed to
+# build-ove-image.sh in agent-installer-utils.
+full_ocp_version=$(skopeo inspect --authfile $PULL_SECRET_FILE docker://$OPENSHIFT_RELEASE_IMAGE | jq -r '.Labels["io.openshift.release"]')
+
 function create_pxe_files() {
     local asset_dir=${1}
     local openshift_install=${2}
@@ -87,6 +95,16 @@ function create_agent_iso_no_registry() {
   if [[ ! -d $OPENSHIFT_AGENT_INSTALER_UTILS_PATH ]]; then
     sync_repo_and_patch go/src/github.com/openshift/agent-installer-utils https://github.com/openshift/agent-installer-utils.git
   fi
+
+  # If the openshift-install binary was built from source, copy it to the appliance's 
+  # asset directory. This allows it to be used by the appliance to generate the 
+  # unconfigured-ignition instead of the appliance downloading the binary from 
+  # the release.
+  if [ ! -z "$KNI_INSTALL_FROM_GIT" -a -f "${OCP_DIR}/openshift-install" ]; then
+      mkdir -p "${OCP_DIR}/iso_builder/${full_ocp_version}/appliance/"
+      cp "${OCP_DIR}/openshift-install" "${OCP_DIR}/iso_builder/${full_ocp_version}/appliance/"
+  fi
+ 
   # Create agent ISO without registry a.k.a. OVE ISO
   local asset_dir=${1}
   pushd .
@@ -104,8 +122,8 @@ function create_agent_iso_no_registry() {
 function cleanup_diskspace_agent_iso_noregistry() {
  local asset_dir=${1%/}  # Remove trailing slash if present
 
-  # Iterate over all versioned directories matching 4.19.*
-  for dir in "$asset_dir"/4.19.*; do
+  # Iterate over all versioned directories matching ${full_ocp_version}*
+  for dir in "$asset_dir"/${full_ocp_version}*; do
     [ -d "$dir" ] || continue
 
     echo "Cleaning up directory: $dir"


### PR DESCRIPTION
If the openshift-install binary was built from source, this change creates a symlink to it in the appliance's asset directory. Placing it in the asset directory will signal to the appliance to use it instead of downloading it from the release.

This allows us to test changes in the installer repo without having to wait for it to merge and appear in an offcial release image.

Hard coding to version 4.19 in the directory structures used by the *agent_iso_no_registry functions has also be removed.

Works in conjunction with: https://github.com/openshift/agent-installer-utils/pull/122