### PR TITLE
AGENT-1383: Use agent-iso-builder image

### DIFF
--- a/agent/cleanup.sh
+++ b/agent/cleanup.sh
@@ -23,10 +23,15 @@ function agent_remove_iscsi_disks() {
       done
 }
 
-if [[ "${AGENT_E2E_TEST_BOOT_MODE}" == "DISKIMAGE" ]]; then
+if [[ -d "${OCP_DIR}/cache" && -d "${OCP_DIR}/temp" ]]; then
     sudo rm -rf "${OCP_DIR}/cache"
     sudo rm -rf "${OCP_DIR}/temp"
     sudo podman rmi -f ${APPLIANCE_IMAGE} || true
+fi
+
+if [[ -d "${OCP_DIR}/iso_builder" ]]; then
+    sudo rm -rf "${OCP_DIR}/iso_builder"
+    sudo podman rmi -f ${AGENT_ISO_BUILDER_IMAGE} || true
 fi
 
 if [[ -d ${BOOT_SERVER_DIR} ]]; then

--- a/agent/common.sh
+++ b/agent/common.sh
@@ -26,6 +26,14 @@ export ISCSI_DEVICE_NAME=${ISCSI_DEVICE_NAME:-"/dev/sdb"}
 # See: https://github.com/openshift/appliance
 export APPLIANCE_IMAGE=${APPLIANCE_IMAGE:-"quay.io/edge-infrastructure/openshift-appliance:latest"}
 
+if [ "${AGENT_E2E_TEST_BOOT_MODE}" == "ISO_NO_REGISTRY" ] ; then
+    full_ocp_version=$(skopeo inspect --authfile $PULL_SECRET_FILE docker://$OPENSHIFT_RELEASE_IMAGE | jq -r '.Labels["io.openshift.release"]')
+    major_minor_patch_version=$(echo "\"$full_ocp_version\"" | jq -r 'split("-")[0]')
+    major_minor_version=$(echo $major_minor_patch_version | cut -d'.' -f1,2 )
+    export AGENT_ISO_BUILDER_IMAGE=${AGENT_ISO_BUILDER_IMAGE:-"registry.ci.openshift.org/ocp/${major_minor_version}:agent-iso-builder"}
+    echo "Using AGENT_ISO_BUILDER_IMAGE: ${AGENT_ISO_BUILDER_IMAGE}"
+fi
+
 # Override command name in case of extraction
 export OPENSHIFT_INSTALLER_CMD="openshift-install"
 

--- a/common.sh
+++ b/common.sh
@@ -170,7 +170,6 @@ if [ -z "${OPENSHIFT_RELEASE_IMAGE:-}" ]; then
 fi
 export OPENSHIFT_RELEASE_IMAGE="${OPENSHIFT_RELEASE_IMAGE:-$LATEST_CI_IMAGE}"
 export OPENSHIFT_INSTALL_PATH="${OPENSHIFT_INSTALL_PATH:-$GOPATH/src/github.com/openshift/installer}"
-export OPENSHIFT_AGENT_INSTALER_UTILS_PATH="${OPENSHIFT_AGENT_INSTALER_UTILS_PATH:-$GOPATH/src/github.com/openshift/agent-installer-utils}"
 
 # Override the image to use for installing hive
 export HIVE_DEPLOY_IMAGE="${HIVE_DEPLOY_IMAGE:-registry.ci.openshift.org/openshift/hive-v4.0:hive}"

--- a/config_example.sh
+++ b/config_example.sh
@@ -854,6 +854,7 @@ set -x
 # To generate an ISO that can be used in a disconnected environment 
 # without using a registry a.k.a. OVE ISO, set the boot mode to 'ISO_NO_REGISTRY'.
 # export AGENT_E2E_TEST_BOOT_MODE=ISO
+# export AGENT_ISO_BUILDER_IMAGE="registry.ci.openshift.org/ocp/4.21:agent-iso-builder"
 
 # AGENT_CLEANUP_ISO_BUILDER_CACHE_LOCAL_DEV is an optional environment variable used to trigger
 # cleanup of cached files and other artifacts during local development and is useful when


### PR DESCRIPTION
 Switch from cloning agent-installer-utils repo to using the `agent-iso-builder` container image when creating OVE ISOs for disconnected environments.

###   What changed

  - Extract ISO builder tooling from a container image instead of cloning the git repo
  - Auto-detect the right image version based on the OpenShift release (e.g., `registry.ci.openshift.org/ocp/4.21:agent-iso-builder`)
  - Clean up the extracted files and container image when done

###   Why

  This is faster, more consistent with CI, and automatically matches the tooling version to your OpenShift version.

 ---Description drafted with assistance from Claude
