### PR TITLE
Add config templates and use-template.sh for common deployment scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,17 @@ Considering that this is a new install on a clean OS, the next tasks should be p
 
 5. Create a config file
 
+    **Option A** - Use a pre-built template (recommended):
+
+    ```bash
+    ./use-template.sh --list              # See available templates
+    ./use-template.sh ipi-ipv4-compact    # Activate a template
+    ```
+
+    See [config-templates/](config-templates/) for all available templates.
+
+    **Option B** - Start from the full example:
+
     `cp config_example.sh config_$USER.sh`
 
 6. Configure dev-scripts working directory
@@ -60,7 +71,30 @@ Considering that this is a new install on a clean OS, the next tasks should be p
 
 ## Configuration
 
-Make a copy of the `config_example.sh` to `config_$USER.sh`.
+### Using Templates (recommended)
+
+Pre-built templates are available in [`config-templates/`](config-templates/) for common deployment scenarios. Use the helper script to activate one:
+
+```bash
+# List all templates
+./use-template.sh --list
+
+# Activate a template - creates config_$USER.sh
+./use-template.sh ipi-ipv4-compact
+
+# Or pass CI_TOKEN directly
+CI_TOKEN=sha256~xxxx ./use-template.sh agent-sno-ipv4
+```
+
+Then edit `config_$USER.sh` to set your `CI_TOKEN` if you haven't passed it via environment.
+
+### Manual Configuration
+
+Alternatively, make a copy of the `config_example.sh` to `config_$USER.sh`:
+
+```bash
+cp config_example.sh config_$USER.sh
+```
 
 Go to https://console-openshift-console.apps.ci.l2s4.p1.openshiftapps.com/, click on your name in the top
 right, copy the login command, extract the token from the command and

--- a/config-templates/README.md
+++ b/config-templates/README.md
@@ -1,0 +1,95 @@
+# Config Templates
+
+Pre-built configuration templates for common dev-scripts deployment scenarios.
+
+## Quick Start
+
+```bash
+# List available templates
+./use-template.sh --list
+
+# Activate a template (copies it to config_$USER.sh)
+./use-template.sh <template-name>
+
+# Edit to add your CI_TOKEN (if not already set)
+vi config_$USER.sh
+
+# Deploy (IPI)
+make
+
+# Deploy (Agent-based)
+cd agent && ./01_agent_requirements.sh && ./03_agent_build_installer.sh && \
+  ./04_agent_prepare_release.sh && ./05_agent_configure.sh && \
+  ./06_agent_create_cluster.sh
+```
+
+You can also pass `CI_TOKEN` via environment variable to skip the manual edit:
+
+```bash
+CI_TOKEN=sha256~your-token ./use-template.sh ipi-ipv4-compact
+make
+```
+
+## Available Templates
+
+### IPI (Installer Provisioned Infrastructure)
+
+| Template | Description | Masters | Workers | IP Stack |
+|----------|-------------|---------|---------|----------|
+| `ipi-ipv4-compact` | Compact IPv4 cluster | 3 | 0 | IPv4 |
+| `ipi-ipv4-ha` | HA IPv4 cluster | 3 | 2 | IPv4 |
+| `ipi-ipv6-ha` | HA IPv6 cluster | 3 | 2 | IPv6 |
+| `ipi-dualstack-v4v6-ha` | HA dual-stack cluster (IPv4-primary) | 3 | 2 | v4v6 |
+| `ipi-dualstack-v6v4-ha` | HA dual-stack cluster (IPv6-primary) | 3 | 2 | v6v4 |
+
+### Agent-Based Installer
+
+| Template | Description | Scenario | IP Stack |
+|----------|-------------|----------|----------|
+| `agent-sno-ipv4` | Single Node OpenShift | SNO_IPV4 | IPv4 |
+| `agent-sno-ipv6` | Single Node OpenShift | SNO_IPV6 | IPv6 |
+| `agent-compact-ipv4` | Compact cluster (3 masters) | COMPACT_IPV4 | IPv4 |
+| `agent-ha-ipv4` | HA cluster (3+2) | HA_IPV4 | IPv4 |
+| `agent-ha-ipv6` | HA cluster (3+2) | HA_IPV6 | IPv6 |
+
+## Customizing Templates
+
+After activating a template, you can edit `config_$USER.sh` to customize any
+settings. See [config_example.sh](../config_example.sh) for a full reference of
+all available options.
+
+Common customizations:
+
+```bash
+# Change the OCP version
+export OPENSHIFT_RELEASE_STREAM="4.21"
+
+# Use a GA release instead of nightly
+export OPENSHIFT_RELEASE_TYPE="ga"
+
+# Increase VM resources
+export MASTER_MEMORY=32768
+export MASTER_VCPU=16
+
+# Change working directory
+export WORKING_DIR="/home/dev-scripts"
+
+# Enable FIPS
+export FIPS_MODE=true
+
+# Enable MetalLB
+export ENABLE_METALLB_MODE="l2"
+```
+
+## Creating New Templates
+
+To add a new template, create a `.sh` file in this directory following the
+existing naming convention:
+
+- `<method>-<variant>-<ip-stack>.sh`
+- Examples: `ipi-ipv4-compact.sh`, `agent-sno-ipv4.sh`
+
+Each template should include:
+1. A header comment describing the deployment scenario
+2. The `CI_TOKEN` placeholder block
+3. Only the settings that differ from defaults

