### PR TITLE
OPNET-708: Add asset files for new CI job to test br-ex.

### DIFF
--- a/network-configs/day2/nmstate/brex-ci-bond/00-brex-ci-master.yml
+++ b/network-configs/day2/nmstate/brex-ci-bond/00-brex-ci-master.yml
@@ -1,0 +1,17 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: 00-brex-ci-master
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+        - contents:
+            source: data:text/plain;charset=utf-8;base64,aW50ZXJmYWNlczoNCi0gbmFtZTogZW5wMnMwDQogIHR5cGU6IGV0aGVybmV0DQogIHN0YXRlOiB1cA0KICBpcHY0Og0KICAgIGVuYWJsZWQ6IGZhbHNlDQogIGlwdjY6DQogICAgZW5hYmxlZDogZmFsc2UNCi0gbmFtZTogZW5wM3MwDQogIHR5cGU6IGV0aGVybmV0DQogIHN0YXRlOiB1cA0KICBpcHY0Og0KICAgIGVuYWJsZWQ6IGZhbHNlDQogIGlwdjY6DQogICAgZW5hYmxlZDogZmFsc2UNCi0gbmFtZTogYnItZXgNCiAgdHlwZTogb3ZzLWJyaWRnZQ0KICBzdGF0ZTogdXANCiAgaXB2NDoNCiAgICBlbmFibGVkOiBmYWxzZQ0KICAgIGRoY3A6IGZhbHNlDQogIGlwdjY6DQogICAgZW5hYmxlZDogZmFsc2UNCiAgICBkaGNwOiBmYWxzZQ0KICBicmlkZ2U6DQogICAgcG9ydDoNCiAgICAtIG5hbWU6IGVucDJzMA0KICAgIC0gbmFtZTogYnItZXgNCi0gbmFtZTogYnItZXgNCiAgdHlwZTogb3ZzLWludGVyZmFjZQ0KICBzdGF0ZTogdXANCiAgY29weS1tYWMtZnJvbTogZW5wMnMwDQogIGlwdjQ6DQogICAgZW5hYmxlZDogdHJ1ZQ0KICAgIGRoY3A6IHRydWUNCiAgaXB2NjoNCiAgICBlbmFibGVkOiBmYWxzZQ0KICAgIGRoY3A6IGZhbHNl
+          mode: 0644
+          overwrite: true
+          path: /etc/nmstate/openshift/cluster.yml

--- a/network-configs/day2/nmstate/brex-ci-bond/00-brex-ci-worker.yml
+++ b/network-configs/day2/nmstate/brex-ci-bond/00-brex-ci-worker.yml
@@ -1,0 +1,17 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 00-brex-ci-worker
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+        - contents:
+            source: data:text/plain;charset=utf-8;base64,aW50ZXJmYWNlczoNCi0gbmFtZTogZW5wMnMwDQogIHR5cGU6IGV0aGVybmV0DQogIHN0YXRlOiB1cA0KICBpcHY0Og0KICAgIGVuYWJsZWQ6IGZhbHNlDQogIGlwdjY6DQogICAgZW5hYmxlZDogZmFsc2UNCi0gbmFtZTogZW5wM3MwDQogIHR5cGU6IGV0aGVybmV0DQogIHN0YXRlOiB1cA0KICBpcHY0Og0KICAgIGVuYWJsZWQ6IGZhbHNlDQogIGlwdjY6DQogICAgZW5hYmxlZDogZmFsc2UNCi0gbmFtZTogYnItZXgNCiAgdHlwZTogb3ZzLWJyaWRnZQ0KICBzdGF0ZTogdXANCiAgaXB2NDoNCiAgICBlbmFibGVkOiBmYWxzZQ0KICAgIGRoY3A6IGZhbHNlDQogIGlwdjY6DQogICAgZW5hYmxlZDogZmFsc2UNCiAgICBkaGNwOiBmYWxzZQ0KICBicmlkZ2U6DQogICAgcG9ydDoNCiAgICAtIG5hbWU6IGVucDJzMA0KICAgIC0gbmFtZTogYnItZXgNCi0gbmFtZTogYnItZXgNCiAgdHlwZTogb3ZzLWludGVyZmFjZQ0KICBzdGF0ZTogdXANCiAgY29weS1tYWMtZnJvbTogZW5wMnMwDQogIGlwdjQ6DQogICAgZW5hYmxlZDogdHJ1ZQ0KICAgIGRoY3A6IHRydWUNCiAgaXB2NjoNCiAgICBlbmFibGVkOiBmYWxzZQ0KICAgIGRoY3A6IGZhbHNl
+          mode: 0644
+          overwrite: true
+          path: /etc/nmstate/openshift/cluster.yml

--- a/network-configs/day2/nmstate/brex-ci-bond/10-ignore-enp3s0-master.yml
+++ b/network-configs/day2/nmstate/brex-ci-bond/10-ignore-enp3s0-master.yml
@@ -1,0 +1,17 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: 10-ignore-enp3s0-master
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+        - contents:
+            source: data:text/plain;charset=utf-8;base64,W2RldmljZS1lbnAzczBdCm1hdGNoLWRldmljZT1pbnRlcmZhY2UtbmFtZTplbnAzczAKa2VlcC1jb25maWd1cmF0aW9uPW5vCmFsbG93ZWQtY29ubmVjdGlvbnM9ZXhjZXB0Om9yaWdpbjpubS1pbml0cmQtZ2VuZXJhdG9y
+          mode: 0644
+          overwrite: true
+          path: /etc/NetworkManager/conf.d/10-ignore-enp3s0.conf

--- a/network-configs/day2/nmstate/brex-ci-bond/10-ignore-enp3s0-worker.yml
+++ b/network-configs/day2/nmstate/brex-ci-bond/10-ignore-enp3s0-worker.yml
@@ -1,0 +1,17 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 10-ignore-enp3s0-worker
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+        - contents:
+            source: data:text/plain;charset=utf-8;base64,W2RldmljZS1lbnAzczBdCm1hdGNoLWRldmljZT1pbnRlcmZhY2UtbmFtZTplbnAzczAKa2VlcC1jb25maWd1cmF0aW9uPW5vCmFsbG93ZWQtY29ubmVjdGlvbnM9ZXhjZXB0Om9yaWdpbjpubS1pbml0cmQtZ2VuZXJhdG9y
+          mode: 0644
+          overwrite: true
+          path: /etc/NetworkManager/conf.d/10-ignore-enp3s0.conf


### PR DESCRIPTION
As per [OPNET-708](https://issues.redhat.com/browse/OPNET-708) we found out that we do not have a reliable way to test br-ex in NMState. This PR is a preparation for the work in the release repository.