### PR TITLE
Fix redfish_verify_ca boolean handling in certificate

### DIFF
--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -474,7 +474,8 @@ function generate_ocp_host_manifest() {
         encoded_password=$(echo -n "$password" | base64)
         if is_lower_version "$(openshift_version $OCP_DIR)" "4.22"; then
           # Heads up, "verify_ca" in ironic driver config, and "disableCertificateVerification" in BMH have opposite meaning
-          disableCertificateVerification=$([ "$verify_ca" = "False" ] && echo "true" || echo "false")
+          # Handle both boolean false and string "False" - jq outputs boolean false as lowercase "false"
+          disableCertificateVerification=$([[ "${verify_ca,,}" = "false" ]] && echo "true" || echo "false")
         else
           disableCertificateVerification=false
         fi

--- a/utils.sh
+++ b/utils.sh
@@ -272,7 +272,8 @@ EOF
           if is_lower_version "$(openshift_version $OCP_DIR)" "4.22"; then
               # Heads up, "verify ca" in ironic driver config, and "disableCertificateVerification" in BMH have opposite meaning
               verify_ca=$(node_val ${idx} "driver_info.redfish_verify_ca")
-              disable_certificate_verification=$([ "$verify_ca" = "False" ] && echo "true" || echo "false")
+              # Handle both boolean false and string "False" - jq outputs boolean false as lowercase "false"
+              disable_certificate_verification=$([[ "${verify_ca,,}" = "false" ]] && echo "true" || echo "false")
               cat << EOF
           disableCertificateVerification: ${disable_certificate_verification}
 EOF


### PR DESCRIPTION
The code was checking for the string 'False' (capital F), but when jq extracts a boolean false from JSON, it outputs 'false' (lowercase). This caused the check to fail, resulting in TLS verification being enabled even when redfish_verify_ca was set to false in nodes.json.

Fixed by checking for both 'False' and 'false' in both:
- utils.sh: node_map_to_install_config_hosts() function
- ocp_install_env.sh: generate_ocp_host_manifest() function

This ensures that disableCertificateVerification is correctly set to true when redfish_verify_ca is false, allowing Ironic to connect to iDRAC Redfish endpoints with self-signed certificates.

Related to PR 1812 which enabled TLS validation for Redfish emulator.

Cursor GPT-5.2 generated. 