### PR TITLE
Stop recommended disk sizes that are too low

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,17 +438,17 @@ by the [vm_setup_vars.yml](vm_setup_vars.yml) file, which sets some dev-scripts
 variables that override the defaults in metal3-dev-env.
 
 The VM resources can be overridden by setting the following environment variables
-in `config_$USER.sh`:
+in `config_$USER.sh` (check `config_example.sh` for recommended defaults):
 
 ```
 # Change VM resources for masters
 #export MASTER_MEMORY=16384
-#export MASTER_DISK=20
+#export MASTER_DISK=60
 #export MASTER_VCPU=8
 
 # Change VM resources for workers
 #export WORKER_MEMORY=8192
-#export WORKER_DISK=20
+#export WORKER_DISK=60
 #export WORKER_VCPU=4
 ```
 

--- a/agent/docs/config-presets-and-options.md
+++ b/agent/docs/config-presets-and-options.md
@@ -40,13 +40,13 @@ values to to achieve the above cluster topologies.
 | NUM_WORKERS         |    2    |           2+          |    0    |              0              |
 | NUM_EXTRA_WORKERS   |    0    |           0           |    0    |              0              |
 | MASTER_MEMORY       |  16384  |         16384         |  16384  |            32768            |
-| MASTER_DISK         |    30   |          120          |   120   |             120             |
+| MASTER_DISK         |    60   |          120          |   120   |             120             |
 | MASTER_VCPU         |    8    |           8           |    8    |              8              |
 | WORKER_MEMORY       |   8192  |         16384         |         |                             |
-| WORKER_DISK         |    30   |          120          |         |                             |
+| WORKER_DISK         |    60   |          120          |         |                             |
 | WORKER_VCPU         |    4    |           4           |         |                             |
 | EXTRA_WORKER_MEMORY |   8192  |         16384         |         |                             |
-| EXTRA_WORKER_DISK   |    30   |          120          |         |                             |
+| EXTRA_WORKER_DISK   |    60   |          120          |         |                             |
 | EXTRA_WORKER_VCPU   |    4    |           4           |         |                             |
 
 ## Defining the Network Topology

--- a/config_example.sh
+++ b/config_example.sh
@@ -512,13 +512,15 @@ set -x
 
 # MASTER_MEMORY, MASTER_DISK, MASTER_VCPU -
 # Change VM resources for masters
+# The provided defaults are really bare minimum: if possible, you should
+# always increase them.
 ## Defaults:
-## MASTER_DISK=30
+## MASTER_DISK=60
 ## MASTER_MEMORY=16384
 ## MASTER_VCPU=8
 #
 #export MASTER_MEMORY=16384
-#export MASTER_DISK=40
+#export MASTER_DISK=60
 #export MASTER_VCPU=8
 
 # ARBITER_HOSTNAME_FORMAT -
@@ -567,13 +569,15 @@ set -x
 
 # WORKER_MEMORY, WORKER_DISK, WORKER_VCPU -
 # Change VM resources for workers.
+# The provided defaults are really bare minimum: if possible, you should
+# always increase them.
 ## Defaults:
-## WORKER_DISK=30
+## WORKER_DISK=60
 ## WORKER_MEMORY=8192
 ## WORKER_VCPU=4
 #
 #export WORKER_MEMORY=8192
-#export WORKER_DISK=30
+#export WORKER_DISK=60
 #export WORKER_VCPU=4
 
 # NUM_EXTRA_WORKERS - Indicate number of extra VMs to create but not deploy.
@@ -585,12 +589,12 @@ set -x
 # Change VM resources for extra workers. If not supplied defaults to the
 # regular workers specs.
 ## Defaults:
-## EXTRA_WORKER_DISK=30
+## EXTRA_WORKER_DISK=60
 ## EXTRA_WORKER_MEMORY=8192
 ## EXTRA_WORKER_VCPU=4
 #
 #export EXTRA_WORKER_MEMORY=8192
-#export EXTRA_WORKER_DISK=30
+#export EXTRA_WORKER_DISK=60
 #export EXTRA_WORKER_VCPU=4
 
 # EXTRA_WORKERS_ONLINE_STATUS -


### PR DESCRIPTION
Still a lot of references to 30 GiB, even though the default value is 60
(and in some cases it's still not enough).

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
