### PR TITLE
Fix missing local registry for baremetal with MIRROR_IMAGES

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -97,6 +97,25 @@ if [[ "${NODES_PLATFORM}" == "baremetal" ]]; then
 
     switch_to_internal_dns
 
+    # When MIRROR_IMAGES is configured, the local registry must be running
+    # before 04_setup_ironic.sh attempts to mirror release images into it.
+    # This covers virtual-baremetal (sushy-emulator) CI environments that
+    # set NODES_PLATFORM=baremetal together with MIRROR_IMAGES=true.
+    if use_registry "podman"; then
+        setup_local_registry
+        rm -f "${REGISTRY_CREDS}"
+        sudo podman login --authfile "${REGISTRY_CREDS}" \
+            -u "${REGISTRY_USER}" -p "${REGISTRY_PASS}" \
+            "${LOCAL_REGISTRY_DNS_NAME}":"${LOCAL_REGISTRY_PORT}"
+    elif use_registry ""; then
+        setup_local_registry
+    else
+        echo '{}' | sudo dd of="${REGISTRY_CREDS}"
+    fi
+    if [ -f "${REGISTRY_CREDS}" ]; then
+        sudo chown "$USER":"$USER" "${REGISTRY_CREDS}"
+    fi
+
     exit 0
 fi
 


### PR DESCRIPTION
## Summary

PR #1922 added an early `exit 0` in `02_configure_host.sh` for
`NODES_PLATFORM=baremetal`, which skips `setup_local_registry`.
This breaks environments that combine `NODES_PLATFORM=baremetal`
with `MIRROR_IMAGES=true` (e.g. virtual-baremetal CI using
sushy-emulator on libvirt VMs), because `04_setup_ironic.sh` still
attempts to mirror release images into the local registry at port
5000 and gets "connection refused".

This affects downstream RHOSO CI jobs like `uni04delta-ipv6` that
provision OCP via Ironic on virtual baremetal nodes and require
image mirroring for IPv6 connectivity.

## Changes

Add registry setup to the baremetal early-exit path in
`02_configure_host.sh`:

- If using podman registry (`use_registry "podman"`): start the
  registry and create `REGISTRY_CREDS` via `podman login` — mirrors
  the existing pattern in the libvirt path (lines 471–487)
- If using quay registry (`use_registry ""`): start it
- If no registry needed: create an empty `{}` `REGISTRY_CREDS`
  authfile so `write_pull_secret()` does not fail on the missing file

## Root cause

The early-exit path introduced by #1922 assumed that baremetal
deployments never need a local registry. This is true for "real"
baremetal (standalone provisioning hosts pulling from external
registries), but not for virtual-baremetal setups that use
`MIRROR_IMAGES=true` to mirror OCP release images locally.

## Related

- Regression from: #1922
- Complements: #1937 (fixes `write_pull_secret()` crash; this PR
  fixes the registry not running)
- Downstream workaround: https://github.com/openstack-k8s-operators/ci-framework/pull/4078
  (creates empty auth file but does not start the registry)

## Test plan

- [ ] `NODES_PLATFORM=baremetal`, `MIRROR_IMAGES=true`: registry
  starts, `oc adm release mirror` succeeds
- [ ] `NODES_PLATFORM=baremetal`, `MIRROR_IMAGES` unset: empty
  authfile created, no registry started, `write_pull_secret()` works
- [ ] `NODES_PLATFORM=libvirt`: no behavior change (early-exit block
  not reached)

Made with [Cursor](https://cursor.com)