### PR TITLE
NO-ISSUE: Fix ISO no registry artifacts cleanup

### DIFF
--- a/agent/06_agent_create_cluster.sh
+++ b/agent/06_agent_create_cluster.sh
@@ -97,29 +97,6 @@ function assert_agent_no_registry_iso_size(){
   fi
 }
 
-# Deletes all files and directories under asset_dir
-# example, ocp/ostest/iso_builder/4.19.* 
-# except the final generated ISO file (agent-ove.x86_64.iso), 
-# to free up disk space while preserving the built artifact.
-# Note: This optional cleanup is relevant only when the
-# AGENT_CLEANUP_ISO_BUILDER_CACHE_LOCAL_DEV is set as as true, 
-function cleanup_diskspace_agent_iso_noregistry() {
- local asset_dir=${1%/}  # Remove trailing slash if present
-
-  # Iterate over all versioned directories matching 4.19.*
-  for dir in "$asset_dir"/4.19.*; do
-    [ -d "$dir" ] || continue
-
-    echo "Cleaning up directory: $dir"
-
-    # Delete all files and symlinks except the agent-ove.x86_64.iso
-    sudo find "$dir" \( -type f -o -type l \) ! -name 'agent-ove.x86_64.iso' -print -delete
-
-    # Remove any empty directories left behind
-    sudo find "$dir" -type d -empty -print -delete
-  done
-}
-
 function set_device_config_image() {
 
     for (( n=0; n<${2}; n++ ))

--- a/agent/iso_no_registry.sh
+++ b/agent/iso_no_registry.sh
@@ -100,3 +100,26 @@ function create_agent_iso_no_registry() {
   rm -rf "${asset_dir}"/src
   popd
 }
+
+# Deletes all files and directories under asset_dir
+# example, ocp/ostest/iso_builder/4.19.* 
+# except the final generated ISO file (agent-ove.x86_64.iso), 
+# to free up disk space while preserving the built artifact.
+# Note: This optional cleanup is relevant only when the
+# AGENT_CLEANUP_ISO_BUILDER_CACHE_LOCAL_DEV is set as as true, 
+function cleanup_diskspace_agent_iso_noregistry() {
+ local asset_dir=${1%/}  # Remove trailing slash if present
+
+  # Iterate over all versioned directories
+  for dir in "$asset_dir"/[0-9]*.[0-9]*.*; do
+    [ -d "$dir" ] || continue
+
+    echo "Cleaning up directory: $dir"
+
+    # Delete all files and symlinks except the agent-ove.x86_64.iso
+    sudo find "$dir" \( -type f -o -type l \) ! -name 'agent-ove.x86_64.iso' -print -delete
+
+    # Remove any empty directories left behind
+    sudo find "$dir" -type d -empty -print -delete
+  done
+}


### PR DESCRIPTION
Cleans up any OCP version under isobuilder not just 4.19.*. Also moved the iso no registry code into one single central file.