### PR TITLE
Fix formatting issue with agent bond configuration

### DIFF
--- a/agent/roles/manifests/templates/agent-config_bond_yaml.j2
+++ b/agent/roles/manifests/templates/agent-config_bond_yaml.j2
@@ -13,7 +13,7 @@ rendezvousIP: {{ ips[0] }}
 {% else %}
 rendezvousIP: {{ ipsv6[0] }}
 {% endif %}
-{% if (boot_mode == "PXE") or (boot_mode == "ISCSI") or (agent_minimal_iso == "true" and mirror_images %}
+{% if (boot_mode == "PXE") or (boot_mode == "ISCSI") or (agent_minimal_iso == "true" and mirror_images) %}
 bootArtifactsBaseURL: {{ boot_server_url }}
 {% endif %}
 hosts:


### PR DESCRIPTION
A regression was introduced in https://github.com/openshift-metal3/dev-scripts/pull/1727 that broke agent-installer bonding. This fixes the Jinja formatting.