### PR TITLE
OCPEDGE-2172: fix: re-order how we populate nodes

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -165,7 +165,7 @@ if [ ${NUM_EXTRA_WORKERS} -ne 0 ]; then
   ORIG_NODES_FILE="${NODES_FILE}.orig"
   cp -f ${NODES_FILE} ${ORIG_NODES_FILE}
   sudo chown -R $USER:$GROUP ${NODES_FILE}
-  jq "{nodes: .nodes[:$((NUM_MASTERS + NUM_WORKERS))]}" ${ORIG_NODES_FILE} | tee ${NODES_FILE}
+  jq "{nodes: .nodes[:$((NUM_MASTERS + NUM_ARBITERS + NUM_WORKERS))]}" ${ORIG_NODES_FILE} | tee ${NODES_FILE}
   jq "{nodes: .nodes[-${NUM_EXTRA_WORKERS}:]}" ${ORIG_NODES_FILE} | tee ${EXTRA_NODES_FILE}
 fi
 

--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -401,13 +401,13 @@ EOF
   if [ -z "${HOSTS_SWAP_DEFINITION:-}" ]; then
     cat >> "${outdir}/install-config.yaml" << EOF
 $(node_map_to_install_config_hosts $NUM_MASTERS 0 master)
-$(node_map_to_install_config_hosts $NUM_WORKERS $NUM_MASTERS worker)
-$(node_map_to_install_config_hosts $NUM_ARBITERS $(( NUM_MASTERS + NUM_WORKERS )) arbiter)
+$(node_map_to_install_config_hosts $NUM_ARBITERS $NUM_MASTERS arbiter)
+$(node_map_to_install_config_hosts $NUM_WORKERS $(( NUM_MASTERS + NUM_ARBITERS )) worker)
 EOF
   else
     cat >> "${outdir}/install-config.yaml" << EOF
-$(node_map_to_install_config_hosts $NUM_ARBITERS $(( NUM_MASTERS + NUM_WORKERS )) arbiter)
-$(node_map_to_install_config_hosts $NUM_WORKERS $NUM_MASTERS worker)
+$(node_map_to_install_config_hosts $NUM_WORKERS $(( NUM_MASTERS + NUM_ARBITERS )) worker)
+$(node_map_to_install_config_hosts $NUM_ARBITERS $NUM_MASTERS arbiter)
 $(node_map_to_install_config_hosts $NUM_MASTERS 0 master)
 EOF
   fi


### PR DESCRIPTION
- When adding workers to arbiter deployments, the arbiter nodes are created between masters and workers in the array, updating logic to correctly ingest those positions
- Update extra workers var to include arbiter count