### PR TITLE
OCPBUGS-76433: Increase delay for cluster creation in UI-driven install

### DIFF
--- a/agent/isobuilder/ui_driven_cluster_installation/main.go
+++ b/agent/isobuilder/ui_driven_cluster_installation/main.go
@@ -139,7 +139,7 @@ func clusterDetails(page *rod.Page, path string) error {
 	page.MustElement("#form-input-pullSecret-field").MustInput(`{"auths":{"":{"auth":"dXNlcjpwYXNz"}}}`)
 
 	// Allow UI enough time to complete the background API call to create the cluster
-	time.Sleep(2 * time.Second)
+	time.Sleep(10 * time.Second)
 	page.MustElement("button[name='next']").MustWaitEnabled()
 
 	err := saveFullPageScreenshot(page, path)


### PR DESCRIPTION
If the delay is too short after cluster creation we consistently get failures as the Next button isn't available yet. Increase this delay to improve reliability.