### PR TITLE
Restore metal3-dev-env only if it exists

### DIFF
--- a/ocp_cleanup.sh
+++ b/ocp_cleanup.sh
@@ -74,5 +74,8 @@ fi
 sudo sed -ie '/^allow /d' /etc/chrony.conf
 
 # Restore file after workaround
-cd ${METAL3_DEV_ENV_PATH}
-git checkout vm-setup/roles/packages_installation/tasks/centos_required_packages.yml
+if [ -d ${METAL3_DEV_ENV_PATH} ]; then
+  cd ${METAL3_DEV_ENV_PATH}
+  git checkout vm-setup/roles/packages_installation/tasks/centos_required_packages.yml
+fi
+


### PR DESCRIPTION
If the metal3-dev-env dir does not exist for some reason (it was removed before, or changed location before the cleanup), the clenaup will fail.
Restore it only if the dir exists.