### PR TITLE
Use set -euxo pipefail in 03, 05, and 06 scripts

### DIFF
--- a/03_build_installer.sh
+++ b/03_build_installer.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
-set -x
-set -e
+set -euxo pipefail
 
 source logging.sh
 source common.sh

--- a/05_create_install_config.sh
+++ b/05_create_install_config.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
-set -x
-set -e
+set -euxo pipefail
 
 source logging.sh
 source common.sh

--- a/06_create_cluster.sh
+++ b/06_create_cluster.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
-set -x
-set -e
+set -euxo pipefail
 
 source logging.sh
 source common.sh
@@ -14,9 +13,9 @@ source validation.sh
 early_deploy_validation
 
 if [[ ! -z "$INSTALLER_PROXY" ]]; then
-  export HTTP_PROXY=${HTTP_PROXY}
-  export HTTPS_PROXY=${HTTPS_PROXY}
-  export NO_PROXY=${NO_PROXY}
+  export HTTP_PROXY=${HTTP_PROXY:-}
+  export HTTPS_PROXY=${HTTPS_PROXY:-}
+  export NO_PROXY=${NO_PROXY:-}
   # Update libvirt firewalld policy to allow the VM to connect to the proxy
   sudo firewall-cmd --policy=libvirt-to-host --add-port=$INSTALLER_PROXY_PORT/tcp
   # Allow the bootstrap VM to talk directly to services on the bootstrap host
@@ -87,7 +86,7 @@ if [[ -n "${MIRROR_IMAGES}" && "${MIRROR_IMAGES,,}" != "false" ]]; then
       -p '[{"op": "add", "path": "/spec/disableAllDefaultSources", "value": true}]'
 fi
 
-if [[ -n "${APPLY_EXTRA_WORKERS}" ]]; then
+if [[ -n "${APPLY_EXTRA_WORKERS:-}" ]]; then
     if [[ ${NUM_EXTRA_WORKERS} -ne 0 && -s "${OCP_DIR}/extra_host_manifests.yaml" ]]; then
         oc apply -f "${OCP_DIR}/extra_host_manifests.yaml"
 
@@ -108,7 +107,7 @@ if [[ ${NUM_EXTRA_WORKERS} -ne 0 && -d "${OCP_DIR}/extras" ]]; then
     oc create secret generic extraworkers-secret --from-file="${OCP_DIR}/extras/" -n openshift-machine-api
 fi
 
-if [[ -n "${APPLY_ARM_WORKERS}" ]]; then
+if [[ -n "${APPLY_ARM_WORKERS:-}" ]]; then
     if [[ ${NUM_ARM_WORKERS} -ne 0 && -s "${OCP_DIR}/extra_arm_host_manifests.yaml" ]]; then
         oc apply -f "${OCP_DIR}/extra_arm_host_manifests.yaml"
 
@@ -129,9 +128,9 @@ if [[ ${NUM_ARM_WORKERS} -ne 0 && -d "${OCP_DIR}/arm" ]]; then
     oc create secret generic armworkers-secret --from-file="${OCP_DIR}/arm/" -n openshift-machine-api
 fi
 
-if [[ ! -z "${ENABLE_METALLB}" ]]; then
+if [[ ! -z "${ENABLE_METALLB:-}" ]]; then
 
