### PR TITLE
CORENET-6097: Open BGP port 179 for no-overlay mode

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -122,6 +122,9 @@ sudo systemctl enable --now firewalld
 # access.
 configure_chronyd
 
+# Open BGP port for no-overlay mode enabled for default network
+sudo firewall-cmd --zone=libvirt --add-port=179/tcp
+
 export VNC_CONSOLE=true
 if [[ $(uname -m) == "aarch64" ]]; then
   VNC_CONSOLE=false


### PR DESCRIPTION
Add firewall rule to open port 179/tcp in the libvirt zone during host configuration. This port is required for BGP routing when no-overlay mode is enabled for the default network.