### PR TITLE
NO-JIRA: Fix hardcoded x86_64 references in agent and boot-image paths

### DIFF
--- a/agent/01_agent_requirements.sh
+++ b/agent/01_agent_requirements.sh
@@ -41,7 +41,7 @@ if [[ "${MIRROR_COMMAND}" == oc-mirror ]]; then
    oc_mirror_file=oc-mirror.tar.gz
    oc_mirror_exec=${oc_mirror_file%%.*}
    if [[ ! -f "/usr/local/bin/${oc_mirror_exec}" ]]; then
-      curl -O -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/${oc_mirror_file}
+      curl -O -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/${oc_mirror_file}
       tar xzf ${oc_mirror_file}
       chmod +x "${oc_mirror_exec}"
       sudo mv -f "${oc_mirror_exec}" /usr/local/bin

--- a/agent/06_agent_create_cluster.sh
+++ b/agent/06_agent_create_cluster.sh
@@ -5,6 +5,11 @@ shopt -s nocasematch
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 ARCH=$(uname -m)
 
+CDROM_BUS="sata"
+if [[ "${ARCH}" == "aarch64" ]]; then
+    CDROM_BUS="scsi"
+fi
+
 LOGDIR="${SCRIPTDIR}/logs"
 source "$SCRIPTDIR/logging.sh"
 source "$SCRIPTDIR/common.sh"
