### PR TITLE
Remove el8 support (glibc too old for recent oc CLI)

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -86,31 +86,6 @@ fi
 # Install ansible, other packages are installed via
 # vm-setup/install-package-playbook.yml
 case $DISTRO in
-  "centos8"|"rhel8"|"almalinux8"|"rocky8")
-    # install network-scripts package to be able to use legacy network commands
-    sudo dnf install -y network-scripts
-    if [[ $DISTRO == "centos8" ]] && [[ "$NAME" != *"Stream"* ]]; then
-        echo "CentOS is not supported, please switch to CentOS Stream / RHEL / Rocky / Alma"
-        exit 1
-    fi
-    if [[ $DISTRO == "centos8" || $DISTRO == "almalinux8" || $DISTRO == "rocky8" ]]; then
-      sudo dnf -y install epel-release dnf --enablerepo=extras
-    elif [[ $DISTRO == "rhel8" ]]; then
-      # Enable EPEL for python3-passlib and python3-bcrypt required by metal3-dev-env
-      sudo dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-      if sudo subscription-manager repos --list-enabled 2>&1 | grep "ansible-2-for-rhel-8-$(uname -m)-rpms"; then
-        # The packaged 2.x ansible is too old for compatibility with metal3-dev-env
-        sudo dnf erase -y ansible
-        sudo subscription-manager repos --disable=ansible-2-for-rhel-8-$(uname -m)-rpms
-      fi
-    fi
-    # Note recent ansible needs python >= 3.8 so we install 3.9 here
-    sudo dnf -y install python39
-    sudo alternatives --set python /usr/bin/python3.9
-    sudo alternatives --set python3 /usr/bin/python3.9
-    sudo update-alternatives --install /usr/bin/pip3 pip3 /usr/bin/pip3.9 1
-    PYTHON_DEVEL="python39-devel"
-    ;;
   "centos9"|"rhel9"|"almalinux9"|"rocky9")
     sudo dnf -y install python3-pip
     if [[ $DISTRO == "centos9" || $DISTRO == "almalinux9" || $DISTRO == "rocky9" ]] ; then
@@ -130,7 +105,7 @@ case $DISTRO in
     PYTHON_DEVEL="python3-devel"
     ;;
   *)
-    echo -n "CentOS or RHEL version not supported"
+    echo -n "CentOS 9 or RHEL 9 required (el8 is no longer supported due to glibc requirements)"
     exit 1
     ;;
 esac
@@ -173,7 +148,6 @@ ANSIBLE_FORCE_COLOR=true ansible-playbook \
   -e "go_version=$GO_VERSION" \
   -e "go_custom_mirror=$GO_CUSTOM_MIRROR" \
   -e "GOARCH=$GOARCH" \
-  $ALMA_PYTHON_OVERRIDE \
   -i vm-setup/inventory.ini \
   -b -vvv vm-setup/install-package-playbook.yml
 popd
@@ -190,13 +164,6 @@ fi
 
 if [[ "${NODES_PLATFORM}" == "baremetal" ]] ; then
     sudo dnf -y install ipmitool
-fi
-
-# needed if we are using locally built images
-# We stop any systemd service so we can run in a container, since
-# there's no RPM/systemd version available for RHEL8
-if sudo systemctl is-active docker-distribution.service; then
-  sudo systemctl disable --now docker-distribution.service
 fi
 
 retry_with_timeout 5 60 "curl -L $OPENSHIFT_CLIENT_TOOLS_URL | sudo tar -U -C /usr/local/bin -xzf -"

--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -150,7 +150,6 @@ ansible-playbook \
     -e "worker_hostname_format=$WORKER_HOSTNAME_FORMAT" \
     -e "libvirt_arch=$(uname -m)" \
     -e "enable_vnc_console=$VNC_CONSOLE" \
-    $ALMA_PYTHON_OVERRIDE \
     -i ${VM_SETUP_PATH}/inventory.ini \
     -b -vvv ${VM_SETUP_PATH}/setup-playbook.yml
 
@@ -347,7 +346,6 @@ ANSIBLE_FORCE_COLOR=true ansible-playbook \
     -e "external_interface=$BAREMETAL_NETWORK_NAME" \
     -e "{vm_host_ports: [80, ${LOCAL_REGISTRY_PORT}, 8000, ${INSTALLER_PROXY_PORT}, ${AGENT_BOOT_SERVER_PORT}, 3260]}" \
     -e "vbmc_port_range=$VBMC_BASE_PORT:$VBMC_MAX_PORT" \
-    $ALMA_PYTHON_OVERRIDE \
     -i ${VM_SETUP_PATH}/inventory.ini \
     -b -vvv ${VM_SETUP_PATH}/firewall.yml
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ other components of OpenShift via support for a baremetal platform type.
 
 # Pre-requisites
 
