### PR TITLE
NO-JIRA: Remove override of MIRROR_IMAGES for OVE

### DIFF
--- a/agent/common.sh
+++ b/agent/common.sh
@@ -92,7 +92,6 @@ if [ "${AGENT_E2E_TEST_BOOT_MODE}" == "ISO_NO_REGISTRY" ] ; then
     if [[ -z "${NETWORKING_MODE}" ]]; then
         export NETWORKING_MODE="DHCP"
     fi
-    export MIRROR_IMAGES=false
 fi
 
 function getRendezvousIP() {

--- a/network.sh
+++ b/network.sh
@@ -139,7 +139,9 @@ elif [[ "$IP_STACK" = "v6" ]]; then
   export SERVICE_SUBNET_V4=""
   export SERVICE_SUBNET_V6=${SERVICE_SUBNET_V6:-"fd02::/112"}
   export NETWORK_TYPE=${NETWORK_TYPE:-"OVNKubernetes"}
-  export MIRROR_IMAGES=${MIRROR_IMAGES:-true}
+  if [[ ${AGENT_E2E_TEST_BOOT_MODE} != "ISO_NO_REGISTRY" ]]; then
+    export MIRROR_IMAGES=${MIRROR_IMAGES:-true}
+  fi
 elif [[ "$IP_STACK" = "v4v6" || "$IP_STACK" = "v6v4" ]]; then
   export CLUSTER_SUBNET_V4=${CLUSTER_SUBNET_V4:-"10.128.0.0/14"}
   export CLUSTER_SUBNET_V6=${CLUSTER_SUBNET_V6:-"fd01::/48"}


### PR DESCRIPTION
MIRROR_IMAGES was set to false for ISO_NO_REGISTRY in https://github.com/openshift-metal3/dev-scripts/pull/1897. this breaks the ability to use local images for testing OVE.