--- a/config-templates/agent-compact-ipv4.sh
+++ b/config-templates/agent-compact-ipv4.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+################################################################################
+## Agent-Based Compact IPv4 (3 masters, 0 workers)
+##
+## A compact cluster using the agent-based installer with IPv4 networking.
+## Three control-plane nodes that also run workloads, no dedicated workers.
+##
+## Usage:
+##   ./use-template.sh agent-compact-ipv4
+##   # Then edit config_$USER.sh to set your CI_TOKEN
+##   cd agent && ./01_agent_requirements.sh && ./03_agent_build_installer.sh && \
+##     ./04_agent_prepare_release.sh && ./05_agent_configure.sh && \
+##     ./06_agent_create_cluster.sh
+##
+################################################################################
+
+# CI_TOKEN - **REQUIRED**
+# Get this token from https://console-openshift-console.apps.ci.l2s4.p1.openshiftapps.com/
+# by clicking on your name in the top right corner and copying the login command
+set +x
+export CI_TOKEN='<insert-your-token-here>'
+set -x
+
+# Network: IPv4 single stack (default is v6)
+export IP_STACK="v4"
+
+# Agent-based installer settings
+export AGENT_E2E_TEST_SCENARIO="COMPACT_IPV4"

--- a/config-templates/agent-ha-ipv4.sh
+++ b/config-templates/agent-ha-ipv4.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+################################################################################
+## Agent-Based HA IPv4 (3 masters, 2 workers)
+##
+## A full HA cluster using the agent-based installer with IPv4 networking.
+## Standard production-like topology with separate control plane and workers.
+##
+## Usage:
+##   ./use-template.sh agent-ha-ipv4
+##   # Then edit config_$USER.sh to set your CI_TOKEN
+##   cd agent && ./01_agent_requirements.sh && ./03_agent_build_installer.sh && \
+##     ./04_agent_prepare_release.sh && ./05_agent_configure.sh && \
+##     ./06_agent_create_cluster.sh
+##
+################################################################################
+
+# CI_TOKEN - **REQUIRED**
+# Get this token from https://console-openshift-console.apps.ci.l2s4.p1.openshiftapps.com/
+# by clicking on your name in the top right corner and copying the login command
+set +x
+export CI_TOKEN='<insert-your-token-here>'
+set -x
+
+# Network: IPv4 single stack (default is v6)
+export IP_STACK="v4"
+
+# Agent-based installer settings
+export AGENT_E2E_TEST_SCENARIO="HA_IPV4"

--- a/config-templates/agent-ha-ipv6.sh
+++ b/config-templates/agent-ha-ipv6.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+################################################################################
+## Agent-Based HA IPv6 (3 masters, 2 workers)
+##
+## A full HA cluster using the agent-based installer with IPv6 networking.
+## Useful for testing IPv6-only environments with agent-based deployments.
+##
+## Usage:
+##   ./use-template.sh agent-ha-ipv6
+##   # Then edit config_$USER.sh to set your CI_TOKEN
+##   cd agent && ./01_agent_requirements.sh && ./03_agent_build_installer.sh && \
+##     ./04_agent_prepare_release.sh && ./05_agent_configure.sh && \
+##     ./06_agent_create_cluster.sh
+##
+################################################################################
+
+# CI_TOKEN - **REQUIRED**
+# Get this token from https://console-openshift-console.apps.ci.l2s4.p1.openshiftapps.com/
+# by clicking on your name in the top right corner and copying the login command
+set +x
+export CI_TOKEN='<insert-your-token-here>'
+set -x
+
+# Agent-based installer settings
+export AGENT_E2E_TEST_SCENARIO="HA_IPV6"
+
+# Local registry is required for IPv6 deployments
+export ENABLE_LOCAL_REGISTRY=true

