### PR TITLE
OCPBUGS-67300: Fixes for Agent installer OVE UI driven installation

### DIFF
--- a/agent/06_agent_create_cluster.sh
+++ b/agent/06_agent_create_cluster.sh
@@ -85,7 +85,12 @@ function create_config_image() {
 function create_agent_iso_no_registry() {
   local asset_dir=${1}
 
+  AGENT_ISO_BUILDER_IMAGE=$(getAgentISOBuilderImage)
+
   id=$(podman create --pull always --authfile "${PULL_SECRET_FILE}" "${AGENT_ISO_BUILDER_IMAGE}") &&  podman cp "${id}":/src "${asset_dir}" &&  podman rm "${id}"
+
+  # Update release_info.json as its needed by CI tests
+  save_release_info ${OPENSHIFT_RELEASE_IMAGE} ${OCP_DIR}
 
   # Create agent ISO without registry a.k.a. OVE ISO
   pushd .

--- a/agent/agent_post_install_validation.sh
+++ b/agent/agent_post_install_validation.sh
@@ -6,9 +6,29 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 source $SCRIPTDIR/common.sh
 
 if [[ "${AGENT_E2E_TEST_BOOT_MODE}" == "ISO_NO_REGISTRY" ]]; then
-  oc wait clusterversion version --for=condition=Available=True   --timeout=60m
-  oc get csv -A
-  oc get packagemanifests -n openshift-marketplace 
+    MAX_ATTEMPTS=120
+    SLEEP_SECONDS=30  # Wait time between connection attempts
+    ATTEMPT_COUNT=0
+
+    echo "Starting oc wait retry loop for API connection up to 60 minutes..."
+    set +x  # Disable debug tracing for cleaner output
+    while ! oc wait clusterversion version --for=condition=Available=True --timeout=1s 2>/dev/null; do
+        ATTEMPT_COUNT=$((ATTEMPT_COUNT + 1))
+        if [ $ATTEMPT_COUNT -ge $MAX_ATTEMPTS ]; then
+            echo ""
+            set -x  # Re-enable debug tracing
+            echo "ERROR: API server connection failed after $MAX_ATTEMPTS attempts over 60 minutes."
+            exit 1
+        fi
+
+        echo -n "."
+        sleep $SLEEP_SECONDS
+    done
+    echo ""
+    set -x  # Re-enable debug tracing
+    echo "SUCCESS: API server connection established and ClusterVersion is available."
+    # Run subsequent commands after successful cluster setup
+    oc get packagemanifests -n openshift-marketplace
 fi
 
 installed_control_plane_nodes=$(oc get nodes --selector=node-role.kubernetes.io/master | grep -v AGE | wc -l)

--- a/agent/cleanup.sh
+++ b/agent/cleanup.sh
@@ -31,6 +31,8 @@ fi
 
 if [[ -d "${OCP_DIR}/iso_builder" ]]; then
     sudo rm -rf "${OCP_DIR}/iso_builder"
+
+    AGENT_ISO_BUILDER_IMAGE=$(getAgentISOBuilderImage)
     sudo podman rmi -f ${AGENT_ISO_BUILDER_IMAGE} || true
 fi
 

--- a/agent/common.sh
+++ b/agent/common.sh
@@ -26,14 +26,6 @@ export ISCSI_DEVICE_NAME=${ISCSI_DEVICE_NAME:-"/dev/sdb"}
 # See: https://github.com/openshift/appliance
 export APPLIANCE_IMAGE=${APPLIANCE_IMAGE:-"quay.io/edge-infrastructure/openshift-appliance:latest"}
 
-if [ "${AGENT_E2E_TEST_BOOT_MODE}" == "ISO_NO_REGISTRY" ] ; then
-    full_ocp_version=$(skopeo inspect --authfile $PULL_SECRET_FILE docker://$OPENSHIFT_RELEASE_IMAGE | jq -r '.Labels["io.openshift.release"]')
-    major_minor_patch_version=$(echo "\"$full_ocp_version\"" | jq -r 'split("-")[0]')
-    major_minor_version=$(echo $major_minor_patch_version | cut -d'.' -f1,2 )
-    export AGENT_ISO_BUILDER_IMAGE=${AGENT_ISO_BUILDER_IMAGE:-"registry.ci.openshift.org/ocp/${major_minor_version}:agent-iso-builder"}
-    echo "Using AGENT_ISO_BUILDER_IMAGE: ${AGENT_ISO_BUILDER_IMAGE}"
-fi
-
 # Override command name in case of extraction
 export OPENSHIFT_INSTALLER_CMD="openshift-install"
 
@@ -92,4 +84,12 @@ function getRendezvousIP() {
     node_zero_mac_address=$(sudo virsh domiflist ${AGENT_RENDEZVOUS_NODE_HOSTNAME} | awk '$3 == "ostestbm" {print $5}')
     rendezvousIP=$(ip neigh | grep $node_zero_mac_address | awk '{print $1}')
     echo $rendezvousIP
+}
+
+function getAgentISOBuilderImage() {
+    full_ocp_version=$(skopeo inspect --authfile $PULL_SECRET_FILE docker://$OPENSHIFT_RELEASE_IMAGE | jq -r '.Labels["io.openshift.release"]')
+    major_minor_patch_version=$(echo "\"$full_ocp_version\"" | jq -r 'split("-")[0]')
+    major_minor_version=$(echo $major_minor_patch_version | cut -d'.' -f1,2 )
+    agent_iso_builder_image="registry.ci.openshift.org/ocp/${major_minor_version}:agent-iso-builder"
+    echo ${agent_iso_builder_image}
 }

--- a/agent/isobuilder/ui_driven_cluster_installation/main.go
+++ b/agent/isobuilder/ui_driven_cluster_installation/main.go
@@ -138,7 +138,12 @@ func clusterDetails(page *rod.Page, path string) error {
 }
 
 func virtualizationBundle(page *rod.Page, path string) error {
-	page.MustElement("#bundle-virtualization").MustClick().MustWaitEnabled()
+	checkbox := page.MustElement("#bundle-virtualization")
+	checkbox.MustScrollIntoView()
+	checkbox.MustClick()
+	// Allow UI enough time to complete the background API call
+	time.Sleep(2 * time.Second)
+	page.MustElement("button[name='next']").MustWaitEnabled()
 	err := saveFullPageScreenshot(page, path)
 	if err != nil {
 		return err

--- a/common.sh
+++ b/common.sh
@@ -541,7 +541,7 @@ if [[ ! -z ${AGENT_E2E_TEST_SCENARIO} ]]; then
     fi
   fi
 
-  if [ "$AGENT_OPERATORS" =~ "mtv" ]; then
+  if [[ "$AGENT_OPERATORS" =~ "mtv" ]]; then
     export MASTER_VCPU=9
   fi
 

--- a/config_example.sh
+++ b/config_example.sh
@@ -854,7 +854,6 @@ set -x
 # To generate an ISO that can be used in a disconnected environment 
 # without using a registry a.k.a. OVE ISO, set the boot mode to 'ISO_NO_REGISTRY'.
 # export AGENT_E2E_TEST_BOOT_MODE=ISO
-# export AGENT_ISO_BUILDER_IMAGE="registry.ci.openshift.org/ocp/4.21:agent-iso-builder"
 
 # AGENT_CLEANUP_ISO_BUILDER_CACHE_LOCAL_DEV is an optional environment variable used to trigger
 # cleanup of cached files and other artifacts during local development and is useful when


### PR DESCRIPTION
A few fixes when using agent-based-installer with
AGENT_E2E_TEST_BOOT_MODE=ISO_NO_REGISTRY
as this now runs the full UI-driven installation.

- Added delay for the Virtualization checkbox to give the UI enough time to complete the background API call that registers the operator selection with the backend
- Use the pull-secret after it has been fully configured
- Poll for the API to be available and the oc commands to succeed