### PR TITLE
AGENT-1292: Create agent OVE UI ISO using Dockerfile

### DIFF
--- a/agent/cleanup.sh
+++ b/agent/cleanup.sh
@@ -66,3 +66,7 @@ if [[ "${AGENT_E2E_TEST_BOOT_MODE}" == "ISCSI" ]]; then
     agent_remove_iscsi_disks master $NUM_MASTERS
     agent_remove_iscsi_disks worker $NUM_WORKERS
 fi
+
+if sudo buildah images --storage-driver vfs | grep -q "localhost/appliance-test"; then
+    sudo buildah rmi -f --storage-driver vfs localhost/appliance-test
+fi


### PR DESCRIPTION
Create the agent OVE UI ISO with the Dockerfile added for Konflux integration in order to exercise this build method. Add a flag to switch between using this Dockerfile and the build-ove-image.sh script.