@@ -143,13 +148,13 @@ function attach_agent_iso() {
     for (( n=0; n<${2}; n++ ))
     do
         name=${CLUSTER_NAME}_${1}_${n}
-        sudo virt-xml "${name}" --add-device --disk "${agent_iso}",device=cdrom,target.dev=sdc
+        sudo virt-xml "${name}" --add-device --disk "${agent_iso}",device=cdrom,target.dev=sdc,target.bus=${CDROM_BUS}
 	if [ "${AGENT_USE_APPLIANCE_MODEL}" == true ]; then
 	    if [ "${AGENT_APPLIANCE_HOTPLUG}" == true ]; then
                 # Add the device with no image. It will be added later using change-media when config-drive is created
-                sudo virt-xml "${name}" --add-device --disk device=cdrom,target.dev="${config_image_drive}"
+                sudo virt-xml "${name}" --add-device --disk device=cdrom,target.dev="${config_image_drive}",target.bus=${CDROM_BUS}
 	    else
-	        sudo virt-xml "${name}" --add-device --disk "${config_image_dir}/agentconfig.noarch.iso,device=cdrom,target.dev=${config_image_drive}"
+	        sudo virt-xml "${name}" --add-device --disk "${config_image_dir}/agentconfig.noarch.iso,device=cdrom,target.dev=${config_image_drive},target.bus=${CDROM_BUS}"
 	    fi
         fi
         sudo virt-xml "${name}" --edit target=sda --disk="boot_order=1"
@@ -175,8 +180,8 @@ function attach_appliance_diskimage() {
         # Attach the appliance disk image and the config ISO 
         sudo virt-xml "${name}" --remove-device --disk all
         sudo virt-xml "${name}" --add-device --disk "${disk_image}",device=disk,target.dev=sda
-        sudo virt-xml "${name}" --add-device --disk "${config_image_dir}/agentconfig.noarch.iso,device=cdrom,target.dev=${config_image_drive}"
-        
+        sudo virt-xml "${name}" --add-device --disk "${config_image_dir}/agentconfig.noarch.iso,device=cdrom,target.dev=${config_image_drive},target.bus=${CDROM_BUS}"
+
         # Boot machine from the appliance disk image
         sudo virt-xml "${name}" --edit target=sda --disk="boot_order=1" --start
     done
@@ -190,7 +195,7 @@ function attach_agent_iso_no_registry() {
     for (( n=0; n<${2}; n++ ))
     do
         name=${CLUSTER_NAME}_${1}_${n}
-        sudo virt-xml "${name}" --add-device --disk "${agent_iso_no_registry}",device=cdrom,target.dev=sdc
+        sudo virt-xml "${name}" --add-device --disk "${agent_iso_no_registry}",device=cdrom,target.dev=sdc,target.bus=${CDROM_BUS}
         sudo virt-xml "${name}" --edit target=sda --disk="boot_order=1"
         sudo virt-xml "${name}" --edit target=sdc --disk="boot_order=2" --start
     done

--- a/agent/07_agent_add_extraworker_nodes.sh
+++ b/agent/07_agent_add_extraworker_nodes.sh
@@ -76,7 +76,7 @@ case "${AGENT_E2E_TEST_BOOT_MODE}" in
 
     for (( n=0; n < NUM_EXTRA_WORKERS; n++ ))
     do
-        sudo virt-xml "${CLUSTER_NAME}_extraworker_${n}" --add-device --disk "$OCP_DIR/add-node//node.x86_64.iso,device=cdrom,target.dev=sdc"
+        sudo virt-xml "${CLUSTER_NAME}_extraworker_${n}" --add-device --disk "$OCP_DIR/add-node//node.$(uname -m).iso,device=cdrom,target.dev=sdc"
         sudo virt-xml "${CLUSTER_NAME}_extraworker_${n}" --edit target=sda --disk="boot_order=1"
         sudo virt-xml "${CLUSTER_NAME}_extraworker_${n}" --edit target=sdc --disk="boot_order=2" --start
     done

--- a/agent/common.sh
+++ b/agent/common.sh
@@ -48,7 +48,7 @@ export EXTRA_MANIFESTS_PATH="${OCP_DIR}/openshift"
 #    in install-config.yaml, OR
 # 3. ISCSI, to contain the iPXE file needed for iSCSI booting
 export BOOT_SERVER_DIR=${WORKING_DIR}/boot-artifacts
-export PXE_BOOT_FILE=agent.x86_64.ipxe
+export PXE_BOOT_FILE=agent.$(uname -m).ipxe
 # FIXME:  agent/common.sh is sourced without network.sh
 # wrap_if_ipv6 and PROVISIONING_HOST_EXTERNAL_IP are undefined
 # errors masked by export which returns true

--- a/agent/iscsi_utils.sh
+++ b/agent/iscsi_utils.sh
@@ -31,7 +31,7 @@ function agent_create_iscsi_network() {
   <ip address="${ISCSI_NETWORK_SUBNET}.1" netmask="255.255.255.0">
     <dhcp>
       <range start='${ISCSI_NETWORK_SUBNET}.20' end='${ISCSI_NETWORK_SUBNET}.120'/>
-      <bootp file='http://${ISCSI_NETWORK_SUBNET}.1:8089/agent.x86_64-iscsi.ipxe'/>
+      <bootp file='http://${ISCSI_NETWORK_SUBNET}.1:8089/agent.$(uname -m)-iscsi.ipxe'/>
     </dhcp>
   </ip>
 </network>
@@ -79,7 +79,7 @@ function agent_create_iscsi_pxe_file() {
 
     # Set 'hostname' variable in file. It will be resolved by host during PXE boot
     # in order to access a unique target for this host.
-cat > "${boot_dir}/agent.x86_64-iscsi.ipxe" << EOF
+cat > "${boot_dir}/agent.$(uname -m)-iscsi.ipxe" << EOF
 #!ipxe
 set initiator-iqn ${ISCSI_INITIATOR_BASE}:\${hostname}
 sanboot --keep iscsi:${ISCSI_NETWORK_SUBNET}.1::::${ISCSI_INITIATOR_BASE}:\${hostname}

--- a/agent/iso_no_registry.sh
+++ b/agent/iso_no_registry.sh
@@ -106,7 +106,7 @@ function create_agent_iso_no_registry() {
 
 # Deletes all files and directories under asset_dir
 # example, ocp/ostest/iso_builder/4.19.* 
-# except the final generated ISO file (agent-ove.x86_64.iso), 
+# except the final generated ISO file (agent-ove.${ARCH}.iso),
 # to free up disk space while preserving the built artifact.
 # Note: This optional cleanup is relevant only when the
 # AGENT_CLEANUP_ISO_BUILDER_CACHE_LOCAL_DEV is set as as true, 
@@ -119,8 +119,8 @@ function cleanup_diskspace_agent_iso_noregistry() {
 
     echo "Cleaning up directory: $dir"
 
-    # Delete all files and symlinks except the agent-ove.x86_64.iso
-    sudo find "$dir" \( -type f -o -type l \) ! -name 'agent-ove.x86_64.iso' -print -delete
+    # Delete all files and symlinks except the agent-ove ISO
+    sudo find "$dir" \( -type f -o -type l \) ! -name "agent-ove.${ARCH}.iso" -print -delete
 
     # Remove any empty directories left behind
     sudo find "$dir" -type d -empty -print -delete

--- a/rhcos.sh
+++ b/rhcos.sh
@@ -1,6 +1,6 @@
 if $OPENSHIFT_INSTALLER coreos print-stream-json >/dev/null 2>&1; then
     $OPENSHIFT_INSTALLER coreos print-stream-json > "$OCP_DIR/rhcos.json"
-    TOP_LEVEL_FORMAT="$(jq -r '.architectures.x86_64.artifacts.openstack.formats | keys[]' "$OCP_DIR/rhcos.json" | head -n1)"
+    TOP_LEVEL_FORMAT="$(jq -r ".architectures.$(uname -m).artifacts.openstack.formats | keys[]" "$OCP_DIR/rhcos.json" | head -n1)"
     MACHINE_OS_INSTALLER_IMAGE_URL=$(jq -r ".architectures.$(uname -m).artifacts.openstack.formats[\"${TOP_LEVEL_FORMAT}\"].disk.location" "$OCP_DIR/rhcos.json")
     export MACHINE_OS_INSTALLER_IMAGE_URL
     MACHINE_OS_INSTALLER_IMAGE_SHA256=$(jq -r ".architectures.$(uname -m).artifacts.openstack.formats[\"${TOP_LEVEL_FORMAT}\"].disk[\"sha256\"]" "$OCP_DIR/rhcos.json")


### PR DESCRIPTION
## Summary

- Replace hardcoded `x86_64` architecture strings with `$(uname -m)` or `${ARCH}` in agent-based installation scripts and RHCOS boot image resolution
- Enables the agent-based installation path to work on native aarch64 hosts (e.g. AWS Graviton bare metal)
- The IPI path still requires upstream Metal3 multi-arch container images; the agent path does **not** depend on Ironic and can work independently

## Changes

| File | Fix |
|------|-----|
| `agent/common.sh` | PXE boot filename |
| `agent/iscsi_utils.sh` | iSCSI boot filenames (DHCP bootp + generated iPXE file) |
| `agent/07_agent_add_extraworker_nodes.sh` | Extra worker node ISO filename |
| `agent/iso_no_registry.sh` | OVE ISO cleanup exclusion pattern |
| `agent/01_agent_requirements.sh` | oc-mirror download URL |
| `rhcos.sh` | RHCOS format key lookup (was hardcoded to `.architectures.x86_64`, now uses host arch) |

## Context

Companion to #1908 (CPU model fix for native aarch64 KVM). That PR fixes the IPI VM template; this one fixes the agent-based installation path. Both are independent and can merge in either order.

## Test plan

- [ ] Agent-based installation on aarch64 host (AWS Graviton c7g.metal)
- [ ] Verify x86_64 deployments unaffected (all substitutions evaluate to `x86_64` on x86 hosts)
- [ ] PXE boot path
- [ ] iSCSI boot path
- [ ] Extra worker node addition

🤖 Generated with [Claude Code](https://claude.com/claude-code)