### PR TITLE
Update metal3-dev-env pin to dba726c2

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -19,19 +19,11 @@ if [ -z "${METAL3_DEV_ENV:-}" ]; then
   # TODO -- come up with a plan for continuously updating this
   # Note we only do this in the case where METAL3_DEV_ENV is
   # unset, to enable developer testing of local checkouts
-  git reset f5c0b859717e71c35701905161caa6e65221b3fb --hard
+  git reset dba726c297571cc24a5205e873ad9e66ad1c719c --hard
 
   # Ansible 9+ requires Python 3.10+, but CentOS Stream 9 ships Python 3.9.
   # Patch metal3-dev-env to use Ansible 8.x on centos9/rhel9.
   sed -i '/ANSIBLE_VERSION/{ s/10\.7\.0/8.7.0/; }' lib/common.sh
-
-  # Go tarball defaults hardcode linux-amd64; use GOARCH passed as extra var.
-  # Upstream fix: https://github.com/metal3-io/metal3-dev-env/pull/1694
-  GO_DEFAULTS="vm-setup/roles/packages_installation/defaults/main.yml"
-  if grep -q 'linux-amd64' "${GO_DEFAULTS}"; then
-    sed -i 's/go_tarball: "go{{ go_version }}.linux-amd64.tar.gz"/go_tarball: "go{{ go_version }}.linux-{{ GOARCH | default('\''amd64'\'') }}.tar.gz"/' \
-      "${GO_DEFAULTS}"
-  fi
 
   popd
 fi

--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -129,16 +129,6 @@ export VNC_CONSOLE=true
 if [[ $(uname -m) == "aarch64" ]]; then
   VNC_CONSOLE=false
   echo "libvirt_cdrombus: scsi" >> vm_setup_vars.yml
-  # On native aarch64 KVM (e.g. AWS Graviton), the upstream metal3-dev-env
-  # template hardcodes cortex-a57 for all aarch64 VMs. That model only works
-  # under qemu emulation; native KVM requires host-passthrough. Narrow the
-  # CPU conditional so native aarch64 falls through to host-passthrough,
-  # without affecting the <os> or <features> sections that must still fire.
-  # Upstream fix: https://github.com/metal3-io/metal3-dev-env/pull/1694
-  TEMPLATE="${VM_SETUP_PATH}/roles/libvirt/templates/baremetalvm.xml.j2"
-  if [ -f "${TEMPLATE}" ] && grep -q '{% if is_aarch64 %}' "${TEMPLATE}"; then
-    sed -i '/{% if is_aarch64 %}/{N; /<!--/s/{% if is_aarch64 %}/{% if is_aarch64 and libvirt_domain_type == '"'"'qemu'"'"' %}/}' "${TEMPLATE}"
-  fi
 fi
 
 # playbooks depend on it

--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -227,12 +227,14 @@ if [ "$NODES_PLATFORM" = "libvirt" ]; then
         sudo rm -f "$WORKING_DIR/virtualbmc/vbmc/master.pid"
         sudo podman run -d --net host --privileged --name vbmc --pod ironic-pod \
              -v "$WORKING_DIR/virtualbmc/vbmc":/root/.vbmc -v "/root/.ssh":/root/ssh \
+             -v /var/run/libvirt:/var/run/libvirt \
              "${VBMC_IMAGE}"
     fi
 
     if ! is_running sushy-tools; then
         sudo podman run -d --net host --privileged --name sushy-tools --pod ironic-pod \
              -v "$WORKING_DIR/virtualbmc/sushy-tools":/root/sushy -v "/root/.ssh":/root/ssh \
+             -v /var/run/libvirt:/var/run/libvirt \
              "${SUSHY_TOOLS_IMAGE}"
     fi
 fi

--- a/agent/05_agent_configure.sh
+++ b/agent/05_agent_configure.sh
@@ -614,12 +614,14 @@ function get_nodes_bmc_info() {
         sudo rm -f "$WORKING_DIR/virtualbmc/vbmc/master.pid"
         sudo podman run -d --net host --privileged --name vbmc \
              -v "$WORKING_DIR/virtualbmc/vbmc":/root/.vbmc -v "/root/.ssh":/root/ssh \
+             -v /var/run/libvirt:/var/run/libvirt \
              "${VBMC_IMAGE}"
       fi
 
       if ! is_running sushy-tools; then
         sudo podman run -d --net host --privileged --name sushy-tools \
              -v "$WORKING_DIR/virtualbmc/sushy-tools":/root/sushy -v "/root/.ssh":/root/ssh \
+             -v /var/run/libvirt:/var/run/libvirt \
              "${SUSHY_TOOLS_IMAGE}"
       fi
     fi


### PR DESCRIPTION
## Summary

- Bump `metal3-dev-env` pinned commit from `f5c0b85` → `dba726c` to pick up [metal3-io/metal3-dev-env#1694](https://github.com/metal3-io/metal3-dev-env/pull/1694) (Go tarball arch detection + CPU model template fix for aarch64 KVM)
- Remove the Go tarball `sed` workaround in `01_install_requirements.sh` — upstream now uses `go_arch` (auto-detected from `ansible_architecture`)
- Remove the CPU model `sed` workaround in `02_configure_host.sh` — upstream template now gates `cortex-a57` on `effective_domain_type == 'qemu'`, so native KVM correctly falls through to `host-passthrough`
- Ansible 8.x downgrade `sed` remains — CentOS Stream 9 ships Python 3.9 and Ansible 9+ requires Python 3.10+
- **Mount libvirt socket into vbmc and sushy-tools containers** — required by upstream commit `97ecdb7` which switched the BMC libvirt connection from `qemu+ssh://` to `qemu:///system` (local socket) to fix CI flakiness where SSH-based connections caused vbmc to ack power-on without libvirt executing it

### Why the libvirt socket mount is needed

The new metal3-dev-env pin includes [97ecdb7](https://github.com/metal3-io/metal3-dev-env/commit/97ecdb787e019ab3975a17c89929c572a1434657) ("vbmc: use local libvirt socket instead of SSH") which made two coordinated changes:

1. **Ansible role** (`virtbmc/tasks/setup_tasks.yml`): changed `vbmc_libvirt_uri` from `qemu+ssh://root@.../system` to `qemu:///system`
2. **Container startup** (`02_configure_host.sh`): added `-v /var/run/libvirt:/var/run/libvirt` to vbmc and sushy-tools containers

dev-scripts consumes the Ansible roles via `setup-playbook.yml` (so conf.py now contains `qemu:///system`), but has its own container startup code in `04_setup_ironic.sh` and `agent/05_agent_configure.sh`. Without adding the socket mount here too, sushy-tools tries to connect to the local libvirt socket which isn't available inside the container, causing nodes to hang at `registering` indefinitely.

## Test plan

- [x] aarch64 Graviton fencing-IPI deployment — 2-node cluster, all COs Available, Redfish BMC endpoints responding
- [ ] CI passes on x86_64 (standard IPI/agent flows)