### PR TITLE
NO-JIRA: Bump metal3-dev-env to e5cb63c

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -19,7 +19,7 @@ if [ -z "${METAL3_DEV_ENV}" ]; then
   # TODO -- come up with a plan for continuously updating this
   # Note we only do this in the case where METAL3_DEV_ENV is
   # unset, to enable developer testing of local checkouts
-  git reset f5c0b859717e71c35701905161caa6e65221b3fb --hard
+  git reset e5cb63c6a9dcd0d4544a1ae6855c6769957a8984 --hard
 
   # Ansible 9+ requires Python 3.10+, but CentOS Stream 9 ships Python 3.9.
   # Patch metal3-dev-env to use Ansible 8.x on centos9/rhel9.


### PR DESCRIPTION
 Bump metal3-dev-env pinned commit to e5cb63c6a9dcd0d4544a1ae6855c6769957a8984 which includes metal3-io/metal3-dev-env#1666.

  This increases the DNF retry count from 3 to 5 and delay from 10s to 30s for all package installation Ansible tasks in metal3-dev-env. The "Refresh DNF cache" task was the weakest link with only 30s max wait (3 retries x 10s), which proved insufficient during extended EPEL mirror outages, causing recurring CI install failures.

 The new values (5 retries x 30s = 150s max wait) are closer to what dev-scripts' own 01_install_requirements.sh already uses (MAX_RETRIES=5 with exponential backoff, up to 225s).