### PR TITLE
NO-ISSUE: avoid creating unnecessary vfs graphRoot storage folders when not needed

### DIFF
--- a/agent/cleanup.sh
+++ b/agent/cleanup.sh
@@ -67,6 +67,6 @@ if [[ "${AGENT_E2E_TEST_BOOT_MODE}" == "ISCSI" ]]; then
     agent_remove_iscsi_disks worker $NUM_WORKERS
 fi
 
-if sudo buildah images --storage-driver vfs | grep -q "localhost/appliance-test"; then
-    sudo buildah rmi -f --storage-driver vfs localhost/appliance-test
+if [[ -d "$(sudo buildah info --format '{{.store.GraphRoot}}')/vfs" ]] ; then
+    sudo buildah rmi -f --storage-driver vfs localhost/appliance-test >/dev/null 2>&1 || true
 fi


### PR DESCRIPTION
buildah command with --storage-driver create unconditionally vfs folders in the graphRoot storage dir, and that can mess up the environment and subsequent podman commands