### PR TITLE
OCPEDGE-2733: feat: add SNO Bootsrap-in-Place (BiP) installation support

### DIFF
--- a/06_create_cluster.sh
+++ b/06_create_cluster.sh
@@ -32,15 +32,19 @@ if [ -n "$EXTERNAL_LOADBALANCER" ]; then
   ./external_loadbalancer.sh &
 fi
 
-# Call openshift-installer to deploy the bootstrap node and masters
-create_cluster "${OCP_DIR}"
+if [[ "${BOOTSTRAP_IN_PLACE:-false}" == "true" ]]; then
+  create_bip_cluster "${OCP_DIR}"
+else
+  # Call openshift-installer to deploy the bootstrap node and masters
+  create_cluster "${OCP_DIR}"
 
-# Kill the dnsmasq container on the host since it is performing DHCP and doesn't
-# allow our pod in openshift to take over.  We don't want to take down all of ironic
-# as it makes cleanup "make clean" not work properly.
-for name in dnsmasq ironic-inspector ; do
-    sudo podman ps | grep -w "$name$" && sudo podman stop $name
-done
+  # Kill the dnsmasq container on the host since it is performing DHCP and doesn't
+  # allow our pod in openshift to take over.  We don't want to take down all of ironic
+  # as it makes cleanup "make clean" not work properly.
+  for name in dnsmasq ironic-inspector ; do
+      sudo podman ps | grep -w "$name$" && sudo podman stop $name
+  done
+fi
 
 
 # Default to emptyDir for image-reg storage

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: default all agent agent_cleanup agent_build_installer agent_configure agent_create_cluster infra_only requirements configure ironic ocp_run install_config clean ocp_cleanup ironic_cleanup host_cleanup cache_cleanup registry_cleanup proxy_cleanup workingdir_cleanup podman_cleanup bell
+.PHONY: default all agent agent_cleanup agent_build_installer agent_configure agent_create_cluster infra_only sno_bip requirements configure ironic ocp_run install_config clean ocp_cleanup ironic_cleanup host_cleanup cache_cleanup registry_cleanup proxy_cleanup workingdir_cleanup podman_cleanup bell
 default: requirements configure build_installer ironic install_config ocp_run bell
 
 all: default
@@ -12,6 +12,9 @@ agent: agent_requirements requirements configure agent_build_installer agent_pre
 # Deploy cluster with agent installer flow and adds nodes after initial install
 # Requires at least 1 extra worker node to be configured with disk size at least 100Gß
 agent_plus_add_node: agent agent_add_extraworker_nodes
+
+# Deploy SNO cluster using Bootstrap-in-Place (no Ironic, no bootstrap VM)
+sno_bip: requirements configure build_installer install_config ocp_run bell
 
 # Setup infrastructure only (VMs, networks, BMC emulation) without cluster deployment
 # Useful for testing external deployment tools

