### PR TITLE
NO-ISSUE: switch default CI registry to quay-proxy.ci.openshift.org

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -336,6 +336,7 @@ set +x
 export CI_TOKEN=${CI_TOKEN:-}
 set -x
 export CI_SERVER=${CI_SERVER:-api.ci.l2s4.p1.openshiftapps.com}
+export CI_REGISTRY=${CI_REGISTRY:-quay-proxy.ci.openshift.org}
 export PERSONAL_PULL_SECRET=${PERSONAL_PULL_SECRET:-$SCRIPTDIR/pull_secret.json}
 
 # Ensure working dir is always different than script dir. If not, some

--- a/common.sh
+++ b/common.sh
@@ -189,7 +189,7 @@ if [[ -z "$OPENSHIFT_CI" ]]; then
   export OPENSHIFT_VERSION=${OPENSHIFT_VERSION:-$(echo "$OPENSHIFT_RELEASE_IMAGE" | sed "s/.*:\([[:digit:]]\.[[:digit:]]*\).*/\1/")}
 fi
 
-OPENSHIFT_RELEASE_TAG=$(echo "$OPENSHIFT_RELEASE_IMAGE" | sed -E 's/[[:alnum:]\/.-]*(release|okd).*://')
+OPENSHIFT_RELEASE_TAG="${OPENSHIFT_RELEASE_IMAGE##*:}"
 export OPENSHIFT_RELEASE_TAG
 
 # Use "ipmi" for 4.3 as it didn't support redfish, for other versions

--- a/config_example.sh
+++ b/config_example.sh
@@ -13,10 +13,16 @@ export CI_TOKEN=''
 set -x
 
 # CI_SERVER -
-# When testing e.g cluster-bot builds, you must change CI_TOKEN to one
-# from a different cluster, in which case this should be updated
+# API server of the CI cluster used to authenticate and obtain
+# registry credentials. Default: api.ci.l2s4.p1.openshiftapps.com
 #
 #export CI_SERVER=api.ci.l2s4.p1.openshiftapps.com
+
+# CI_REGISTRY -
+# The CI image registry. Default: quay-proxy.ci.openshift.org
+# To use the old integrated registry:
+#
+#export CI_REGISTRY=registry.ci.openshift.org
 
 # OPENSHIFT_CI
 # This variable is intended to indicate that dev-scripts is running in a CI environment,

--- a/utils.sh
+++ b/utils.sh
@@ -988,7 +988,8 @@ function add_local_certificate_as_trusted() {
 
 function verify_pull_secret() {
   # Do some PULL_SECRET sanity checking
-  if [[ "${OPENSHIFT_RELEASE_IMAGE}" == *"registry.ci.openshift.org"* ]]; then
+  if [[ "${OPENSHIFT_RELEASE_IMAGE}" == *"registry.ci.openshift.org"* ]] || \
+     [[ "${OPENSHIFT_RELEASE_IMAGE}" == *"quay-proxy.ci.openshift.org"* ]]; then
       if [[ ${#CI_TOKEN} = 0 ]]; then
           error "Please login to https://console-openshift-console.apps.ci.l2s4.p1.openshiftapps.com/ and copy the token from the login command from the menu in the top right corner to set CI_TOKEN."
           exit 1
@@ -1016,14 +1017,18 @@ function write_pull_secret() {
 
     verify_pull_secret
 
-    # Get a current pull secret for registry.ci.openshift.org using the token
+    # Get a current pull secret for the CI registry using the token
     tmpkubeconfig=$(mktemp --tmpdir "kubeconfig--XXXXXXXXXX")
     _tmpfiles="$_tmpfiles $tmpkubeconfig"
     oc login "https://${CI_SERVER}:6443" --kubeconfig="$tmpkubeconfig" --token="${CI_TOKEN}"
     tmppullsecret=$(mktemp --tmpdir "pullsecret--XXXXXXXXXX")
     echo '{}' > "$tmppullsecret"
     _tmpfiles="$_tmpfiles $tmppullsecret"
-    oc registry login --kubeconfig="$tmpkubeconfig" --to="$tmppullsecret"
+    oc --kubeconfig="$tmpkubeconfig" whoami -t | \
+        podman login "${CI_REGISTRY}" \
+            --username "$(oc --kubeconfig="$tmpkubeconfig" whoami)" \
+            --password-stdin \
+            --authfile "$tmppullsecret"
 
     # Combine the personal pull secret with the ones for the CI
     # registry and the local registry credentials.

--- a/utils.sh
+++ b/utils.sh
@@ -1024,6 +1024,9 @@ function write_pull_secret() {
     tmppullsecret=$(mktemp --tmpdir "pullsecret--XXXXXXXXXX")
     echo '{}' > "$tmppullsecret"
     _tmpfiles="$_tmpfiles $tmppullsecret"
+    # Pull secret for registry.ci.openshift.org (auto-discovered from the cluster)
+    oc registry login --kubeconfig="$tmpkubeconfig" --to="$tmppullsecret"
+    # Pull secret for quay-proxy.ci.openshift.org
     oc --kubeconfig="$tmpkubeconfig" whoami -t | \
         podman login "${CI_REGISTRY}" \
             --username "$(oc --kubeconfig="$tmpkubeconfig" whoami)" \


### PR DESCRIPTION
As per the latest CI change described here https://docs.ci.openshift.org/how-tos/use-registries-in-build-farm/#container-image-data-flows, the CI default registry is now quay-proxy.ci.openshift.org