### PR TITLE
NO-ISSUE: Fix issues in automate-no-registry-agent-tui

### DIFF
--- a/agent/e2e/agent-tui/automate-no-registry-agent-tui.sh
+++ b/agent/e2e/agent-tui/automate-no-registry-agent-tui.sh
@@ -2,6 +2,7 @@
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../../" && pwd )"
 source $SCRIPTDIR/common.sh
+source $SCRIPTDIR/agent/common.sh
 source $SCRIPTDIR/agent/e2e/agent-tui/utils.sh
 
 set +x

--- a/agent/e2e/agent-tui/utils.sh
+++ b/agent/e2e/agent-tui/utils.sh
@@ -66,8 +66,8 @@ function pressKeys(){
   local text=$2
   local node=$3
 
-  if [[ -n "$VAR" ]]; then
-    echo "$msg $ip on node $node"
+  if [[ -n "$node" ]]; then
+    echo "$msg $text on node $node"
   else
    echo $msg
   fi


### PR DESCRIPTION
source agent/common.sh in e2e/agent-tui/utils.sh so that it can find the getRendezvousIP function. This was missed in PR #1771.

The $VAR and $ip variables in pressKeys was not defined. Renamed them to $node and $text as that appears to be what was originally intended.