### PR TITLE
NO-ISSUE: Fix broken SNO cluster install for ISO_NO_REGISTRY

### DIFF
--- a/agent/isobuilder/ui_driven_cluster_installation/main.go
+++ b/agent/isobuilder/ui_driven_cluster_installation/main.go
@@ -478,7 +478,7 @@ func virtualizationBundle(page *rod.Page, path string) error {
 		logrus.Info("Looking for Single Operators button (SNO)...")
 		wait(5 * time.Second)
 
-		singleOpsButton, err := page.Timeout(10*time.Second).ElementR("button", "Single Operators")
+		singleOpsButton, err := page.Timeout(10*time.Second).ElementR("button", "[Ss]ingle [Oo]perators")
 		if err != nil {
 			return fmt.Errorf("Single Operators button not found: %v", err)
 		}


### PR DESCRIPTION
SNO installation failing with "Single Operators button not found" error.
The assisted-installer-ui [PR #3805](https://github.com/openshift-assisted/assisted-installer-ui/pull/3805) changed the button text:
  - **Old:** "Single Operators (N | M selected)"
  - **New:** "Single operators (N selected)" (lowercase 'o')

Our exact string match `"Single Operators"` no longer works. This PR uses case-insensitive regex pattern to match both old and new UI.