--- a/config-templates/agent-sno-ipv4.sh
+++ b/config-templates/agent-sno-ipv4.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+################################################################################
+## Agent-Based SNO IPv4 (Single Node OpenShift)
+##
+## A single-node OpenShift deployment using the agent-based installer.
+## Ideal for edge computing scenarios or minimal footprint testing.
+##
+## Usage:
+##   ./use-template.sh agent-sno-ipv4
+##   # Then edit config_$USER.sh to set your CI_TOKEN
+##   cd agent && ./01_agent_requirements.sh && ./03_agent_build_installer.sh && \
+##     ./04_agent_prepare_release.sh && ./05_agent_configure.sh && \
+##     ./06_agent_create_cluster.sh
+##
+################################################################################
+
+# CI_TOKEN - **REQUIRED**
+# Get this token from https://console-openshift-console.apps.ci.l2s4.p1.openshiftapps.com/
+# by clicking on your name in the top right corner and copying the login command
+set +x
+export CI_TOKEN='<insert-your-token-here>'
+set -x
+
+# Network: IPv4 single stack (default is v6)
+export IP_STACK="v4"
+
+# Agent-based installer settings
+export AGENT_E2E_TEST_SCENARIO="SNO_IPV4"

--- a/config-templates/agent-sno-ipv6.sh
+++ b/config-templates/agent-sno-ipv6.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+################################################################################
+## Agent-Based SNO IPv6 (Single Node OpenShift)
+##
+## A single-node OpenShift deployment using the agent-based installer with
+## IPv6 networking. For edge scenarios requiring IPv6-only connectivity.
+##
+## Usage:
+##   ./use-template.sh agent-sno-ipv6
+##   # Then edit config_$USER.sh to set your CI_TOKEN
+##   cd agent && ./01_agent_requirements.sh && ./03_agent_build_installer.sh && \
+##     ./04_agent_prepare_release.sh && ./05_agent_configure.sh && \
+##     ./06_agent_create_cluster.sh
+##
+################################################################################
+
+# CI_TOKEN - **REQUIRED**
+# Get this token from https://console-openshift-console.apps.ci.l2s4.p1.openshiftapps.com/
+# by clicking on your name in the top right corner and copying the login command
+set +x
+export CI_TOKEN='<insert-your-token-here>'
+set -x
+
+# Agent-based installer settings
+export AGENT_E2E_TEST_SCENARIO="SNO_IPV6"
+
+# Local registry is required for IPv6 deployments
+export ENABLE_LOCAL_REGISTRY=true

--- a/config-templates/ipi-dualstack-v4v6-ha.sh
+++ b/config-templates/ipi-dualstack-v4v6-ha.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+################################################################################
+## IPI Dual-Stack HA Cluster (IPv4-primary, 3 masters, 2 workers)
+##
+## A dual-stack cluster using traditional IPI with Ironic.
+## IPv4-primary with IPv6 secondary.
+##
+## Usage:
+##   ./use-template.sh ipi-dualstack-v4v6-ha
+##   # Then edit config_$USER.sh to set your CI_TOKEN
+##   make
+##
+################################################################################
+
+# CI_TOKEN - **REQUIRED**
+# Get this token from https://console-openshift-console.apps.ci.l2s4.p1.openshiftapps.com/
+# by clicking on your name in the top right corner and copying the login command
+set +x
+export CI_TOKEN='<insert-your-token-here>'
+set -x
+
+# Network: IPv4-primary dual stack
+export IP_STACK="v4v6"
+
+# Local registry is required for dual-stack deployments
+export ENABLE_LOCAL_REGISTRY=true

--- a/config-templates/ipi-dualstack-v6v4-ha.sh
+++ b/config-templates/ipi-dualstack-v6v4-ha.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+################################################################################
+## IPI Dual-Stack HA Cluster (IPv6-primary, 3 masters, 2 workers)
+##
+## A dual-stack cluster using traditional IPI with Ironic.
+## IPv6-primary with IPv4 secondary.
+##
+## Usage:
+##   ./use-template.sh ipi-dualstack-v6v4-ha
+##   # Then edit config_$USER.sh to set your CI_TOKEN
+##   make
+##
+################################################################################
+
+# CI_TOKEN - **REQUIRED**
+# Get this token from https://console-openshift-console.apps.ci.l2s4.p1.openshiftapps.com/
+# by clicking on your name in the top right corner and copying the login command
+set +x
+export CI_TOKEN='<insert-your-token-here>'
+set -x
+
+# Network: IPv6-primary dual stack
+export IP_STACK="v6v4"
+
+# Local registry is required for dual-stack deployments
+export ENABLE_LOCAL_REGISTRY=true

