### PR TITLE
NO-ISSUE: re-introduce the possibility to override the APPLIANCE_IMAGE for OVE ISO

### DIFF
--- a/agent/iso_no_registry.sh
+++ b/agent/iso_no_registry.sh
@@ -30,6 +30,7 @@ function build_ove_iso_script() {
     --pull-secret-file "${PULL_SECRET_FILE}" \
     --release-image-url "${release_image_url}" \
     --ssh-key-file "${SSH_KEY_FILE}" \
+    ${APPLIANCE_IMAGE:+--appliance-image "${APPLIANCE_IMAGE}"} \
     --dir "${asset_dir}" \
     # shellckeck disable=SC2086 # build-ove-image.sh doesn't handle empty args
     ${mirror_path_arg} \


### PR DESCRIPTION
This was accidentally removed in https://github.com/openshift-metal3/dev-scripts/pull/1830, but it is required to support Appliance CI jobs