### PR TITLE
OCPBUGS-85432: Increase resources for lvm in agent iso-no-registry

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -549,8 +549,8 @@ if [[ ! -z ${AGENT_E2E_TEST_SCENARIO} ]]; then
   # Increase master vCPU for agent OVE ISO installs or when certain operators like 'mtv' are used,
   # as some operators require more CPUs.
   if [ "${AGENT_E2E_TEST_BOOT_MODE}" == "ISO_NO_REGISTRY" ]; then
-    if ((MASTER_VCPU < 9)); then
-      export MASTER_VCPU=9
+    if ((MASTER_VCPU < 10)); then
+      export MASTER_VCPU=10
     fi
     if [ "${SCENARIO}" == "SNO" ]; then
        if ((MASTER_VCPU < 16)); then
@@ -572,6 +572,9 @@ if [[ ! -z ${AGENT_E2E_TEST_SCENARIO} ]]; then
           if ((MASTER_DISK < 300)); then
             export MASTER_DISK=300
           fi
+
+          # The LVM operator is used by default and requires an additional disk
+          export VM_EXTRADISKS=true
         ;;
     esac
   fi


### PR DESCRIPTION
By default the lvm-operator is now included as a dependency for CNV in the iso-no-registry test. The MASTER_VCPU must be increased to 10 in order for the master roles to be correctly assigned. In addition an additional disk must be created, as LVM requires at least one non-installation HDD/SSD disk on the host.