### PR TITLE
OCPEDGE-2463: fix(cluster): add local registry CA trust when MIRROR_IMAGES is enabled

### DIFF
--- a/06_create_cluster.sh
+++ b/06_create_cluster.sh
@@ -71,7 +71,7 @@ EOF
         cluster --type merge --patch '{"spec":{"storage":{"pvc":{"claim":""}},"managementState":"Managed","replicas": 2}}'
 fi
 
-if [[ ! -z "${ENABLE_LOCAL_REGISTRY}" ]]; then
+if [[ -n "${ENABLE_LOCAL_REGISTRY}" ]] || [[ "${MIRROR_IMAGES,,}" != "false" && -n "${MIRROR_IMAGES}" ]]; then
     # Configure tools image registry and cluster samples operator
     # when local image stream is enabled. These are basically to run CI tests
     # depend on tools image.


### PR DESCRIPTION
IPv6 deployments default to MIRROR_IMAGES=true but the local registry CA trust patch only ran when ENABLE_LOCAL_REGISTRY was explicitly set. This caused CAPI to crashloop with x509 certificate errors when pulling from the local registry.

This fix aligns the condition with the pattern used elsewhere in the codebase (utils.sh:150, 474, network.sh:206) to check if MIRROR_IMAGES is active, ensuring the trust bundle is added whenever the local registry is actually in use.