### PR TITLE
Exclude openssl from upgrade

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -25,6 +25,8 @@ if [ -z "${METAL3_DEV_ENV:-}" ]; then
   # Patch metal3-dev-env to use Ansible 8.x on centos9/rhel9.
   sed -i '/ANSIBLE_VERSION/{ s/10\.7\.0/8.7.0/; }' lib/common.sh
 
+# TODO: remove once Python fixed OpenSSL regression
+  sed -i '/name: "{{ packages.centos.common.packages }}"/a\      exclude: "openssl*"' vm-setup/roles/packages_installation/tasks/main.yml
   popd
 fi
 
@@ -48,6 +50,11 @@ old_version=$(sudo dnf info NetworkManager | grep Version | cut -d ':' -f 2)
 MAX_RETRIES=5
 # Delay between attempts (in seconds)
 _YUM_RETRY_BACKOFF=15
+
+# TODO: remove once Python fixed OpenSSL regression
+sudo dnf install -y --allowerasing openssl-3.5.5-3.el9 openssl-devel-3.5.5-3.el9 openssl-libs-3.5.5-3.el9
+sudo dnf install -y python3-dnf-plugin-versionlock
+sudo dnf versionlock add openssl openssl-libs openssl-devel
 
 attempt=1
 while (( attempt <= MAX_RETRIES )); do


### PR DESCRIPTION
  https://github.com/python/cpython/issues/151504
  breaks SSL connections with openssl* > 3.5.7
  Remove once Python backport in CentOS Stream 9