--- a/config-templates/ipi-ipv4-compact.sh
+++ b/config-templates/ipi-ipv4-compact.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+################################################################################
+## IPI IPv4 Compact Cluster (3 masters, 0 workers)
+##
+## A minimal IPv4 single-stack compact cluster using traditional IPI
+## (Installer Provisioned Infrastructure) with Ironic.
+## Good for local development and testing with reduced resource requirements.
+##
+## Usage:
+##   ./use-template.sh ipi-ipv4-compact
+##   # Then edit config_$USER.sh to set your CI_TOKEN
+##   make
+##
+################################################################################
+
+# CI_TOKEN - **REQUIRED**
+# Get this token from https://console-openshift-console.apps.ci.l2s4.p1.openshiftapps.com/
+# by clicking on your name in the top right corner and copying the login command
+set +x
+export CI_TOKEN='<insert-your-token-here>'
+set -x
+
+# Network: IPv4 single stack (default is v6)
+export IP_STACK="v4"
+
+# Compact cluster: no workers
+export NUM_WORKERS=0

--- a/config-templates/ipi-ipv4-ha.sh
+++ b/config-templates/ipi-ipv4-ha.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+################################################################################
+## IPI IPv4 HA Cluster (3 masters, 2 workers)
+##
+## A full HA IPv4 cluster using traditional IPI (Installer Provisioned
+## Infrastructure) with Ironic. Standard deployment with separate control
+## plane and worker nodes.
+##
+## Usage:
+##   ./use-template.sh ipi-ipv4-ha
+##   # Then edit config_$USER.sh to set your CI_TOKEN
+##   make
+##
+################################################################################
+
+# CI_TOKEN - **REQUIRED**
+# Get this token from https://console-openshift-console.apps.ci.l2s4.p1.openshiftapps.com/
+# by clicking on your name in the top right corner and copying the login command
+set +x
+export CI_TOKEN='<insert-your-token-here>'
+set -x
+
+# Network: IPv4 single stack (default is v6)
+export IP_STACK="v4"

--- a/config-templates/ipi-ipv6-ha.sh
+++ b/config-templates/ipi-ipv6-ha.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+################################################################################
+## IPI IPv6 HA Cluster (3 masters, 2 workers)
+##
+## A full HA IPv6 single-stack cluster using traditional IPI with Ironic.
+## Useful for testing IPv6-only environments.
+##
+## Usage:
+##   ./use-template.sh ipi-ipv6-ha
+##   # Then edit config_$USER.sh to set your CI_TOKEN
+##   make
+##
+################################################################################
+
+# CI_TOKEN - **REQUIRED**
+# Get this token from https://console-openshift-console.apps.ci.l2s4.p1.openshiftapps.com/
+# by clicking on your name in the top right corner and copying the login command
+set +x
+export CI_TOKEN='<insert-your-token-here>'
+set -x
+
+# Local registry is required for IPv6 deployments
+export ENABLE_LOCAL_REGISTRY=true