-- CentOS 8 or RHEL 8 host
-  - Alma and Rocky Linux 8 are also supported on a best effort basis
+- CentOS Stream 9 or RHEL 9 host
+  - Alma and Rocky Linux 9 are also supported on a best effort basis
 - file system that supports d_type (see [Troubleshooting](#Troubleshooting) section for more information)
 - ideally on a bare metal host with at least 64G of RAM
 - run as a user with passwordless sudo access

--- a/common.sh
+++ b/common.sh
@@ -392,14 +392,8 @@ if [ -n "$EXTERNAL_LOADBALANCER" -a -z "$ENABLE_BOOTSTRAP_STATIC_IP" ]; then
   exit 1
 fi
 
-# TODO(bnemec): Once https://github.com/ansible/ansible/pull/75537 merges this
-# can be removed.
-ALMA_PYTHON_OVERRIDE=
 source /etc/os-release
 export DISTRO="${ID}${VERSION_ID%.*}"
-if [[ $DISTRO == "almalinux8" || $DISTRO == "rocky8" ]]; then
-    ALMA_PYTHON_OVERRIDE="-e ansible_python_interpreter=/usr/libexec/platform-python"
-fi
 
 export ENABLE_LOCAL_REGISTRY=${ENABLE_LOCAL_REGISTRY:-}
 

--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -28,7 +28,6 @@ ansible-playbook \
     -e "virthost=$HOSTNAME" \
     -e "manage_baremetal=$MANAGE_BR_BRIDGE" \
     -e "nodes_file=$NODES_FILE" \
-    $ALMA_PYTHON_OVERRIDE \
     -i ${VM_SETUP_PATH}/inventory.ini \
     -b -vvv ${VM_SETUP_PATH}/teardown-playbook.yml
 

--- a/images/Dockerfile.ci
+++ b/images/Dockerfile.ci
@@ -5,24 +5,10 @@ FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-open
 
 ENV HOME /output
 
-# For RHEL8
-RUN if grep "platform:el8" /etc/os-release ; then \
-    INSTALL_PKGS="ansible python3-pip nss_wrapper" && \
-    dnf install --disablerepo=epel -y $INSTALL_PKGS && \
-    pip3 install packet-python && \
-    ansible-galaxy collection install "community.general:4.8.1" && \
-    dnf clean all && \
-    rm -rf /var/cache/dnf/* && \
-    chmod -R g+rwx /output ; \
-    fi
-
-# For RHEL9
-RUN if grep "platform:el9" /etc/os-release ; then \
-    INSTALL_PKGS="ansible-core python3.11-pip nss_wrapper" && \
+RUN INSTALL_PKGS="ansible-core python3.11-pip nss_wrapper" && \
     dnf install --disablerepo=epel -y $INSTALL_PKGS && \
     pip3.11 install -r https://raw.githubusercontent.com/equinix-labs/ansible-collection-equinix/main/requirements.txt && \
     ansible-galaxy collection install "community.general" "ansible.posix" "equinix.cloud" && \
     dnf clean all && \
     rm -rf /var/cache/dnf/* && \
-    chmod -R g+rwx /output ; \
-    fi
+    chmod -R g+rwx /output

--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -47,10 +47,6 @@ function extract_command() {
 
     _tmpfiles="$_tmpfiles $extract_dir"
 
-    if [[ $cmd == "oc.rhel8" ]]; then
-      cmd="oc"
-    fi
-
     mv "${extract_dir}/${cmd}" "${outdir}"
 }
 
@@ -58,9 +54,7 @@ function extract_command() {
 function extract_oc() {
     extract_dir=$(mktemp --tmpdir -d "installer--XXXXXXXXXX")
     _tmpfiles="$_tmpfiles $extract_dir"
-    if ! extract_command oc.rhel8 "$1" "${extract_dir}"; then
-      extract_command oc "$1" "${extract_dir}"
-    fi
+    extract_command oc "$1" "${extract_dir}"
     sudo mv "${extract_dir}/oc" /usr/local/bin
 }
 

--- a/validation.sh
+++ b/validation.sh
@@ -21,10 +21,10 @@ function early_either_validation() {
         exit 1
     fi
 
-    # Check CentOS version
+    # Check CentOS/RHEL version (el8 is no longer supported due to glibc requirements for oc CLI)
     VER=$(awk -F= '/^VERSION_ID=/ { print $2 }' /etc/os-release | tr -d '"' | cut -f1 -d'.')
-    if [[ ${VER} -lt 8 ]]; then
-        error "CentOS 8/9 or RHEL 8/9 are required."
+    if [[ ${VER} -lt 9 ]]; then
+        error "CentOS 9 or RHEL 9 are required."
         exit 1
     fi
 


### PR DESCRIPTION
Recent OpenShift releases require glibc 2.34+ which is only available in el9. The oc CLI from OCP 4.14+ won't run on el8.

- Remove el8 case from install requirements
- Update validation to require version >= 9
- Remove oc.rhel8 extraction fallback
- Simplify CI Dockerfile to RHEL9 only
- Update README prerequisites