### PR TITLE
Generate FIPS-compatible ssh keys

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -35,7 +35,7 @@ esac
 
 # Generate user ssh key
 if [ ! -f $HOME/.ssh/id_rsa.pub ]; then
-    ssh-keygen -f ~/.ssh/id_rsa -P ""
+    ssh-keygen -f ~/.ssh/id_rsa -t rsa -P ""
 fi
 
 # root needs a private key to talk to libvirt


### PR DESCRIPTION
The default SSH key format in CentOS appears to have changed from RSA to ED25519, however this is not compatible with FIPS. Explicitly request an RSA key to avoid blocking FIPS installs.