--- a/use-template.sh
+++ b/use-template.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+################################################################################
+## use-template.sh - Activate a config template for dev-scripts
+##
+## Copies a template from config-templates/ to config_$USER.sh so that
+## dev-scripts picks it up automatically. If CI_TOKEN is already set in the
+## environment or in an existing config file, it is preserved.
+##
+## Usage:
+##   ./use-template.sh <template-name>    # Copy template to config_$USER.sh
+##   ./use-template.sh --list             # List available templates
+##   ./use-template.sh --help             # Show this help
+##
+## Examples:
+##   ./use-template.sh ipi-ipv4-compact
+##   ./use-template.sh agent-sno-ipv4
+##   CI_TOKEN=sha256~xxx ./use-template.sh ipi-ipv4-ha
+##
+################################################################################
+
+set -euo pipefail
+
+SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEMPLATES_DIR="${SCRIPTDIR}/config-templates"
+TARGET="${SCRIPTDIR}/config_${USER}.sh"
+PLACEHOLDER="<insert-your-token-here>"
+
+usage() {
+    echo "Usage: $0 <template-name> | --list | --help"
+    echo ""
+    echo "Copies a deployment template to config_${USER}.sh"
+    echo ""
+    echo "Options:"
+    echo "  --list, -l    List available templates"
+    echo "  --help, -h    Show this help message"
+    echo ""
+    echo "The CI_TOKEN can be provided in three ways (in order of priority):"
+    echo "  1. CI_TOKEN environment variable"
+    echo "  2. Existing CI_TOKEN in current config_${USER}.sh"
+    echo "  3. Manual edit after template is copied"
+    echo ""
+    echo "Examples:"
+    echo "  $0 ipi-ipv4-compact"
+    echo "  CI_TOKEN=sha256~xxxx $0 agent-sno-ipv4"
+}
+
+list_templates() {
+    echo "Available templates:"
+    echo ""
+    for template in "${TEMPLATES_DIR}"/*.sh; do
+        [ -f "$template" ] || continue
+        name=$(basename "$template" .sh)
+        # Extract the description from the first non-border ## comment line
+        description=$(grep '^##' "$template" | grep -v '^####' | head -1 | sed 's/^## //')
+        printf "  %-30s %s\n" "$name" "$description"
+    done
+    echo ""
+    echo "Use '$0 <template-name>' to activate a template."
+}
+
+# Extract existing CI_TOKEN from the current config file, if present
+get_existing_token() {
+    if [ -f "$TARGET" ]; then
+        # Match lines like: export CI_TOKEN='...' or export CI_TOKEN="..."
+        local token
+        token=$(grep -oP "export CI_TOKEN=['\"]?\K[^'\"]*" "$TARGET" 2>/dev/null || true)
+        if [ -n "$token" ] && [ "$token" != "$PLACEHOLDER" ]; then
+            echo "$token"
+        fi
+    fi
+}
+
+# ---- Main ----
+
+if [ $# -eq 0 ]; then
+    usage
+    exit 1
+fi
+
+case "$1" in
+    --help|-h)
+        usage
+        exit 0
+        ;;
+    --list|-l)
+        list_templates
+        exit 0
+        ;;
+    -*)
+        echo "Error: Unknown option '$1'"
+        usage
+        exit 1
+        ;;
+esac
+
+TEMPLATE_NAME="$1"
+TEMPLATE_FILE="${TEMPLATES_DIR}/${TEMPLATE_NAME}.sh"
+
+if [ ! -f "$TEMPLATE_FILE" ]; then
+    echo "Error: Template '${TEMPLATE_NAME}' not found."
+    echo ""
+    list_templates
+    exit 1
+fi
+
+# Determine the CI_TOKEN to inject
+TOKEN=""
+
+# Priority 1: CI_TOKEN from environment
+if [ -n "${CI_TOKEN:-}" ]; then
+    TOKEN="$CI_TOKEN"
+fi
+
+# Priority 2: CI_TOKEN from existing config file
+if [ -z "$TOKEN" ]; then
+    TOKEN=$(get_existing_token)
+fi
+
+# Backup existing config if present
+if [ -f "$TARGET" ]; then
+    BACKUP="${TARGET}.bak"
+    cp "$TARGET" "$BACKUP"
+    echo "Backed up existing config to $(basename "$BACKUP")"
+fi
+
+# Copy template
+cp "$TEMPLATE_FILE" "$TARGET"
+
+# Inject CI_TOKEN if we have one
+if [ -n "$TOKEN" ]; then
+    sed -i "s|${PLACEHOLDER}|${TOKEN}|g" "$TARGET"
+    if [ -n "${CI_TOKEN:-}" ]; then
+        echo "CI_TOKEN has been set from environment variable."
+    else
+        echo "CI_TOKEN has been preserved from existing config."
+    fi
+else
+    echo ""
+    echo "WARNING: CI_TOKEN is not set."
+    echo "  Edit ${TARGET} and replace '${PLACEHOLDER}' with your token."
+    echo "  Get your token from: https://console-openshift-console.apps.ci.l2s4.p1.openshiftapps.com/"
+    echo ""
+fi
+
+echo "Template '${TEMPLATE_NAME}' activated as $(basename "$TARGET")"
+echo ""
+
+# Show a summary of what was configured
+echo "Configuration summary:"
+grep -E "^export " "$TARGET" | grep -v "CI_TOKEN" | sed 's/^export /  /'


### PR DESCRIPTION
Add pre-built configuration templates under config-templates/ covering IPI (ipv4, ipv6, dualstack, compact) and agent-based (SNO, HA, compact) deployments. Templates only set values that override defaults, so they stay minimal and don't drift as defaults change.

The use-template.sh helper copies a template to config_$USER.sh and preserves the CI_TOKEN across template switches.