-	if [[ -z ${METALLB_IMAGE_BASE} ]]; then
+	if [[ -z ${METALLB_IMAGE_BASE:-} ]]; then
                 # This can use any image in the release, as we are dropping
                 # the hash
 		export METALLB_IMAGE_BASE=$(\
@@ -145,7 +144,7 @@ if [[ ! -z "${ENABLE_METALLB}" ]]; then
 	popd
 fi
 
-if [[ ! -z "${ENABLE_VIRTUAL_MEDIA_VIA_EXTERNAL_NETWORK}" ]]; then
+if [[ ! -z "${ENABLE_VIRTUAL_MEDIA_VIA_EXTERNAL_NETWORK:-}" ]]; then
     oc patch provisioning provisioning-configuration --type merge -p "{\"spec\":{\"virtualMediaViaExternalNetwork\":true}}"
 fi
 

--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -127,7 +127,7 @@ EOF
 }
 
 function external_mac() {
-  if [ -n "$EXTERNAL_BOOTSTRAP_MAC" ] ; then
+  if [ -n "${EXTERNAL_BOOTSTRAP_MAC:-}" ] ; then
 cat <<EOF
     externalMACAddress: $EXTERNAL_BOOTSTRAP_MAC
 EOF
@@ -196,7 +196,7 @@ EOF
 }
 
 function featureSet() {
-    if [[ -n "$FEATURE_SET" ]]; then
+    if [[ -n "${FEATURE_SET:-}" ]]; then
 cat <<EOF
 featureSet: "$FEATURE_SET"
 EOF
@@ -204,7 +204,7 @@ EOF
 }
 
 function featureGates() {
-    if [[ -n "$FEATURE_GATES" ]]; then
+    if [[ -n "${FEATURE_GATES:-}" ]]; then
 cat <<EOF
 featureGates:
 EOF
@@ -217,7 +217,7 @@ EOF
 }
 
 function osImageStream() {
-    if [[ -n "$OS_IMAGE_STREAM" ]]; then
+    if [[ -n "${OS_IMAGE_STREAM:-}" ]]; then
 cat <<EOF
 osImageStream: "$OS_IMAGE_STREAM"
 EOF
@@ -225,14 +225,14 @@ EOF
 }
 
 function capabilities_stanza() {
-    if [[ -n "$BASELINE_CAPABILITY_SET" ]]; then
+    if [[ -n "${BASELINE_CAPABILITY_SET:-}" ]]; then
 cat <<EOF
 capabilities:
   baselineCapabilitySet: "$BASELINE_CAPABILITY_SET"
 EOF
     fi
 
-    if [[ -n "$BASELINE_CAPABILITY_SET" ]] && [[ -n "$ADDITIONAL_CAPABILITIES" ]]; then
+    if [[ -n "${BASELINE_CAPABILITY_SET:-}" ]] && [[ -n "${ADDITIONAL_CAPABILITIES:-}" ]]; then
 cat << EOF
   additionalEnabledCapabilities:
 EOF
@@ -243,7 +243,7 @@ cat << EOF
 EOF
       done
 
-    elif [[ -n "$ADDITIONAL_CAPABILITIES" ]] && [[ -z "$BASELINE_CAPABILITY_SET" ]]; then
+    elif [[ -n "${ADDITIONAL_CAPABILITIES:-}" ]] && [[ -z "${BASELINE_CAPABILITY_SET:-}" ]]; then
       echo "Additional capabilities is set to: $ADDITIONAL_CAPABILITIES, but no desired BASELINE_CAPABILITY_SET is set"
       exit 1
     fi
@@ -264,7 +264,7 @@ EOF
 }
 
 function workload_partitioning() {
-  if [[ -n "${ENABLE_WORKLOAD_PARTITIONING}" ]]; then
+  if [[ -n "${ENABLE_WORKLOAD_PARTITIONING:-}" ]]; then
 cat <<EOF
 cpuPartitioningMode: AllNodes
 EOF
@@ -280,7 +280,7 @@ EOF
 }
 
 function additional_trust_bundle() {
-  if [[ ! -z "$ADDITIONAL_TRUST_BUNDLE" ]]; then
+  if [[ ! -z "${ADDITIONAL_TRUST_BUNDLE:-}" ]]; then
     if [[ -z "${MIRROR_IMAGES}" || "${MIRROR_IMAGES,,}" != "false" ]] && [[ -z "${ENABLE_LOCAL_REGISTRY}" ]]; then
       echo "additionalTrustBundle: |"
     fi

--- a/utils.sh
+++ b/utils.sh
@@ -74,7 +74,7 @@ function configure_chronyd() {
 function custom_ntp(){
   ASSESTS_DIR=$1
   # TODO - consider adding NTP server config to install-config.yaml instead
-  if [ -z "${NTP_SERVERS}" ]; then
+  if [ -z "${NTP_SERVERS:-}" ]; then
     if host clock.redhat.com; then
       NTP_SERVERS="clock.redhat.com"
     elif host pool.ntp.org; then
@@ -82,7 +82,7 @@ function custom_ntp(){
     fi
   fi
 
-  if [ -n "$NTP_SERVERS" ]; then
+  if [ -n "${NTP_SERVERS:-}" ]; then
     cp assets/templates/98_worker-chronyd-custom.yaml.optional assets/generated/98_worker-chronyd-custom.yaml
     cp assets/templates/98_master-chronyd-custom.yaml.optional assets/generated/98_master-chronyd-custom.yaml
     NTPFILECONTENT=$(cat assets/files/etc/chrony.conf)
@@ -125,13 +125,13 @@ function create_cluster() {
     mkdir -p ${assets_dir}/openshift
     generate_assets
 
-    if [ -z "${NTP_SERVERS}" ];
+    if [ -z "${NTP_SERVERS:-}" ];
     then
       export NTP_SERVERS="$PROVISIONING_HOST_EXTERNAL_IP"
     fi
     custom_ntp ${assets_dir}/openshift
 
-    if [[ "${OVN_LOCAL_GATEWAY_MODE}" == "true" ]] && [[ "${NETWORK_TYPE}" == "OVNKubernetes" ]]; then
+    if [[ "${OVN_LOCAL_GATEWAY_MODE:-}" == "true" ]] && [[ "${NETWORK_TYPE}" == "OVNKubernetes" ]]; then
       local_gateway_mode ${assets_dir}/openshift
     fi
     generate_metal3_config


### PR DESCRIPTION
Replace separate set -x / set -e with set -euxo pipefail in 03_build_installer.sh, 05_create_install_config.sh, and 06_create_cluster.sh for consistency with the other main scripts.

Guard environment variables not set by common.sh with :- defaults in 06_create_cluster.sh to avoid nounset errors.