### PR TITLE
NO-JIRA: fix: set WORKER_DISK default to 100GB for TNA/TNF scenarios

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -483,6 +483,7 @@ if [[ ! -z ${AGENT_E2E_TEST_SCENARIO} ]]; then
           export ARBITER_VCPU=${ARBITER_VCPU:-2}
           export ARBITER_MEMORY=${ARBITER_MEMORY:-8192}
           export ARBITER_DISK=${ARBITER_DISK:-50}
+          export WORKER_DISK=${WORKER_DISK:-100}
           export NUM_WORKERS=${NUM_WORKERS:-0}
           ;;
       "TNF" )
@@ -491,6 +492,7 @@ if [[ ! -z ${AGENT_E2E_TEST_SCENARIO} ]]; then
           export MASTER_DISK=${MASTER_DISK:-100}
           export MASTER_MEMORY=${MASTER_MEMORY:-32768}
           export NUM_WORKERS=${NUM_WORKERS:-0}
+          export WORKER_DISK=${WORKER_DISK:-100}
           export ENABLE_TWO_NODE_FENCING="true"
           ;;
       "HA" )


### PR DESCRIPTION
 Set `WORKER_DISK` default to 100GB for TNA and TNF scenarios. 
 
 Previously these scenarios didn't set `WORKER_DISK` because workers were hardcoded to 0.
 
After #1869 made `NUM_WORKERS` customizable, workers now inherit the global default of 60GB, which may be insufficient for OpenShift node.