### PR TITLE
NO-JIRA: Fix lint comment within multi-line command

### DIFF
--- a/agent/06_agent_create_cluster.sh
+++ b/agent/06_agent_create_cluster.sh
@@ -130,7 +130,7 @@ function get_agent_iso() {
 function get_agent_iso_no_registry() {
     local base_dir=$SCRIPTDIR/$OCP_DIR
     local iso_name="agent-ove.${ARCH}.iso"
-    local agent_iso_no_registry=$
+    local agent_iso_no_registry
     agent_iso_no_registry=$(find "$base_dir" -type f -name "$iso_name" 2>/dev/null | head -n 1)
     if [ -z "$agent_iso_no_registry" ]; then
       echo "Error: No agent OVE ISO found matching ${iso_name} in ${base_dir}" >&2

--- a/agent/iso_no_registry.sh
+++ b/agent/iso_no_registry.sh
@@ -26,15 +26,14 @@ function build_ove_iso_script() {
   local mirror_path_arg=$3
   local registry_cert_arg=$4
 
+  # shellcheck disable=SC2086 # mirror_path_arg and registry_cert_arg intentionally unquoted for word splitting
   ./hack/build-ove-image.sh \
     --pull-secret-file "${PULL_SECRET_FILE}" \
     --release-image-url "${release_image_url}" \
     --ssh-key-file "${SSH_KEY_FILE}" \
     ${APPLIANCE_IMAGE:+--appliance-image "${APPLIANCE_IMAGE}"} \
     --dir "${asset_dir}" \
-    # shellckeck disable=SC2086 # build-ove-image.sh doesn't handle empty args
     ${mirror_path_arg} \
-    # shellckeck disable=SC2086 # build-ove-image.sh doesn't handle empty args
     ${registry_cert_arg}
 }
 


### PR DESCRIPTION
The lint changes in https://github.com/openshift-metal3/dev-scripts/pull/1903 introduced a comment within a multi-line command that caused a problem passing in args to build-ove-image.sh. Fixed this along with a cosmetic issue also introduced in that change.