### PR TITLE
METAL-1705: Re-apply "Enable TLS validation for Redfish emulator"

### DIFF
--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -422,7 +422,7 @@ $(node_map_to_install_config_hosts $NUM_MASTERS 0 master)
 EOF
   fi
 
-  if ! is_lower_version "$(openshift_version $OCP_DIR)" "4.21"; then
+  if ! is_lower_version "$(openshift_version $OCP_DIR)" "4.22"; then
     cat >> "${outdir}/install-config.yaml" << EOF
     bmcVerifyCA: |
 $(sudo sed 's/^/      /' "${WORKING_DIR}/virtualbmc/sushy-tools/cert.pem")
@@ -472,8 +472,12 @@ function generate_ocp_host_manifest() {
 
         encoded_username=$(echo -n "$username" | base64)
         encoded_password=$(echo -n "$password" | base64)
-        # Heads up, "verify_ca" in ironic driver config, and "disableCertificateVerification" in BMH have opposite meaning
-        disableCertificateVerification=$([ "$verify_ca" = "False" ] && echo "true" || echo "false")
+        if is_lower_version "$(openshift_version $OCP_DIR)" "4.22"; then
+          # Heads up, "verify_ca" in ironic driver config, and "disableCertificateVerification" in BMH have opposite meaning
+          disableCertificateVerification=$([ "$verify_ca" = "False" ] && echo "true" || echo "false")
+        else
+          disableCertificateVerification=false
+        fi
 
         secret="---
 apiVersion: v1

--- a/utils.sh
+++ b/utils.sh
@@ -268,13 +268,15 @@ function node_map_to_install_config_hosts() {
 EOF
 
       if [[ "$driver_prefix" == "redfish" ]]; then
-          # Set disableCertificateVerification
-          # Heads up, "verify ca" in ironic driver config, and "disableCertificateVerification" in BMH have opposite meaning
-          verify_ca=$(node_val ${idx} "driver_info.redfish_verify_ca")
-          disable_certificate_verification=$([ "$verify_ca" = "False" ] && echo "true" || echo "false")
-          cat << EOF
+          # Set disableCertificateVerification on older versions
+          if is_lower_version "$(openshift_version $OCP_DIR)" "4.22"; then
+              # Heads up, "verify ca" in ironic driver config, and "disableCertificateVerification" in BMH have opposite meaning
+              verify_ca=$(node_val ${idx} "driver_info.redfish_verify_ca")
+              disable_certificate_verification=$([ "$verify_ca" = "False" ] && echo "true" || echo "false")
+              cat << EOF
           disableCertificateVerification: ${disable_certificate_verification}
 EOF
+          fi
       fi
 
 


### PR DESCRIPTION
Reverts the partial revert that disabled the validation in the CI.
Now that we've crossed the release boundary, it should be safe to do.

Starting with version 4.22 instead of 4.21 to be extra safe.

This reverts commit df885c49eb5ef7adf8c9338248060e5016e9e295.
