### PR TITLE
Use set -euxo pipefail in 01_install_requirements

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -ex
+set -euxo pipefail
 
 
 source logging.sh
@@ -10,7 +10,7 @@ source validation.sh
 
 early_deploy_validation true
 
-if [ -z "${METAL3_DEV_ENV}" ]; then
+if [ -z "${METAL3_DEV_ENV:-}" ]; then
   export REPO_PATH=${WORKING_DIR}
   sync_repo_and_patch metal3-dev-env https://github.com/metal3-io/metal3-dev-env.git
   pushd ${METAL3_DEV_ENV_PATH}
@@ -153,7 +153,7 @@ GO_CHECKSUM="$(
 )"
 
 if [ -z "$GO_CHECKSUM" ]; then
-  echo "Error: Could not find checksum for $VERSION ($OS/$ARCH)" >&2
+  echo "Error: Could not find checksum for $VERSION ($OS/$GOARCH)" >&2
 else
   echo "Checksum: $GO_CHECKSUM"
 fi
@@ -180,17 +180,17 @@ ANSIBLE_FORCE_COLOR=true ansible-playbook \
   -b -vvv vm-setup/install-package-playbook.yml
 popd
 
-if [ -n "${KNI_INSTALL_FROM_GIT}" ]; then
+if [ -n "${KNI_INSTALL_FROM_GIT:-}" ]; then
     # zip is required for building the installer from source
     sudo dnf -y install zip
 fi
 
 # Install nfs for persistent volumes
-if [ "${PERSISTENT_IMAGEREG}" == true ] ; then
+if [ "${PERSISTENT_IMAGEREG:-}" == true ] ; then
     sudo dnf -y install nfs-utils
 fi
 
-if [[ "${NODES_PLATFORM}" == "baremetal" ]] ; then
+if [[ "${NODES_PLATFORM:-}" == "baremetal" ]] ; then
     sudo dnf -y install ipmitool
 fi
 

--- a/common.sh
+++ b/common.sh
@@ -6,9 +6,10 @@ export PATH="/usr/local/go/bin:$HOME/.local/bin:$PATH"
 # Set a PS4 value which logs the script name and line #.
 export PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
-eval "$(go env)"
-
-export PATH="${GOPATH}/bin:$PATH"
+if command -v go &>/dev/null; then
+    eval "$(go env)"
+    export PATH="${GOPATH}/bin:$PATH"
+fi
 
 # Ensure if a go program crashes we get a coredump
 #
@@ -169,7 +170,9 @@ if [ -z "${OPENSHIFT_RELEASE_IMAGE:-}" ]; then
   fi
 fi
 export OPENSHIFT_RELEASE_IMAGE="${OPENSHIFT_RELEASE_IMAGE:-$LATEST_CI_IMAGE}"
-export OPENSHIFT_INSTALL_PATH="${OPENSHIFT_INSTALL_PATH:-$GOPATH/src/github.com/openshift/installer}"
+if [[ -n "${GOPATH:-}" ]]; then
+    export OPENSHIFT_INSTALL_PATH="${OPENSHIFT_INSTALL_PATH:-$GOPATH/src/github.com/openshift/installer}"
+fi
 
 # Override the image to use for installing hive
 export HIVE_DEPLOY_IMAGE="${HIVE_DEPLOY_IMAGE:-registry.ci.openshift.org/openshift/hive-v4.0:hive}"


### PR DESCRIPTION
Replace set -ex with set -euxo pipefail for consistency with
02_configure_host.sh and 04_setup_ironic.sh.

Guard optional environment variables with :- defaults to avoid
nounset errors and fix a $ARCH typo that should be $GOARCH.

Also fix common.sh to handle the case where Go is not yet installed
when sourced by 01_install_requirements.sh — skip 'go env' if the
go binary is absent and default GOPATH to empty.