### PR TITLE
OCPBUGS-74430: Fix screen progression issues with agent OVE UI

### DIFF
--- a/agent/isobuilder/ui_driven_cluster_installation/main.go
+++ b/agent/isobuilder/ui_driven_cluster_installation/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -36,6 +37,7 @@ var (
 
 func main() {
 	logrus.Info("Launching headless browser...")
+	time.Sleep(1 * time.Minute)
 	chromiumPath, _ := launcher.LookPath()
   	url := launcher.New().Bin(chromiumPath).NoSandbox(true).Headless(true).MustLaunch()
 	browser := rod.New().ControlURL(url).MustConnect()
@@ -55,6 +57,11 @@ func main() {
 			screenshotPath = filepath.Join(cwd, ocpDir)
 	}
 
+	// Wait 1 minute before entering cluster details to allow backend initialization
+	// This mimics manual usage where a user takes time to read and fill in the form
+	logrus.Info("Waiting 1 minute to allow backend initialization...")
+	time.Sleep(1 * time.Minute)
+
 	logrus.Info("Enter cluster details")
 	err = clusterDetails(page, filepath.Join(screenshotPath, "01-cluster-details.png"))
 	if err != nil {
@@ -63,29 +70,52 @@ func main() {
 
 	next(page)
 
-	// Wait for page to load and check if cluster creation completed in time
+	// Wait for cluster creation to complete and operators page to load
 	logrus.Info("Waiting for operators page to load...")
-	time.Sleep(3 * time.Second)
+	maxRetries := 5
+	retryDelay := 3 * time.Second
 
-	// Check if we got an error page because cluster wasn't created in time
-	errorMsg, _ := page.Timeout(2 * time.Second).ElementR("div", "Cluster details not found")
-	if errorMsg != nil {
-		logrus.Info("Cluster not ready yet, waiting and reloading...")
-		// Wait longer for cluster creation to complete
-		time.Sleep(5 * time.Second)
-		// Reload the page
-		page.MustReload()
-		page.MustWaitLoad()
-		logrus.Info("Page reloaded, continuing...")
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		time.Sleep(retryDelay)
+
+		// Check if we got an error page because cluster wasn't created in time
+		errorMsg, _ := page.Timeout(2 * time.Second).ElementR("div", "Cluster details not found")
+		if errorMsg != nil {
+			if attempt < maxRetries {
+				logrus.Infof("Cluster not ready yet (attempt %d/%d), waiting and reloading...", attempt, maxRetries)
+				page.MustReload()
+				page.MustWaitLoad()
+				retryDelay = retryDelay + (2 * time.Second) // Increase wait time each retry
+			} else {
+				logrus.Error("Cluster creation timeout - cluster not found after multiple retries")
+				saveFullPageScreenshot(page, filepath.Join(screenshotPath, "02-operators-error.png"))
+				log.Fatal("Failed to load cluster - cluster details not found")
+			}
+		} else {
+			// No error page, cluster loaded successfully
+			logrus.Infof("Operators page loaded successfully (attempt %d)", attempt)
+			break
+		}
 	}
 
 	logrus.Info("Select virtualization bundle")
+
+	// Save API state for debugging
+	saveClusterAPIState(screenshotPath, "02-operators")
+
 	err = virtualizationBundle(page, filepath.Join(screenshotPath, "02-operators.png"))
 	if err != nil {
 		log.Fatalf("failed to select virtualization bundle: %v", err)
 	}
 
+	// Wait for operators page to finish loading before clicking Next
+	logrus.Info("Waiting for operators page to finish loading...")
+	time.Sleep(5 * time.Second)
+
 	next(page)
+
+	// Save API state before host discovery
+	saveClusterAPIState(screenshotPath, "03-hostDiscovery")
 
 	logrus.Info("Await host discovery")
 	err = hostDiscovery(page, filepath.Join(screenshotPath, "03-hostDiscovery.png"))
@@ -119,6 +149,9 @@ func main() {
 	}
 
 	next(page)
+
+	// Save API state before starting installation
+	saveClusterAPIState(screenshotPath, "07-review")
 
 	logrus.Info("Review and start cluster installation")
 	err = review(page, filepath.Join(screenshotPath, "07-review.png"))
@@ -172,8 +205,126 @@ func virtualizationBundle(page *rod.Page, path string) error {
 }
 
 func hostDiscovery(page *rod.Page, path string) error {
-	page.MustElement("button[name='next']").MustWaitEnabled()
-	err := saveFullPageScreenshot(page, path)
+	logrus.Info("Looking for Next button on Host Discovery page...")
+
+	// Wait for button to appear with timeout, but don't keep the timeout context
+	_, err := page.Timeout(10 * time.Second).Element("button[name='next']")
+	if err != nil {
+		logrus.Errorf("Could not find Next button: %v", err)
+		// Save debug screenshot
+		saveFullPageScreenshot(page, strings.Replace(path, ".png", "-error.png", 1))
+		return errs.Wrap(err, "Next button not found on Host Discovery page")
+	}
+
+	logrus.Info("Found Next button, waiting for it to be enabled...")
+	logrus.Info("This may take several minutes while hosts complete discovery and validations...")
+
+	// Poll host status while waiting for Next button to be enabled
+	startTime := time.Now()
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+
+	go func() {
+		clustersURL := fmt.Sprintf("http://%s:3001/api/assisted-install/v2/clusters", rendezvousIP)
+		client := resty.New()
+
+		for range ticker.C {
+			var clusters []map[string]interface{}
+			_, apiErr := client.R().SetResult(&clusters).Get(clustersURL)
+			if apiErr == nil && len(clusters) > 0 {
+				cluster := clusters[0]
+				clusterID, _ := cluster["id"].(string)
+				hostsURL := fmt.Sprintf("%s/%s/hosts", clustersURL, clusterID)
+				var hosts []map[string]interface{}
+				client.R().SetResult(&hosts).Get(hostsURL)
+
+				elapsed := time.Since(startTime).Round(time.Second)
+				logrus.Infof("Waiting %v... %d hosts found:", elapsed, len(hosts))
+
+				for _, host := range hosts {
+					hostStatus, _ := host["status"].(string)
+					hostName, _ := host["requested_hostname"].(string)
+					logrus.Infof("  - %s: %s", hostName, hostStatus)
+				}
+			}
+		}
+	}()
+
+	// Use polling instead of WaitEnabled because of timeout context issues
+	// Check every 5 seconds for up to 10 minutes
+	maxWait := 10 * time.Minute
+	pollInterval := 5 * time.Second
+	deadline := time.Now().Add(maxWait)
+
+	pollCount := 0
+	screenshotPath := filepath.Dir(path)
+	for time.Now().Before(deadline) {
+		pollCount++
+
+		// Get fresh button reference without timeout context
+		nextButton, err := page.Element("button[name='next']")
+
+		var isEnabled bool
+		if err == nil && nextButton != nil {
+			enabled, evalErr := nextButton.Eval(`() => !this.disabled`)
+			if evalErr == nil && enabled != nil {
+				isEnabled = enabled.Value.Bool()
+			} else {
+				err = evalErr
+			}
+		}
+
+		// Log button state every 12 polls (every 60 seconds)
+		if pollCount%12 == 0 {
+			elapsed := time.Since(startTime).Round(time.Second)
+			if err != nil {
+				logrus.Infof("[%v] Button check #%d: Error: %v", elapsed, pollCount, err)
+			} else {
+				logrus.Infof("[%v] Button check #%d: Button enabled=%v", elapsed, pollCount, isEnabled)
+			}
+		}
+
+		// Take screenshot every 2 minutes
+		if pollCount%24 == 0 {
+			elapsed := time.Since(startTime).Round(time.Second)
+			minutes := int(elapsed.Minutes())
+
+			// Scroll to bottom to show Next button area
+			if nextButton != nil {
+				nextButton.ScrollIntoView()
+				time.Sleep(500 * time.Millisecond)
+			}
+
+			screenshotFile := filepath.Join(screenshotPath, fmt.Sprintf("03-hostDiscovery-ui-%dmin.png", minutes))
+			saveFullPageScreenshot(page, screenshotFile)
+		}
+
+		if err == nil && isEnabled {
+			logrus.Info("Next button is now enabled!")
+			ticker.Stop()
+			break
+		}
+		time.Sleep(pollInterval)
+	}
+
+	// Check one final time - get fresh button reference
+	nextButton, err := page.Element("button[name='next']")
+	var finalEnabled bool
+	if err == nil && nextButton != nil {
+		enabled, evalErr := nextButton.Eval(`() => !this.disabled`)
+		if evalErr == nil && enabled != nil {
+			finalEnabled = enabled.Value.Bool()
+		}
+	}
+
+	if err != nil || !finalEnabled {
+		ticker.Stop()
+		saveFullPageScreenshot(page, strings.Replace(path, ".png", "-not-enabled.png", 1))
+		return errs.New("timeout waiting for Next button to be enabled")
+	}
+
+	logrus.Info("Next button is enabled, saving screenshot...")
+	err = saveFullPageScreenshot(page, path)
 	if err != nil {
 		return err
 	}
@@ -282,6 +433,39 @@ func waitForClusterConsoleLink(page *rod.Page, path string) error {
 
 func next(page *rod.Page) {
 	page.MustElement("button[name='next']").MustWaitEnabled().MustClick()
+}
+
+// saveClusterAPIState saves the cluster and hosts API state to JSON files for debugging.
+func saveClusterAPIState(screenshotPath, prefix string) {
+	logrus.Infof("Saving cluster API state (%s)...", prefix)
+	client := resty.New()
+	clustersURL := fmt.Sprintf("http://%s:3001/api/assisted-install/v2/clusters", rendezvousIP)
+
+	var clusters []map[string]interface{}
+	_, err := client.R().SetResult(&clusters).Get(clustersURL)
+	if err == nil && len(clusters) > 0 {
+		cluster := clusters[0]
+		clusterID, _ := cluster["id"].(string)
+
+		// Save cluster config
+		clusterJSON, _ := json.MarshalIndent(cluster, "", "  ")
+		clusterFile := filepath.Join(screenshotPath, prefix+"-cluster.json")
+		os.WriteFile(clusterFile, clusterJSON, 0644)
+		logrus.Infof("Saved cluster config to %s", clusterFile)
+
+		// Save hosts config
+		hostsURL := fmt.Sprintf("%s/%s/hosts", clustersURL, clusterID)
+		var hosts []map[string]interface{}
+		_, err = client.R().SetResult(&hosts).Get(hostsURL)
+		if err == nil {
+			hostsJSON, _ := json.MarshalIndent(hosts, "", "  ")
+			hostsFile := filepath.Join(screenshotPath, prefix+"-hosts.json")
+			os.WriteFile(hostsFile, hostsJSON, 0644)
+			logrus.Infof("Saved %d hosts to %s", len(hosts), hostsFile)
+		}
+	} else {
+		logrus.Warnf("Could not retrieve cluster info from API for %s", prefix)
+	}
 }
 
 // saveFullPageScreenshot captures a full-page screenshot and saves it to the given path.


### PR DESCRIPTION
Fixes multiple issues with the behaviour of the UI-driven installation for Agent OVE, i.e. ISO_NO_REGISTRY test.

- Added a delay before starting the installation. Without this delay the ignition_config_overrides do not set since the IGNITION_CONFIG_OVERRIDE feature had not yet been read from InfraEnv
- Handle progression from the Cluster screen to allow cluster creation to complete and Operators page to load
- Fix Host Discovery page loading to proceed when Next button is available

In addition debug has been added to save the cluster and host status retrieved from the API along with additional screenshots.