### PR TITLE
AGENT-1558: Use agent-iso-builder from quay-proxy

### DIFF
--- a/agent/common.sh
+++ b/agent/common.sh
@@ -120,7 +120,7 @@ function getAgentISOBuilderImage() {
     full_ocp_version=$(skopeo inspect --authfile "$PULL_SECRET_FILE" "docker://$OPENSHIFT_RELEASE_IMAGE" | jq -r '.Labels["io.openshift.release"]')
     major_minor_patch_version=$(echo "\"$full_ocp_version\"" | jq -r 'split("-")[0]')
     major_minor_version=$(echo "$major_minor_patch_version" | cut -d'.' -f1,2 )
-    agent_iso_builder_image="registry.ci.openshift.org/ocp/${major_minor_version}:agent-iso-builder"
+    agent_iso_builder_image="quay-proxy.ci.openshift.org/openshift/ci:ocp_${major_minor_version}_agent-iso-builder"
     echo "${agent_iso_builder_image}"
 }
 

--- a/agent/iso_no_registry.sh
+++ b/agent/iso_no_registry.sh
@@ -75,6 +75,17 @@ function create_agent_iso_no_registry() {
     src_dir="${asset_dir}/src"
   fi
 
+  # Workaround: set APPLIANCE_IMAGE to use quay-proxy if not already set,
+  # since the upstream build-ove-image.sh still defaults to registry.ci.openshift.org
+  # TODO: remove once https://github.com/openshift/agent-installer-utils is updated
+  if [[ -z "${APPLIANCE_IMAGE}" ]]; then
+    local full_ocp_version major_minor_version
+    full_ocp_version=$(skopeo inspect --authfile "$PULL_SECRET_FILE" "docker://$OPENSHIFT_RELEASE_IMAGE" | jq -r '.Labels["io.openshift.release"]')
+    major_minor_version=$(echo "$full_ocp_version" | grep -oP '^\d+\.\d+')
+    export APPLIANCE_IMAGE="quay-proxy.ci.openshift.org/openshift/ci:ocp_${major_minor_version}_agent-preinstall-image-builder"
+    echo "Using APPLIANCE_IMAGE=${APPLIANCE_IMAGE}"
+  fi
+
   pushd .
   cd "${src_dir}"
 


### PR DESCRIPTION
Use agent-iso-builder from quay-proxy instead of registry.ci.openshift.org.

ImageStreams in the ocp namespace on app.ci are now used as tag references only — images are NOT imported under .status. The correct image reference is stored under .spec.tags[].from.name, which points to a digest on QCI (Quay CI), e.g. quay-proxy.ci.openshift.org/openshift/ci@sha256:....
