### PR TITLE
AGENT-1522: override IRI manifest

### DIFF
--- a/agent/iso_no_registry.sh
+++ b/agent/iso_no_registry.sh
@@ -107,6 +107,68 @@ function create_agent_iso_no_registry() {
 
   rm -rf "${asset_dir}"/src
   popd
+
+  inject_iri_manifest_into_ove_iso
+}
+
+function inject_iri_manifest_into_ove_iso() {
+  local agent_iso_no_registry
+  agent_iso_no_registry=$(get_agent_iso_no_registry)
+
+  local release_version
+  release_version=$(oc adm release info --registry-config "$PULL_SECRET_FILE" "$OPENSHIFT_RELEASE_IMAGE" -o json | jq -r '.metadata.version')
+
+  local version_for_tag="${release_version}"
+  if [[ "${OPENSHIFT_RELEASE_TYPE}" != "ci" ]] && [[ "${OPENSHIFT_RELEASE_TYPE}" != "nightly" ]]; then
+    version_for_tag="${release_version}-x86_64"
+  fi
+
+  local ocp_bundle_str="ocp-release-bundle-${version_for_tag}"
+  if [[ ${#ocp_bundle_str} -gt 64 ]]; then
+    ocp_bundle_str="${ocp_bundle_str:0:64}"
+  fi
+
+  local manifest_content
+  manifest_content=$(cat <<EOF
+apiVersion: machineconfiguration.openshift.io/v1
+kind: InternalReleaseImage
+metadata:
+  name: cluster
+spec:
+  releases:
+  - name: ${ocp_bundle_str}
+EOF
+)
+
+  local manifest_b64
+  manifest_b64=$(echo "${manifest_content}" | base64 -w 0)
+
+  local ign_temp_path
+  ign_temp_path="$(mktemp --directory)"
+
+  echo "Extracting OVE ISO ignition to inject IRI manifest..."
+  podman run --pull=newer --privileged --rm \
+    -v /run/udev:/run/udev \
+    -v "${agent_iso_no_registry}:/data/agent.iso" \
+    -w /data \
+    quay.io/coreos/coreos-installer:release iso ignition show agent.iso \
+    > "${ign_temp_path}/iso.ign"
+
+  jq --arg path "/etc/assisted/extra-manifests/internalreleaseimage.yaml" \
+     --arg source "data:text/plain;charset=utf-8;base64,${manifest_b64}" \
+     '.storage.files = [.storage.files[] | select(.path != $path)] + [{"path": $path, "mode": 420, "overwrite": true, "contents": {"source": $source}}]' \
+     < "${ign_temp_path}/iso.ign" > "${ign_temp_path}/modified.ign"
+
+  echo "Embedding modified ignition with IRI manifest..."
+  podman run --privileged --rm \
+    -v /run/udev:/run/udev \
+    -v "${agent_iso_no_registry}:/data/agent.iso" \
+    -v "${ign_temp_path}/modified.ign:/data/modified.ign" \
+    -w /data \
+    quay.io/coreos/coreos-installer:release iso ignition embed -f -i modified.ign agent.iso
+
+  rm -rf "${ign_temp_path}"
+  echo "IRI manifest injected into OVE ISO"
 }
 
 # Deletes all files and directories under asset_dir

--- a/agent/iso_no_registry.sh
+++ b/agent/iso_no_registry.sh
@@ -122,12 +122,10 @@ function cleanup_diskspace_agent_iso_noregistry() {
   for dir in "$asset_dir"/[0-9]*.[0-9]*.*; do
     [ -d "$dir" ] || continue
 
-    echo "Cleaning up directory: $dir"
-
     # Delete all files and symlinks except the agent-ove ISO
-    sudo find "$dir" \( -type f -o -type l \) ! -name "agent-ove.${ARCH}.iso" -print -delete
+    sudo find "$dir" \( -type f -o -type l \) ! -name "agent-ove.${ARCH}.iso" -delete
 
     # Remove any empty directories left behind
-    sudo find "$dir" -type d -empty -print -delete
+    sudo find "$dir" -type d -empty -delete
   done
 }

--- a/agent/isobuilder/ui_driven_cluster_installation/main.go
+++ b/agent/isobuilder/ui_driven_cluster_installation/main.go
@@ -496,7 +496,38 @@ func virtualizationBundle(page *rod.Page, path string) error {
 	}
 
 	wait(5 * time.Second)
-	page.MustElement("button[name='next']").MustWaitEnabled().MustScrollIntoView().MustWaitEnabled()
+
+	logrus.Info("Looking for next button")
+	nextButton := page.MustElement("button[name='next']")
+	logrus.Info("Found next button")
+	err = saveFullPageScreenshot(page, timestampedPath(path, "next-button-found"))
+	if err != nil {
+		return err
+	}
+
+	logrus.Info("Waiting for the next button to be enabled")
+	wait(5 * time.Second)
+	nextButton.MustWaitEnabled()
+	err = saveFullPageScreenshot(page, timestampedPath(path, "next-button-enabled-1"))
+	if err != nil {
+		return err
+	}
+
+	logrus.Info("Waiting for the next button to be available in scrollable page")
+	wait(5 * time.Second)
+	nextButton.MustScrollIntoView()
+	err = saveFullPageScreenshot(page, timestampedPath(path, "next-button-scrollable"))
+	if err != nil {
+		return err
+	}
+
+	logrus.Info("Waiting for the next button to be enabled")
+	wait(5 * time.Second)
+	nextButton.MustWaitEnabled()
+	err = saveFullPageScreenshot(page, timestampedPath(path, "next-button-enabled-2"))
+	if err != nil {
+		return err
+	}
 
 	err = saveFullPageScreenshot(page, timestampedPath(path, "end"))
 	if err != nil {


### PR DESCRIPTION
Temporarily adds internalreleaseimage extra manifest with machineconfiguration.openshift.io/v1 version

(replaces https://github.com/openshift-metal3/dev-scripts/pull/1912)