### PR TITLE
OCPBUGS-100315: Fix baremetal registry and pull secret after #1922

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -97,6 +97,29 @@ if [[ "${NODES_PLATFORM}" == "baremetal" ]]; then
 
     switch_to_internal_dns
 
+    # Add a /etc/hosts entry for $LOCAL_REGISTRY_DNS_NAME
+    sudo sed -i "/${LOCAL_REGISTRY_DNS_NAME}/d" /etc/hosts
+    echo "${PROVISIONING_HOST_EXTERNAL_IP} ${LOCAL_REGISTRY_DNS_NAME}" | sudo tee -a /etc/hosts
+
+    # When MIRROR_IMAGES is configured, the local registry must be running
+    # before 04_setup_ironic.sh attempts to mirror release images into it.
+    # This covers virtual-baremetal (sushy-emulator) CI environments that
+    # set NODES_PLATFORM=baremetal together with MIRROR_IMAGES=true.
+    if use_registry "podman"; then
+        setup_local_registry
+        rm -f "${REGISTRY_CREDS}"
+        sudo podman login --authfile "${REGISTRY_CREDS}" \
+            -u "${REGISTRY_USER}" -p "${REGISTRY_PASS}" \
+            "${LOCAL_REGISTRY_DNS_NAME}":"${LOCAL_REGISTRY_PORT}"
+    elif use_registry ""; then
+        setup_local_registry
+    else
+        echo '{}' | sudo dd of="${REGISTRY_CREDS}"
+    fi
+    if [ -f "${REGISTRY_CREDS}" ]; then
+        sudo chown "$USER":"$USER" "${REGISTRY_CREDS}"
+    fi
+
     exit 0
 fi
 

--- a/utils.sh
+++ b/utils.sh
@@ -1009,8 +1009,12 @@ function write_pull_secret() {
     if [ "${OPENSHIFT_CI}" == true ]; then
         # We don't need to fetch a personal pull secret with the
         # token, but we still need to merge what we're given with the
-        # credentials for the local reigstry.
-        jq -s '.[0] * .[1]' "${REGISTRY_CREDS}" "${PERSONAL_PULL_SECRET}" > "${PULL_SECRET_FILE}"
+        # credentials for the local registry when mirroring is enabled.
+        if use_registry ""; then
+            jq -s '.[0] * .[1]' "${REGISTRY_CREDS}" "${PERSONAL_PULL_SECRET}" > "${PULL_SECRET_FILE}"
+        else
+            cp "${PERSONAL_PULL_SECRET}" "${PULL_SECRET_FILE}"
+        fi
         return
     fi
 
@@ -1025,9 +1029,13 @@ function write_pull_secret() {
     _tmpfiles="$_tmpfiles $tmppullsecret"
     oc registry login --kubeconfig="$tmpkubeconfig" --to="$tmppullsecret"
 
-    # Combine the personal pull secret with the ones for the CI
-    # registry and the local registry credentials.
-    jq -s '.[0] * .[1] * .[2]' "${PERSONAL_PULL_SECRET}" "${REGISTRY_CREDS}" "${tmppullsecret}" > "${PULL_SECRET_FILE}"
+    # Combine the personal pull secret with the CI registry credentials,
+    # and with the local registry credentials only when mirroring is enabled.
+    if use_registry ""; then
+        jq -s '.[0] * .[1] * .[2]' "${PERSONAL_PULL_SECRET}" "${REGISTRY_CREDS}" "${tmppullsecret}" > "${PULL_SECRET_FILE}"
+    else
+        jq -s '.[0] * .[1]' "${PERSONAL_PULL_SECRET}" "${tmppullsecret}" > "${PULL_SECRET_FILE}"
+    fi
 }
 
 function switch_to_internal_dns() {


### PR DESCRIPTION
## Summary

Fixes two regressions introduced by #1922 where the early `exit 0` in
`02_configure_host.sh` for `NODES_PLATFORM=baremetal` skipped both local
registry setup and `REGISTRY_CREDS` file creation.

## Problems fixed

### 1. Baremetal without mirroring (`MIRROR_IMAGES` unset)
`write_pull_secret()` in `utils.sh` unconditionally merged `REGISTRY_CREDS`
(`private-mirror-ocp.json`), causing:
```
jq: error: Could not open file /home/zuul/private-mirror-ocp.json: No such file or directory
```
Affects ShiftStack/RHOSO CI jobs on real baremetal hardware.

### 2. Baremetal with mirroring (`MIRROR_IMAGES=true`)
The local registry at port 5000 never starts, causing `04_setup_ironic.sh`
to fail with "connection refused" when mirroring release images.
Affects virtual-baremetal CI using sushy-emulator (e.g. RHOSO `uni04delta-ipv6` jobs).

## Changes

### `02_configure_host.sh` — registry setup in baremetal early-exit path
- `use_registry "podman"`: starts registry, creates `REGISTRY_CREDS` via podman login
- `use_registry ""` (quay): starts registry
- No registry: creates empty `{}` authfile for `write_pull_secret()` compatibility
- Mirrors the existing pattern in the libvirt path (lines 471–487)

### `utils.sh` — conditional REGISTRY_CREDS merge in write_pull_secret()
- Guards `REGISTRY_CREDS` merge behind `use_registry ""` check
- When mirroring is disabled: merges personal pull secret + CI registry token only
- Applies to both `OPENSHIFT_CI=true` and the standard CI_TOKEN code paths

## Root cause

#1922 assumed baremetal deployments never need a local registry. This is
true for "real" baremetal (standalone provisioning hosts pulling from
external registries), but not for:
- Virtual-baremetal setups using `MIRROR_IMAGES=true`
- Any baremetal path where `write_pull_secret()` is called without mirroring

## Test plan

- [ ] `NODES_PLATFORM=baremetal`, `MIRROR_IMAGES` unset: empty authfile created,
      `write_pull_secret()` succeeds without registry
- [ ] `NODES_PLATFORM=baremetal`, `MIRROR_IMAGES=true`: registry starts,
      `oc adm release mirror` succeeds
- [ ] `NODES_PLATFORM=libvirt`: no behavior change (early-exit block not reached)
- [ ] Verified against ShiftStack RHOSO CI job failure on serval70 (2026-07-28)

## Related

- Regression from: #1922
- Supersedes: #1938
- Downstream workaround: openstack-k8s-operators/ci-framework#4078