### PR TITLE
Don't include agent GUI log bundle in screenshot archive

### DIFF
--- a/agent/gather.sh
+++ b/agent/gather.sh
@@ -51,11 +51,6 @@ if [[ "$num_screenshots" -gt 0 ]]; then
         files_to_archive+=("${OCP_DIR}"/*.png)
     fi
 
-    # Include installation logs if available
-    if [[ -f "${OCP_DIR}/installation-logs.tar" ]]; then
-        files_to_archive+=("${OCP_DIR}/installation-logs.tar")
-    fi
-
     # Create archive with all collected files
     tar -cJf $archive_name "${files_to_archive[@]}"
 else


### PR DESCRIPTION
If we get past a certain point in installation (presumably the start of bootstrapping), the log bundle downloaded from assisted-service contains secrets that set off the secret detector in CI. (In practice all of these secrets seem to relate to the cluster under test, which has been deleted by the time the CI artifacts are published.) Including this in the screenshots archive (which is the artifact collected by the CI step) means that the entire screenshot archive is redacted.

Continue to download the log bundle for local debugging, but don't include it in the screenshot archive.