### PR TITLE
OPNET-748: Support running with external loadbalancer

### DIFF
--- a/06_create_cluster.sh
+++ b/06_create_cluster.sh
@@ -29,6 +29,10 @@ if [[ ! -z "$INSTALLER_PROXY" ]]; then
   fi
 fi
 
+if [ -n "$EXTERNAL_LOADBALANCER" ]; then
+  ./external_loadbalancer.sh &
+fi
+
 # Call openshift-installer to deploy the bootstrap node and masters
 create_cluster ${OCP_DIR}
 

--- a/common.sh
+++ b/common.sh
@@ -386,6 +386,13 @@ export TEST_CUSTOM_MAO=${TEST_CUSTOM_MAO:-false}
 # (Currently this just expects a non-empty value, the IP is fixed to .9)
 export ENABLE_BOOTSTRAP_STATIC_IP=${ENABLE_BOOTSTRAP_STATIC_IP:-}
 
+export EXTERNAL_LOADBALANCER=${EXTERNAL_LOADBALANCER:-}
+
+if [ -n "$EXTERNAL_LOADBALANCER" -a -z "$ENABLE_BOOTSTRAP_STATIC_IP" ]; then
+  error "EXTERNAL_LOADBALANCER requires ENABLE_BOOTSTRAP_STATIC_IP to be set as well"
+  exit 1
+fi
+
 # TODO(bnemec): Once https://github.com/ansible/ansible/pull/75537 merges this
 # can be removed.
 ALMA_PYTHON_OVERRIDE=

--- a/config_example.sh
+++ b/config_example.sh
@@ -427,6 +427,16 @@ set -x
 # When set to any value this will cause dev-scripts to include duplicate nics
 # on the primary network. This is intended for testing bonded network configs
 # and may not work without a bond config.
+# export BOND_PRIMARY_INTERFACE=1
+
+# EXTERNAL_LOADBALANCER -
+# When set to any value this will cause dev-scripts to configure an haproxy
+# loadbalancer on the host and configure the cluster to use it instead of the
+# internal loadbalancer.
+# Because of the way the loadbalancer config is written, this only works when
+# using single stack (either ipv4 or ipv6) and a static bootstrap IP (see the
+# ENABLE_BOOTSTRAP_STATIC_IP option above).
+# export EXTERNAL_LOADBALANCER=1
 
 ################################################################################
 ## VM Settings

--- a/network.sh
+++ b/network.sh
@@ -253,12 +253,20 @@ function get_vips() {
     #
     if [[ -n "${EXTERNAL_SUBNET_V4}" ]]; then
         API_VIPS_V4=$(dig +noall +answer "api.${CLUSTER_DOMAIN}" @$(network_ip ${BAREMETAL_NETWORK_NAME}) | awk '{print $NF}')
-        INGRESS_VIPS_V4=$(nth_ip $EXTERNAL_SUBNET_V4 4)
+        if [ -z "$EXTERNAL_LOADBALANCER" ]; then
+          INGRESS_VIPS_V4=$(nth_ip $EXTERNAL_SUBNET_V4 4)
+        else
+          INGRESS_VIPS_V4=$(nth_ip $EXTERNAL_SUBNET_V4 1)
+        fi
     fi
 
     if [[ -n "${EXTERNAL_SUBNET_V6}" ]]; then
         API_VIPS_V6=$(dig -t AAAA +noall +answer "api.${CLUSTER_DOMAIN}" @$(network_ip ${BAREMETAL_NETWORK_NAME}) | awk '{print $NF}')
-        INGRESS_VIPS_V6=$(nth_ip $EXTERNAL_SUBNET_V6 4)
+        if [ -z "$EXTERNAL_LOADBALANCER" ]; then
+          INGRESS_VIPS_V6=$(nth_ip $EXTERNAL_SUBNET_V6 4)
+        else
+          INGRESS_VIPS_V6=$(nth_ip $EXTERNAL_SUBNET_V6 1)
+        fi
     fi
 
     if [[ "$IP_STACK" == "v4" || "$IP_STACK" == "v4v6" ]]; then

--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -191,6 +191,15 @@ function setVIPs() {
     esac
 }
 
+function loadbalancer_type() {
+    if [ -n "$EXTERNAL_LOADBALANCER" ]; then
+cat <<EOF
+    loadBalancer:
+      type: UserManaged
+EOF
+    fi
+}
+
 function featureSet() {
     if [[ -n "$FEATURE_SET" ]]; then
 cat <<EOF
@@ -395,6 +404,7 @@ $(cluster_os_image)
 $(setVIPs apivips)
 $(setVIPs ingressvips)
 $(dnsvip)
+$(loadbalancer_type)
     hosts:
 EOF
 

--- a/vm_setup_vars.yml
+++ b/vm_setup_vars.yml
@@ -59,6 +59,13 @@ dns_extrahosts:
     hostnames:
       - "virthost"
 
+dns_externalhosts:
+  - ip: "{{ baremetal_network_cidr | nthhost(1) }}"
+    hostnames:
+      - "virthost"
+      - "api"
+      - "api-int"
+
 network_config_folder: "{{ lookup('env', 'NETWORK_CONFIG_FOLDER') | default(false) }}"
 hosts_config: "{{ lookup('template', network_config_folder + '/hosts.yaml', errors='ignore') | default('[]', true) | from_yaml }}"
 dns_customhosts: "{{ [] if not network_config_folder else hosts_config }}"
@@ -88,7 +95,7 @@ external_network:
       - 65535
     domain: "{{ cluster_domain }}"
     dns:
-      hosts: "{{ dns_extrahosts + dns_customhosts + dns_dualstackhost if lookup('env', 'EXTERNAL_SUBNET_V6') else dns_extrahosts + dns_customhosts }}"
+      hosts: "{{ dns_externalhosts + dns_customhosts if lookup('env', 'EXTERNAL_LOADBALANCER') else dns_extrahosts + dns_customhosts + dns_dualstackhost if lookup('env', 'EXTERNAL_SUBNET_V6') else dns_extrahosts + dns_customhosts }}"
       forwarders:
         - domain: "apps.{{ cluster_domain }}"
           addr: "127.0.0.1"


### PR DESCRIPTION
Add an EXTERNAL_LOADBALANCER option to the config settings that configures the external loadbalancer and tells the cluster to use it instead of the internal one.