--- a/common.sh
+++ b/common.sh
@@ -417,6 +417,21 @@ if [[ "${BMC_DRIVER}" != "redfish" ]] && [[ "${ENABLE_TWO_NODE_FENCING:-}" == "t
   exit 1
 fi
 
+# Bootstrap-in-Place (BiP) for Single Node OpenShift
+export BOOTSTRAP_IN_PLACE=${BOOTSTRAP_IN_PLACE:-false}
+export SNO_INSTALLATION_DISK=${SNO_INSTALLATION_DISK:-/dev/sda}
+
+if [[ "${BOOTSTRAP_IN_PLACE}" == "true" ]]; then
+  if [[ ${NUM_MASTERS} -ne 1 ]] || [[ ${NUM_WORKERS} -ne 0 ]]; then
+    echo "BOOTSTRAP_IN_PLACE requires NUM_MASTERS=1 and NUM_WORKERS=0 (SNO configuration)."
+    exit 1
+  fi
+  export MASTER_VCPU=${MASTER_VCPU:-16}
+  export MASTER_DISK=${MASTER_DISK:-120}
+  export MASTER_MEMORY=${MASTER_MEMORY:-32768}
+  export NETWORK_TYPE="OVNKubernetes"
+fi
+
 # Defaults the DISABLE_MULTICAST variable
 export DISABLE_MULTICAST=${DISABLE_MULTICAST:-false}
 

--- a/config_example.sh
+++ b/config_example.sh
@@ -830,6 +830,20 @@ set -x
 # export BOND_CONFIG='none'
 
 ################################################################################
+## Bootstrap-in-Place (BiP) for Single Node OpenShift
+##
+
+# When enabled, deploys SNO without Ironic or a bootstrap VM.
+# The single master bootstraps itself from a RHCOS live ISO with embedded ignition.
+# Use 'make sno_bip' instead of 'make' to skip the Ironic setup step.
+# Requires NUM_MASTERS=1 and NUM_WORKERS=0.
+# export BOOTSTRAP_IN_PLACE=true
+
+# The disk where CoreOS will be installed on the SNO node.
+# Default is /dev/vda (virtio disk for libvirt VMs).
+# export SNO_INSTALLATION_DISK="/dev/vda"
+
+################################################################################
 ## Agent Deployment
 ##
 

--- a/network.sh
+++ b/network.sh
@@ -315,7 +315,7 @@ function configure_dnsmasq() {
   ingressVips=${2}
 
   # make sure the dns_masq config file is cleaned up (add_dnsmasq_multi_entry() only appends)
-  rm -f "${PATH_CONF_DNSMASQ}"
+  sudo rm -f "${PATH_CONF_DNSMASQ}"
 
   add_dnsmasq_multi_entry "apivip" "${apiVips}"
   if [[ ${AGENT_E2E_TEST_BOOT_MODE} == "ISO_NO_REGISTRY" ]] && [[ "${NUM_MASTERS}" -gt "1" ]]; then

--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -360,6 +360,15 @@ EOF
   fi
 }
 
+function bootstrap_in_place_config() {
+  if [[ "${BOOTSTRAP_IN_PLACE:-false}" == "true" ]]; then
+cat <<EOF
+bootstrapInPlace:
+  installationDisk: ${SNO_INSTALLATION_DISK}
+EOF
+  fi
+}
+
 function generate_ocp_install_config() {
     local outdir
 
@@ -406,14 +415,24 @@ controlPlane:
   name: master
   replicas: ${NUM_MASTERS}
   architecture: $(get_arch install_config)
-  platform:
-    baremetal: {}
+$([ "${BOOTSTRAP_IN_PLACE:-false}" != "true" ] && echo '  platform:
+    baremetal: {}')
 $(node_map_to_install_config_fencing_credentials)
 $(arbiter_stanza)
 $(featureSet)
 $(featureGates)
 $(osImageStream)
 $(capabilities_stanza)
+$(bootstrap_in_place_config)
+EOF
+
+  if [[ "${BOOTSTRAP_IN_PLACE:-false}" == "true" ]]; then
+    cat >> "${outdir}/install-config.yaml" << EOF
+platform:
+  none: {}
+EOF
+  else
+    cat >> "${outdir}/install-config.yaml" << EOF
 platform:
   baremetal:
 $(libvirturi)
@@ -429,25 +448,26 @@ $(loadbalancer_type)
     hosts:
 EOF
 
-  if [ -z "${HOSTS_SWAP_DEFINITION:-}" ]; then
-    cat >> "${outdir}/install-config.yaml" << EOF
+    if [ -z "${HOSTS_SWAP_DEFINITION:-}" ]; then
+      cat >> "${outdir}/install-config.yaml" << EOF
 $(node_map_to_install_config_hosts "$NUM_MASTERS" 0 master)
 $(node_map_to_install_config_hosts "$NUM_ARBITERS" "$NUM_MASTERS" arbiter)
 $(node_map_to_install_config_hosts "$NUM_WORKERS" $(( NUM_MASTERS + NUM_ARBITERS )) worker)
 EOF
-  else
-    cat >> "${outdir}/install-config.yaml" << EOF
+    else
+      cat >> "${outdir}/install-config.yaml" << EOF
 $(node_map_to_install_config_hosts "$NUM_WORKERS" $(( NUM_MASTERS + NUM_ARBITERS )) worker)
 $(node_map_to_install_config_hosts "$NUM_ARBITERS" "$NUM_MASTERS" arbiter)
 $(node_map_to_install_config_hosts "$NUM_MASTERS" 0 master)
 EOF
-  fi
+    fi
 
-  if ! is_lower_version "$(openshift_version "$OCP_DIR")" "4.22"; then
-    cat >> "${outdir}/install-config.yaml" << EOF
+    if ! is_lower_version "$(openshift_version "$OCP_DIR")" "4.22"; then
+      cat >> "${outdir}/install-config.yaml" << EOF
     bmcVerifyCA: |
 $(sudo sed 's/^/      /' "${WORKING_DIR}/virtualbmc/sushy-tools/cert.pem")
 EOF
+    fi
   fi
 
     cat >> "${outdir}/install-config.yaml" << EOF

--- a/rhcos.sh
+++ b/rhcos.sh
@@ -23,6 +23,15 @@ if $OPENSHIFT_INSTALLER coreos print-stream-json >/dev/null 2>&1; then
     MACHINE_OS_INSTALLER_BOOTSTRAP_IMAGE_UNCOMPRESSED_SHA256=$(jq -r ".architectures.$(uname -m).artifacts.qemu.formats[\"${TOP_LEVEL_FORMAT}\"].disk[\"uncompressed-sha256\"]" "$OCP_DIR/rhcos.json")
     export MACHINE_OS_INSTALLER_BOOTSTRAP_IMAGE_UNCOMPRESSED_SHA256
     export MACHINE_OS_BOOTSTRAP_IMAGE_UNCOMPRESSED_SHA256=${MACHINE_OS_BOOTSTRAP_IMAGE_UNCOMPRESSED_SHA256:-${MACHINE_OS_INSTALLER_BOOTSTRAP_IMAGE_UNCOMPRESSED_SHA256}}
+
+    if [[ "${BOOTSTRAP_IN_PLACE:-false}" == "true" ]]; then
+        MACHINE_OS_INSTALLER_LIVE_ISO_URL=$(jq -r ".architectures.$(uname -m).artifacts.metal.formats.iso.disk.location" "$OCP_DIR/rhcos.json")
+        export MACHINE_OS_INSTALLER_LIVE_ISO_URL
+        MACHINE_OS_INSTALLER_LIVE_ISO_SHA256=$(jq -r ".architectures.$(uname -m).artifacts.metal.formats.iso.disk[\"sha256\"]" "$OCP_DIR/rhcos.json")
+        export MACHINE_OS_INSTALLER_LIVE_ISO_SHA256
+        export MACHINE_OS_LIVE_ISO_URL=${MACHINE_OS_LIVE_ISO_URL:-${MACHINE_OS_INSTALLER_LIVE_ISO_URL}}
+        export MACHINE_OS_LIVE_ISO_SHA256=${MACHINE_OS_LIVE_ISO_SHA256:-${MACHINE_OS_INSTALLER_LIVE_ISO_SHA256}}
+    fi
 else
   if [[ ! -f "$OCP_DIR/rhcos.json" ]]; then
     if [[ -v JOB_NAME ]] && [[ "$JOB_NAME" =~ "openshift-installer" ]]; then
@@ -66,4 +75,13 @@ else
   MACHINE_OS_INSTALLER_BOOTSTRAP_IMAGE_UNCOMPRESSED_SHA256=$(jq -r '.images.qemu["uncompressed-sha256"]' "$OCP_DIR/rhcos.json")
   export MACHINE_OS_INSTALLER_BOOTSTRAP_IMAGE_UNCOMPRESSED_SHA256
   export MACHINE_OS_BOOTSTRAP_IMAGE_UNCOMPRESSED_SHA256=${MACHINE_OS_BOOTSTRAP_IMAGE_UNCOMPRESSED_SHA256:-${MACHINE_OS_INSTALLER_BOOTSTRAP_IMAGE_UNCOMPRESSED_SHA256}}
+
+  if [[ "${BOOTSTRAP_IN_PLACE:-false}" == "true" ]]; then
+      MACHINE_OS_INSTALLER_LIVE_ISO_URL=$(jq -r '.baseURI + .images.iso.path' "$OCP_DIR/rhcos.json")
+      export MACHINE_OS_INSTALLER_LIVE_ISO_URL
+      MACHINE_OS_INSTALLER_LIVE_ISO_SHA256=$(jq -r '.images.iso.sha256' "$OCP_DIR/rhcos.json")
+      export MACHINE_OS_INSTALLER_LIVE_ISO_SHA256
+      export MACHINE_OS_LIVE_ISO_URL=${MACHINE_OS_LIVE_ISO_URL:-${MACHINE_OS_INSTALLER_LIVE_ISO_URL}}
+      export MACHINE_OS_LIVE_ISO_SHA256=${MACHINE_OS_LIVE_ISO_SHA256:-${MACHINE_OS_INSTALLER_LIVE_ISO_SHA256}}
+  fi
 fi

--- a/utils.sh
+++ b/utils.sh
@@ -100,13 +100,8 @@ function custom_ntp(){
   fi
 }
 
-function create_cluster() {
-    local assets_dir
-
-    assets_dir="$1"
-
-    # Enable terraform debug logging
-    export TF_LOG=DEBUG
+function prepare_manifests() {
+    local assets_dir="$1"
 
     # Disable sigstore image policy verification for non-GA releases.
     # The installer adds a CVO override marking the ClusterImagePolicy as unmanaged,
@@ -194,6 +189,17 @@ function create_cluster() {
     mkdir -p "${assets_dir}/saved-assets"
     cp -av "${assets_dir}/openshift" "${assets_dir}/saved-assets"
     cp -av "${assets_dir}/manifests" "${assets_dir}/saved-assets"
+}
+
+function create_cluster() {
+    local assets_dir
+
+    assets_dir="$1"
+
+    # Enable terraform debug logging
+    export TF_LOG=DEBUG
+
+    prepare_manifests "${assets_dir}"
 
     if [ ! -z "${IGNITION_EXTRA:-}" ]; then
       $OPENSHIFT_INSTALLER --dir "${assets_dir}" --log-level=debug create ignition-configs
@@ -209,6 +215,111 @@ function create_cluster() {
 
     trap auth_template_and_removetmp EXIT
     $OPENSHIFT_INSTALLER --dir "${assets_dir}" --log-level=debug create cluster 2>&1 | grep --line-buffered -v 'password\|X-Auth-Token\|UserData:'
+}
+
+function create_bip_cluster() {
+    local assets_dir
+    assets_dir="$(realpath "$1")"
+
+    prepare_manifests "${assets_dir}"
+
+    $OPENSHIFT_INSTALLER --dir "${assets_dir}" --log-level=debug create single-node-ignition-config
+
+    local iso_dir="${assets_dir}/iso"
+    mkdir -p "${iso_dir}"
+
+    local live_iso="${iso_dir}/rhcos-live.iso"
+    local live_iso_name
+    live_iso_name=$(basename "${MACHINE_OS_LIVE_ISO_URL}")
+    local cached_iso="${IRONIC_DATA_DIR}/html/images/${live_iso_name}"
+
+    if [ ! -f "${cached_iso}" ]; then
+      echo "Downloading RHCOS live ISO..."
+      curl -g --insecure -L -o "${cached_iso}" "${MACHINE_OS_LIVE_ISO_URL}"
+      echo "${MACHINE_OS_LIVE_ISO_SHA256} $(basename "${cached_iso}")" | tee "${cached_iso}.sha256sum"
+      pushd "$(dirname "${cached_iso}")"
+      sha256sum --strict --check "${cached_iso}.sha256sum" || ( rm -f "${cached_iso}" ; exit 1 )
+      popd
+    fi
+    cp "${cached_iso}" "${live_iso}"
+
+    # Mark the provisioning network interface as unmanaged so that
+    # NetworkManager-wait-online does not block on it
+    local vm_name="${CLUSTER_NAME}_master_0"
+    local prov_mac
+    prov_mac=$(sudo virsh dumpxml "${vm_name}" | xmllint --xpath "string(//interface[descendant::source[@bridge='${PROVISIONING_NETWORK_NAME}']]/mac/@address)" -)
+    if [[ -n "${prov_mac}" ]]; then
+      local nmconn_dir="${iso_dir}/nm"
+      mkdir -p "${nmconn_dir}"
+      cat > "${nmconn_dir}/10-provisioning-unmanaged.nmconnection" << NMEOF
+[connection]
+id=provisioning-unmanaged
+type=ethernet
+autoconnect=false
+
+[ethernet]
+mac-address=${prov_mac}
+NMEOF
+      chmod 600 "${nmconn_dir}/10-provisioning-unmanaged.nmconnection"
+      sudo podman run --rm --privileged \
+          -v "${iso_dir}:/iso:z" -v "${nmconn_dir}:/nm:z" \
+          quay.io/coreos/coreos-installer:release \
+          iso network embed \
+          -k /nm/10-provisioning-unmanaged.nmconnection \
+          /iso/rhcos-live.iso
+    fi
+
+    local bip_iso="${iso_dir}/rhcos-bip.iso"
+    sudo podman run --rm --privileged \
+        -v "${assets_dir}:/data:z" -v "${iso_dir}:/iso:z" \
+        quay.io/coreos/coreos-installer:release \
+        iso ignition embed -i /data/bootstrap-in-place-for-live-iso.ign \
+        -o /iso/rhcos-bip.iso /iso/rhcos-live.iso
+
+    local master_mac
+    master_mac=$(sudo virsh dumpxml "${vm_name}" | xmllint --xpath "string(//interface[descendant::source[@bridge='${BAREMETAL_NETWORK_NAME}']]/mac/@address)" -)
+
+    sudo virt-xml "${vm_name}" --add-device \
+        --disk "${bip_iso}",device=cdrom,target.dev=sdc
+    sudo virt-xml "${vm_name}" --edit target=sda --disk="boot_order=1"
+    sudo virt-xml "${vm_name}" --edit target=sdc --disk="boot_order=2" --start
+
+    # Wait for the node to get an IP via DHCP, then configure DNS to match
+    echo "Waiting for master node to obtain an IP address..."
+    local master_ip=""
+    for i in $(seq 1 60); do
+      if [[ "$IP_STACK" == "v4" ]] || [[ "$IP_STACK" == "v4v6" ]]; then
+        master_ip=$(ip -4 neigh show dev "${BAREMETAL_NETWORK_NAME}" \
+            | grep -i "${master_mac}" | awk '{print $1}' | head -1) || true
+      else
+        master_ip=$(ip -6 neigh show dev "${BAREMETAL_NETWORK_NAME}" \
+            | grep -i "${master_mac}" | grep -v '^fe80' | awk '{print $1}' | head -1) || true
+      fi
+      if [[ -n "${master_ip}" ]]; then
+        break
+      fi
+      sleep 5
+    done
+
+    if [[ -z "${master_ip}" ]]; then
+      echo "ERROR: Timed out waiting for master node to get an IP address"
+      exit 1
+    fi
+    echo "Master node IP: ${master_ip}"
+
+    configure_dnsmasq "${master_ip}" "${master_ip}"
+
+    # Add DNS entries to the libvirt network dnsmasq (the node queries this,
+    # not the NetworkManager dnsmasq on the hypervisor).
+    # Both hostnames must be in a single <host> element (libvirt rejects
+    # duplicate IPs across separate entries).
+    local net_name="${BAREMETAL_NETWORK_NAME}"
+    sudo virsh net-update "${net_name}" add dns-host \
+        "<host ip='${master_ip}'><hostname>api.${CLUSTER_DOMAIN}</hostname><hostname>api-int.${CLUSTER_DOMAIN}</hostname></host>" --live
+
+    trap auth_template_and_removetmp EXIT
+    $OPENSHIFT_INSTALLER --dir "${assets_dir}" --log-level=debug wait-for bootstrap-complete
+    $OPENSHIFT_INSTALLER --dir "${assets_dir}" --log-level=debug wait-for install-complete 2>&1 | grep --line-buffered -v 'password\|X-Auth-Token\|UserData:'
 }
 
 function network_ip() {


### PR DESCRIPTION
Adding the SNO deployment via Bootstrap-in-Place, where the master node bootstraps itself from a RHCOS live ISO with embedded ignition, eliminating the need for Ironic and a separate bootstrap VM.

## How to use

SNO Bootstrap-in-Place (BiP) Installation
Bootstrap-in-Place deploys a Single Node OpenShift cluster without Ironic or a bootstrap VM. The single master node bootstraps itself from a RHCOS live ISO with embedded ignition.

### 1. Create config.sh

```
#!/bin/bash

# Required: pull secret (download from https://console.redhat.com/openshift/install/pull-secret)
# Place it at ~/.pull-secret.json or set PERSONAL_PULL_SECRET

# SNO BiP configuration
export BOOTSTRAP_IN_PLACE=true
export NUM_MASTERS=1
export NUM_WORKERS=0
export IP_STACK=v4

# Release image
export OPENSHIFT_RELEASE_IMAGE=quay.io/openshift-release-dev/ocp-release:4.21.0-multi

# Optional: override installation disk (default: /dev/sda)
# export SNO_INSTALLATION_DISK="/dev/sda"

# Optional: override VM resources (defaults below are set automatically)
# export MASTER_VCPU=16
# export MASTER_DISK=120     # GB
# export MASTER_MEMORY=32768 # MB
```

### 2. Deploy

`CONFIG=config.sh make sno_bip`
This runs steps 01-03 and 05-06 (Ironic step 04 is skipped), then:

- Generates single-node ignition config
- Downloads and prepares the RHCOS live ISO with embedded ignition
- Boots the VM from the ISO
- Waits for bootstrap and installation to complete

### 3. Access the cluster

```
export KUBECONFIG=ocp/${CLUSTER_NAME:-ostest}/auth/kubeconfig
oc get nodes
oc get co
```
### 4. Cleanup
`CONFIG=config.sh make clean`