### PR TITLE
OCPBUGS-66339: Partially revert "Enable TLS validation for Redfish emulator"

### DIFF
--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -361,8 +361,6 @@ function generate_ocp_install_config() {
       NETWORK_TYPE=OVNKubernetes
     fi
 
-    OCP_VERSION=$(openshift_version $OCP_DIR)
-
     cat > "${outdir}/install-config.yaml" << EOF
 apiVersion: v1
 baseDomain: ${BASE_DOMAIN}
@@ -464,12 +462,8 @@ function generate_ocp_host_manifest() {
 
         encoded_username=$(echo -n "$username" | base64)
         encoded_password=$(echo -n "$password" | base64)
-        if is_lower_version "$(openshift_version $OCP_DIR)" "4.21"; then
-          # Heads up, "verify_ca" in ironic driver config, and "disableCertificateVerification" in BMH have opposite meaning
-          disableCertificateVerification=$([ "$verify_ca" = "False" ] && echo "true" || echo "false")
-        else
-          disableCertificateVerification=false
-        fi
+        # Heads up, "verify_ca" in ironic driver config, and "disableCertificateVerification" in BMH have opposite meaning
+        disableCertificateVerification=$([ "$verify_ca" = "False" ] && echo "true" || echo "false")
 
         secret="---
 apiVersion: v1

--- a/utils.sh
+++ b/utils.sh
@@ -268,15 +268,13 @@ function node_map_to_install_config_hosts() {
 EOF
 
       if [[ "$driver_prefix" == "redfish" ]]; then
-          # Set disableCertificateVerification on older versions
-          if is_lower_version "$(openshift_version $OCP_DIR)" "4.21"; then
-              # Heads up, "verify ca" in ironic driver config, and "disableCertificateVerification" in BMH have opposite meaning
-              verify_ca=$(node_val ${idx} "driver_info.redfish_verify_ca")
-              disable_certificate_verification=$([ "$verify_ca" = "False" ] && echo "true" || echo "false")
-              cat << EOF
+          # Set disableCertificateVerification
+          # Heads up, "verify ca" in ironic driver config, and "disableCertificateVerification" in BMH have opposite meaning
+          verify_ca=$(node_val ${idx} "driver_info.redfish_verify_ca")
+          disable_certificate_verification=$([ "$verify_ca" = "False" ] && echo "true" || echo "false")
+          cat << EOF
           disableCertificateVerification: ${disable_certificate_verification}
 EOF
-          fi
       fi
 
 


### PR DESCRIPTION
In the original change I assumed that any 4.21 version already contains
the BMC CA.  This is not the case for upgrade jobs, which now fail.

On top of that, dev-scripts is used to run jobs on older builds that
also haven't caught up yet.

I'm keeping the metal3-dev-env bump in place since it does not affect
anything. I also keep settings the BMC CA in the install-config so
that we don't accidentally get into the same situation later.

This reverts commit 1276f86ef38cd08933025e77da3fb6ce561196ec.
