### PR TITLE
Allow limiting virtual media emulator to one IP family

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -161,6 +161,12 @@ if ! [[ -f /usr/share/OVMF/OVMF_CODE.fd || -L /usr/share/OVMF/OVMF_CODE.fd ]]; t
   sudo ln -s /usr/share/edk2/ovmf/OVMF_CODE.fd /usr/share/OVMF/
 fi
 
+# TODO(dtantsur): move this to metal3-dev-env
+if [ ${IP_STACK} = "v6v4" ]; then
+    # Make sure that BMC's use IPv6 on v6-primary stack
+    sed -i "/address/s|//[0-9.]*:|//[${PROVISIONING_HOST_EXTERNAL_IP}]:|" "${NODES_FILE}"
+fi
+
 if [ ${NUM_EXTRA_WORKERS} -ne 0 ]; then
   ORIG_NODES_FILE="${NODES_FILE}.orig"
   cp -f ${NODES_FILE} ${ORIG_NODES_FILE}

--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -228,6 +228,10 @@ if [ "$NODES_PLATFORM" = "libvirt" ]; then
              "${VBMC_IMAGE}"
     fi
 
+    if [[ -n "${REDFISH_EMULATOR_VIRTUAL_MEDIA_IP_FAMILY:-}" ]]; then
+        echo "SUSHY_EMULATOR_VIRTUAL_MEDIA_IP_FAMILY = '${REDFISH_EMULATOR_VIRTUAL_MEDIA_IP_FAMILY}'" | sudo tee -a "$WORKING_DIR/virtualbmc/sushy-tools/conf.py"
+    fi
+
     if ! is_running sushy-tools; then
         sudo podman run -d --net host --privileged --name sushy-tools --pod ironic-pod \
              -v "$WORKING_DIR/virtualbmc/sushy-tools":/root/sushy -v "/root/.ssh":/root/ssh \

--- a/config_example.sh
+++ b/config_example.sh
@@ -440,6 +440,12 @@ set -x
 #
 #export REDFISH_EMULATOR_IGNORE_BOOT_DEVICE=False
 
+# REDFISH_EMULATOR_VIRTUAL_MEDIA_IP_FAMILY
+# Instruct the Redfish emulator to accept only virtual media images of the
+# provided IP familty.
+# Choices: 4, 6
+#export REDFISH_EMULATOR_VIRTUAL_MEDIA_IP_FAMILY=
+
 # VM_TPM_EMULATOR -
 # Add TPM2.0 emulator to VMs.
 # Default is unset


### PR DESCRIPTION
It's a common case by customers. Requires:
- https://review.opendev.org/c/openstack/sushy-tools/+/956904

I also need to fix up the BMC addresses, otherwise the logic does not kick in.