### PR TITLE
Add WORKER_POOL_OS_IMAGE_STREAM

### DIFF
--- a/config_example.sh
+++ b/config_example.sh
@@ -619,6 +619,16 @@ set -x
 #export WORKER_DISK=60
 #export WORKER_VCPU=4
 
+# WORKER_COREOS_STREAM -
+# Override the CoreOS stream label on worker BareMetalHost manifests and the
+# worker MachineSet hostSelector. This controls which IPA (kernel/initrd/rootfs)
+# is used during PXE boot for worker nodes. For example, set to "rhel-10" to
+# boot workers with the RHEL 10 IPA while masters remain on the default stream.
+# Requires matching stream-prefixed images in the machine-os-images container.
+# Default: unset (use the installer's default, typically "rhel-9").
+#
+#export WORKER_COREOS_STREAM=rhel-10
+
 # NUM_EXTRA_WORKERS - Indicate number of extra VMs to create but not deploy.
 # Default: 0
 #

--- a/config_example.sh
+++ b/config_example.sh
@@ -638,6 +638,14 @@ set -x
 #export WORKER_DISK=60
 #export WORKER_VCPU=4
 
+# WORKER_POOL_OS_IMAGE_STREAM -
+# Set osImageStream on the worker compute pool in install-config.yaml.
+# For example, set to "rhel-10" to deploy workers with a different OS
+# stream than the control plane.
+# Default: unset (omitted from install-config).
+#
+#export WORKER_POOL_OS_IMAGE_STREAM=rhel-10
+
 # NUM_EXTRA_WORKERS - Indicate number of extra VMs to create but not deploy.
 # Default: 0
 #

--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -411,6 +411,7 @@ compute:
 - name: worker
   replicas: $NUM_WORKERS
   architecture: $(get_arch install_config)
+$([ -n "${WORKER_POOL_OS_IMAGE_STREAM:-}" ] && echo "  osImageStream: $WORKER_POOL_OS_IMAGE_STREAM")
 controlPlane:
   name: master
   replicas: ${NUM_MASTERS}

--- a/utils.sh
+++ b/utils.sh
@@ -183,6 +183,41 @@ function create_cluster() {
         sed -i s/"watchAllNamespaces: false"/"watchAllNamespaces: true"/ "${assets_dir}/openshift/99_baremetal-provisioning-config.yaml"
     fi
 
+    if [[ -n "${WORKER_COREOS_STREAM:-}" ]]; then
+        # Patch worker BMH manifests to use the specified CoreOS stream.
+        # This controls which IPA (kernel/initrd/rootfs) version is used
+        # during PXE boot for worker nodes.
+        for bmh_file in "${assets_dir}"/openshift/99_openshift-cluster-api_hosts-*.yaml; do
+            if ! grep -q 'installer.openshift.io/role: control-plane' "${bmh_file}"; then
+                sed -i "s/coreos.openshift.io\/stream: .*/coreos.openshift.io\/stream: ${WORKER_COREOS_STREAM}/" "${bmh_file}"
+            fi
+        done
+        # Patch worker MachineSet hostSelector to match the new stream
+        for ms_file in "${assets_dir}"/openshift/99_openshift-cluster-api_worker-machineset-*.yaml; do
+            sed -i "s/coreos.openshift.io\/stream: .*/coreos.openshift.io\/stream: ${WORKER_COREOS_STREAM}/" "${ms_file}"
+        done
+        # Set the worker MachineConfigPool to use the specified stream for
+        # the on-disk OS. Requires the OSStreams feature gate (TechPreviewNoUpgrade).
+        cat > "${assets_dir}/openshift/99_worker-osimagestream.yaml" <<EOF
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  labels:
+    machineconfiguration.openshift.io/mco-built-in: ""
+    pools.operator.machineconfiguration.openshift.io/worker: ""
+  name: worker
+spec:
+  machineConfigSelector:
+    matchLabels:
+      machineconfiguration.openshift.io/role: worker
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/worker: ""
+  osImageStream:
+    name: ${WORKER_COREOS_STREAM}
+EOF
+    fi
+
     if override_openshift_sdn_deprecation; then
       # We had to put `networkType: OVNKubernetes` in the install-config to make the
       # installer happy, so fix that now.


### PR DESCRIPTION
Allow deploying worker nodes with a different CoreOS stream than the default.
When WORKER_POOL_OS_IMAGE_STREAM is set (e.g. "rhel-10"), the worker BMH
manifests and MachineSet hostSelector are configured to use the specified
stream label, and a MachineConfigPool manifest is generated to set
osImageStream for the worker pool.

This enables testing heterogeneous clusters where workers boot with a
different IPA and on-disk OS stream than control-plane nodes.

This depends on https://github.com/openshift/installer/pull/10721