### PR TITLE
Revert "Enable TLS validation for Redfish emulator"

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -19,7 +19,7 @@ if [ -z "${METAL3_DEV_ENV}" ]; then
   # TODO -- come up with a plan for continuously updating this
   # Note we only do this in the case where METAL3_DEV_ENV is
   # unset, to enable developer testing of local checkouts
-  git reset cb83ca7ae9cfabe827d7a784b28e537e098070ae --hard
+  git reset 01530d036cce1ff0b4675768777af7a6c6de7487 --hard
 
   popd
 fi

--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -361,8 +361,6 @@ function generate_ocp_install_config() {
       NETWORK_TYPE=OVNKubernetes
     fi
 
-    OCP_VERSION=$(openshift_version $OCP_DIR)
-
     cat > "${outdir}/install-config.yaml" << EOF
 apiVersion: v1
 baseDomain: ${BASE_DOMAIN}
@@ -414,13 +412,6 @@ $(node_map_to_install_config_hosts $NUM_MASTERS 0 master)
 EOF
   fi
 
-  if ! is_lower_version "$(openshift_version $OCP_DIR)" "4.21"; then
-    cat >> "${outdir}/install-config.yaml" << EOF
-    bmcVerifyCA: |
-$(sudo sed 's/^/      /' "${WORKING_DIR}/virtualbmc/sushy-tools/cert.pem")
-EOF
-  fi
-
     cat >> "${outdir}/install-config.yaml" << EOF
 $(image_mirror_config)
 $(additional_trust_bundle)
@@ -464,12 +455,8 @@ function generate_ocp_host_manifest() {
 
         encoded_username=$(echo -n "$username" | base64)
         encoded_password=$(echo -n "$password" | base64)
-        if is_lower_version "$(openshift_version $OCP_DIR)" "4.21"; then
-          # Heads up, "verify_ca" in ironic driver config, and "disableCertificateVerification" in BMH have opposite meaning
-          disableCertificateVerification=$([ "$verify_ca" = "False" ] && echo "true" || echo "false")
-        else
-          disableCertificateVerification=false
-        fi
+        # Heads up, "verify_ca" in ironic driver config, and "disableCertificateVerification" in BMH have opposite meaning
+        disableCertificateVerification=$([ "$verify_ca" = "False" ] && echo "true" || echo "false")
 
         secret="---
 apiVersion: v1

--- a/utils.sh
+++ b/utils.sh
@@ -268,15 +268,13 @@ function node_map_to_install_config_hosts() {
 EOF
 
       if [[ "$driver_prefix" == "redfish" ]]; then
-          # Set disableCertificateVerification on older versions
-          if is_lower_version "$(openshift_version $OCP_DIR)" "4.21"; then
-              # Heads up, "verify ca" in ironic driver config, and "disableCertificateVerification" in BMH have opposite meaning
-              verify_ca=$(node_val ${idx} "driver_info.redfish_verify_ca")
-              disable_certificate_verification=$([ "$verify_ca" = "False" ] && echo "true" || echo "false")
-              cat << EOF
+          # Set disableCertificateVerification
+          # Heads up, "verify ca" in ironic driver config, and "disableCertificateVerification" in BMH have opposite meaning
+          verify_ca=$(node_val ${idx} "driver_info.redfish_verify_ca")
+          disable_certificate_verification=$([ "$verify_ca" = "False" ] && echo "true" || echo "false")
+          cat << EOF
           disableCertificateVerification: ${disable_certificate_verification}
 EOF
-          fi
       fi
 
 


### PR DESCRIPTION
In the original change I assumed that any 4.21 version already contains the BMC CA.
This is not the case for upgrade jobs, which now fail.

On top of that, dev-scripts is used to run jobs on older builds that also haven't caught up yet.

Reverts openshift-metal3/dev-scripts#1812