### PR TITLE
Add optional top-of-rack LLDP switch emulation

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -512,3 +512,8 @@ if [ "${PERSISTENT_IMAGEREG}" == true ] ; then
     sudo systemctl start nfs-server
     sudo exportfs -a
 fi
+
+# Optionally emulate a top-of-rack LLDP switch towards the cluster VMs
+if [[ -n "${ENABLE_LLDP_TOR:-}" ]]; then
+    lldp/configure_lldp_tor.sh
+fi

--- a/common.sh
+++ b/common.sh
@@ -708,3 +708,8 @@ if [ "${OPENSHIFT_CI}" == true ] ; then
 fi
 
 export ENABLE_CAPI_E2E=${ENABLE_CAPI_E2E:-}
+
+# Optional LLDP top-of-rack switch emulation on the libvirt tap devices
+# (see config_example.sh)
+export ENABLE_LLDP_TOR=${ENABLE_LLDP_TOR:-}
+export LLDP_TOR_SYSTEM_NAME=${LLDP_TOR_SYSTEM_NAME:-lldp-switch}

--- a/config_example.sh
+++ b/config_example.sh
@@ -1056,3 +1056,16 @@ set -x
 # a complete isolation.
 #
 # export AGENT_ISOLATED_NETWORK=""
+
+# ENABLE_LLDP_TOR -
+# Emulate a top-of-rack LLDP switch on the hypervisor: run lldpd bound to
+# the libvirt tap devices (vnet*) so cluster nodes receive LLDPDUs inbound
+# on their NICs, exactly like from a real switch port. Consumed e.g. by the
+# kubernetes-nmstate LLDP e2e tests, which expect a neighbor with system
+# name "lldp-switch" on the primary NIC.
+# Default is unset.
+#
+#export ENABLE_LLDP_TOR=true
+#
+# Advertised LLDP system name (default lldp-switch):
+#export LLDP_TOR_SYSTEM_NAME=lldp-switch

--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -83,3 +83,6 @@ sudo pkill -f oc.*proxy
 
 # Remove image-reg nfsshare
 sudo rm -rf /etc/exports.d/dev-scripts.exports /opt/dev-scripts/nfsshare
+
+# Remove the optional LLDP ToR switch emulation
+lldp/cleanup_lldp_tor.sh

--- a/lldp/cleanup_lldp_tor.sh
+++ b/lldp/cleanup_lldp_tor.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# Tears down the optional LLDP ToR switch emulation deployed by
+# configure_lldp_tor.sh. Tolerant of a missing service / config so it can
+# run unconditionally from host_cleanup.sh. The lldpd package stays
+# installed.
+
+sudo systemctl disable --now lldpd || true
+
+sudo rm -f /etc/lldpd.d/lldp-tor.conf

--- a/lldp/configure_lldp_tor.sh
+++ b/lldp/configure_lldp_tor.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+lldp_dir="$(dirname "$(readlink -f "$0")")"
+# shellcheck disable=SC1091
+source "${lldp_dir}/../common.sh"
+
+# Emulate a production top-of-rack LLDP switch for the cluster VMs.
+#
+# The libvirt bridges do not forward the link-local scoped LLDP group
+# address (01:80:C2:00:00:0E) between ports, and NetworkManager >= 1.59.1
+# filters LLDP frames sourced by the local interface, so cluster nodes
+# never see any LLDP neighbor. Run lldpd on the hypervisor bound to the
+# libvirt tap devices (vnet*): a frame transmitted on a tap is delivered
+# straight to the VM NIC (no bridge forwarding involved), so each node
+# receives LLDPDUs inbound exactly like from a real switch port.
+#
+# lldpd tracks interface add/remove via netlink, so taps created when the
+# VMs boot later (or recreated on node reboot) are picked up automatically.
+
+sudo dnf -y install lldpd
+
+# tx-interval 5: fast neighbor appearance for tests.
+# interface pattern vnet*: only libvirt taps, never physical host NICs.
+sudo tee /etc/lldpd.d/lldp-tor.conf <<EOF
+configure lldp tx-interval 5
+configure system hostname ${LLDP_TOR_SYSTEM_NAME}
+configure system interface pattern vnet*
+EOF
+
+sudo systemctl enable --now lldpd
+# Re-apply the configuration if lldpd was already running
+sudo systemctl restart lldpd
+
+echo "LLDP ToR switch emulation running: system name ${LLDP_TOR_SYSTEM_NAME}, interfaces vnet*"


### PR DESCRIPTION
## What

`ENABLE_LLDP_TOR` runs lldpd on the hypervisor bound to the libvirt tap devices (`vnet*`). Frames transmitted on a tap are delivered straight into the VM NIC, so cluster nodes receive LLDPDUs inbound exactly like from a production top-of-rack switch, without any bridge `group_fwd_mask` change.

## Why

The libvirt bridges do not forward the link-local scoped LLDP group address (`01:80:C2:00:00:0E`) between ports, and NetworkManager >= 1.59.1 filters locally-sourced LLDP frames (NM commit `9a79eba502`), so cluster nodes deployed by dev-scripts never see any LLDP neighbor.

Primary consumer is the kubernetes-nmstate LLDP e2e test, which since nmstate/kubernetes-nmstate#1549 expects an `lldp-switch` neighbor on the primary NIC. Upstream solves this for kubevirtci with `cluster/lldpd-switch.sh`; this adds the dev-scripts equivalent so the OpenShift `e2e-handler-ovn-ipv4` lane can pass again (see openshift/kubernetes-nmstate#765).

## How

- `lldp/configure_lldp_tor.sh`: installs lldpd (EPEL is already enabled by `01_install_requirements.sh`), writes `/etc/lldpd.d/lldp-tor.conf` (tx-interval 5, configurable system name defaulting to `lldp-switch`, interface pattern `vnet*` so only libvirt taps are touched, never physical host NICs), enables and restarts the service. lldpd tracks interface add/remove via netlink, so taps created when the VMs boot later (or recreated on node reboot) are picked up automatically.
- `lldp/cleanup_lldp_tor.sh`: best-effort teardown, wired unconditionally into `host_cleanup.sh`.
- Opt-in hook at the end of `02_configure_host.sh`, defaults in `common.sh`, documentation in `config_example.sh`.

Mirrors the `ENABLE_BGP_TOR` pattern.

---
This PR description was generated using AI. Please verify before acting on it.