### PR TITLE
Improve podman cleanup to remove stopped containers and build cache

### DIFF
--- a/podman_cleanup.sh
+++ b/podman_cleanup.sh
@@ -7,5 +7,4 @@ source validation.sh
 
 early_cleanup_validation
 
-sudo podman image prune --all -f
-sudo podman volume prune -f
+sudo podman system prune -a --volumes --force 


### PR DESCRIPTION
Enhances the podman cleanup script to properly remove all unused containers, images, volumes, and build cache.                                                                                                         
                                                                                                                                                                                                                         
The existing cleanup only ran:                                                                                                                                                                                         
 `podman image prune --all -f` - Only removes dangling/untagged images                                                                                                                                                
 `podman volume prune -f` - Only removes unused volumes                                                                                                                                                               
                                                                                                                                                                                                                         
  This left behind:                                                                                                                                                                                                      
  - Stopped containers                                                                                                                                                                                                   
  - Images associated with stopped containers                                                                                                                                                                            
  - Overlay storage layers from failed builds                                                                                                                                                                            
  - Build cache                                                                                                                                                                                                          
                                                                                                                                                                                                                         
 This caused storage to accumulate from failed ISO builds, often leading to `no space left on device` errors during the OVE ISO generation on local developer machines.                                                                                 
         