### PR TITLE
Fix image builds that don't use --build-arg

### DIFF
--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -83,7 +83,7 @@ for IMAGE_VAR in $(env | grep "_LOCAL_IMAGE=" | grep -o "^[^=]*") ; do
             EXTRA_PKGS_FILE=$(cd "$OLDPWD"; realpath "$EXTRA_PKGS_FILE")
             cp "$EXTRA_PKGS_FILE" "$REPOPATH"
             EXTRA_PKGS_FILE_NAME=$(basename "$EXTRA_PKGS_FILE")
-            BUILD_COMMAND_ARGS+=" --build-arg EXTRA_PKGS_LIST=$EXTRA_PKGS_FILE_NAME"
+            BUILD_COMMAND_ARGS+="EXTRA_PKGS_LIST=$EXTRA_PKGS_FILE_NAME"
         fi
 
         # If we built a custom base image, we should use it as a new base in
@@ -93,7 +93,7 @@ for IMAGE_VAR in $(env | grep "_LOCAL_IMAGE=" | grep -o "^[^=]*") ; do
             sed -i "s/^FROM [^ ]*/FROM ${BASE_IMAGE_DIR}/g" "${IMAGE_DOCKERFILE}"
         fi
 
-        sudo podman build --network host --authfile "$PULL_SECRET_FILE" "$BUILD_COMMAND_ARGS" -t "${!IMAGE_VAR}" -f "$IMAGE_DOCKERFILE" .
+        sudo podman build --network host --authfile "$PULL_SECRET_FILE" --build-arg "$BUILD_COMMAND_ARGS" -t "${!IMAGE_VAR}" -f "$IMAGE_DOCKERFILE" .
         cd -
         sudo podman push --tls-verify=false --authfile "$PULL_SECRET_FILE" "${!IMAGE_VAR}" "${!IMAGE_VAR}"
     fi


### PR DESCRIPTION
As part of the shellcheck fixes, this variable was quoted. However, when the variable is empty this results in a bogus parameter being passed to podman build which caused it to fail.

This appears to have been designed so it could be concatenated, but the variable is reset each time through the loop so I don't think we actually need that. This splits the argument name from its value so we pass valid arguments even when the variable is empty. Passing --build-arg '' seems to work fine with the image build I tested.