### PR TITLE
OPNET-787: Add BGP_VIP_MANAGEMENT one-click knob

### DIFF
--- a/config_example.sh
+++ b/config_example.sh
@@ -238,6 +238,21 @@ set -x
 #export BGP_TOR_ASN=64513
 #export BGP_CLUSTER_ASN=64512
 #
+
+# BGP_VIP_MANAGEMENT -
+# Render platform.baremetal.bgpVIPConfig into the install-config so the
+# cluster advertises its API/ingress VIPs over BGP instead of managing them
+# with keepalived (enhancement 1982, DevPreview). Requires ENABLE_BGP_TOR
+# (the peer the cluster speaks to) and a FEATURE_SET that enables the
+# BGPBasedVIPManagement gate (DevPreviewNoUpgrade). The local ASN defaults
+# to BGP_CLUSTER_ASN, the peer ASN to BGP_TOR_ASN, and the peer address to
+# the ToR address on the external subnet; override the peer address with
+# BGP_VIP_PEER_ADDRESS if your topology differs.
+# Default is unset.
+#
+#export BGP_VIP_MANAGEMENT=true
+#export BGP_VIP_PEER_ADDRESS=
+#
 # FRR container image:
 #export BGP_TOR_IMAGE=quay.io/frrouting/frr:9.1.0
 

--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -198,6 +198,20 @@ EOF
     fi
 }
 
+function bgp_vip_config() {
+    if [[ "${BGP_VIP_MANAGEMENT:-false}" == "true" ]]; then
+        local peer_address
+        peer_address="${BGP_VIP_PEER_ADDRESS:-$(nth_ip "${EXTERNAL_SUBNET_V4}" 1)}"
+cat <<EOF
+    bgpVIPConfig:
+      localASN: ${BGP_CLUSTER_ASN:-64512}
+      peers:
+      - peerAddress: ${peer_address}
+        peerASN: ${BGP_TOR_ASN:-64513}
+EOF
+    fi
+}
+
 function featureSet() {
     if [[ -n "${FEATURE_SET:-}" ]]; then
 cat <<EOF
@@ -445,6 +459,7 @@ $(setVIPs apivips)
 $(setVIPs ingressvips)
 $(dnsvip)
 $(loadbalancer_type)
+$(bgp_vip_config)
     hosts:
 EOF
 

--- a/validation.sh
+++ b/validation.sh
@@ -54,6 +54,7 @@ function early_deploy_validation() {
     CHECK_OC_TOOL_PRESENCE=${1:-"false"}
 
     early_either_validation
+    early_bgp_vip_validation
 
     if [ ! -s "${PERSONAL_PULL_SECRET}" ] && [ "${OPENSHIFT_RELEASE_TYPE}" != "okd" ]; then
         error "${PERSONAL_PULL_SECRET} is missing or empty"
@@ -91,6 +92,24 @@ function early_deploy_validation() {
             exit 1
         fi
     fi
+}
+
+function early_bgp_vip_validation() {
+    if [[ "${BGP_VIP_MANAGEMENT:-false}" != "true" ]]; then
+        return 0
+    fi
+    if [[ "${ENABLE_BGP_TOR:-false}" != "true" ]]; then
+        error "BGP_VIP_MANAGEMENT needs a BGP peer for the cluster to talk to; set ENABLE_BGP_TOR=true"
+        exit 1
+    fi
+    case "${FEATURE_SET:-}" in
+        DevPreviewNoUpgrade|CustomNoUpgrade)
+            ;;
+        *)
+            error "BGP_VIP_MANAGEMENT requires the BGPBasedVIPManagement feature gate; set FEATURE_SET=DevPreviewNoUpgrade (or CustomNoUpgrade with the gate enabled)"
+            exit 1
+            ;;
+    esac
 }
 
 # Perform validation steps that we only want done when trying to clean


### PR DESCRIPTION
Follow-up to #1929 (`ENABLE_BGP_TOR`): a single switch that renders `platform.baremetal.bgpVIPConfig` into the generated install-config, so a BGP-VIP-managed cluster (enhancement 1982, DevPreview; installer support in openshift/installer#10718) deploys with plain `make` instead of hand-patching the install-config.

- `BGP_VIP_MANAGEMENT=true` emits the config block; ASNs and peer address default to the #1929 ToR conventions (`BGP_CLUSTER_ASN`/`BGP_TOR_ASN`, ToR address = first IP of the external subnet), with `BGP_VIP_PEER_ADDRESS` as override
- Hard-fail validation: the knob without `ENABLE_BGP_TOR` or without a `FEATURE_SET` enabling `BGPBasedVIPManagement` (DevPreviewNoUpgrade/CustomNoUpgrade) aborts early with a clear message
- No-op when unset — the emitter renders nothing

Validated on a live dev-scripts hypervisor: rendered block is byte-identical to the configuration used across 20+ validated BGP-VIP installs; guardrail paths exercised. A CI lane consuming this knob (openshift/release, `e2e-metal-ipi-bgp-vip`) follows.

---
This PR was prepared with AI assistance. Please verify before acting on it.