### PR TITLE
Fix quay-proxy ServiceAccount login username

### DIFF
--- a/utils.sh
+++ b/utils.sh
@@ -1027,12 +1027,13 @@ function write_pull_secret() {
     # Pull secret for registry.ci.openshift.org (auto-discovered from the cluster)
     oc registry login --kubeconfig="$tmpkubeconfig" --to="$tmppullsecret"
     # Pull secret for quay-proxy.ci.openshift.org.
-    # Username must be colon-free: oc whoami returns
+    # Replace ':' in the username: oc whoami for a ServiceAccount returns
     # system:serviceaccount:..., which breaks HTTP Basic Auth on quay-proxy.
+    # Humans (Rover) keep a usable whoami; SAs become colon-free.
     # Docs: https://docs.ci.openshift.org/how-tos/use-registries-in-build-farm/
     oc --kubeconfig="$tmpkubeconfig" whoami -t | \
         podman login "${CI_REGISTRY}" \
-            --username "image-puller" \
+            --username "$(oc --kubeconfig="$tmpkubeconfig" whoami | tr ':' '_')" \
             --password-stdin \
             --authfile "$tmppullsecret"
 

--- a/utils.sh
+++ b/utils.sh
@@ -1026,10 +1026,13 @@ function write_pull_secret() {
     _tmpfiles="$_tmpfiles $tmppullsecret"
     # Pull secret for registry.ci.openshift.org (auto-discovered from the cluster)
     oc registry login --kubeconfig="$tmpkubeconfig" --to="$tmppullsecret"
-    # Pull secret for quay-proxy.ci.openshift.org
+    # Pull secret for quay-proxy.ci.openshift.org.
+    # Username must be colon-free: oc whoami returns
+    # system:serviceaccount:..., which breaks HTTP Basic Auth on quay-proxy.
+    # Docs: https://docs.ci.openshift.org/how-tos/use-registries-in-build-farm/
     oc --kubeconfig="$tmpkubeconfig" whoami -t | \
         podman login "${CI_REGISTRY}" \
-            --username "$(oc --kubeconfig="$tmpkubeconfig" whoami)" \
+            --username "image-puller" \
             --password-stdin \
             --authfile "$tmppullsecret"
 


### PR DESCRIPTION
## Summary

Follow-up to #1933: fix `write_pull_secret()` so quay-proxy login works for ServiceAccount CI tokens.

#1933 correctly switched the default CI registry to `quay-proxy.ci.openshift.org` and added a `podman login` step. The username it used breaks auth for ServiceAccounts.

## Problem

```bash
podman login "${CI_REGISTRY}" \
    --username "$(oc whoami)" \
    --password-stdin
```

For a CI ServiceAccount, `oc whoami` returns:

```text
system:serviceaccount:openstack-k8s-operators:image-puller
```

The `:` characters corrupt HTTP Basic Auth password parsing on quay-proxy, so login fails with:

```text
Error: logging into "quay-proxy.ci.openshift.org": invalid username/password
→ make: *** [Makefile:74: build_installer] Error 125
```

The CI token itself is fine (`oc login` and `oc registry login` succeed; the SA can see projects). Only the username format is wrong.

CI docs explicitly warn about this:
https://docs.ci.openshift.org/how-tos/use-registries-in-build-farm/

> IMPORTANT: do NOT use `-u="$(oc whoami)"` for a ServiceAccount.
> Use any colon-free username; the password must be the ServiceAccount token.

## Change

**File:** `utils.sh` (`write_pull_secret()`)

```diff
-            --username "$(oc --kubeconfig="$tmpkubeconfig" whoami)" \
+            --username "image-puller" \
```

Password is unchanged: still piped from `oc whoami -t`.

## Impact

Without this, any non-`OPENSHIFT_CI` path that calls `write_pull_secret()` after #1933 fails at `build_installer` when authenticating to quay-proxy (e.g. ShiftStack/RHOSO Zuul jobs on serval70 using `devscripts_ci_token`).

## Reproduction / validation

```bash
# BAD (current #1933 behavior) — expect fail
oc whoami -t | podman login quay-proxy.ci.openshift.org \
  -u "$(oc whoami)" --password-stdin --authfile /tmp/bad.json

# GOOD (this PR) — expect ok
oc whoami -t | podman login quay-proxy.ci.openshift.org \
  -u image-puller --password-stdin --authfile /tmp/good.json
```

## Test plan

- [ ] Confirm CI token still logs into app.ci as the image-puller SA
- [ ] Confirm broken username form fails quay-proxy login
- [ ] Confirm `-u image-puller` succeeds
- [ ] Re-run a ShiftStack/RHOSO periodic (or equivalent) past `03_build_installer.sh` / `write_pull_secret`

## Related

- Regression from: #1933 (@andfasano)
- Independent of: #1937 (baremetal `REGISTRY_CREDS` / local registry — still needed separately)
- Docs: https://docs.ci.openshift.org/how-tos/use-registries-in-build-farm/
- QCI migration context: https://redhat-internal.slack.com/archives/CFUGK0K9R/p1785235182016299


Made with [Cursor](https://cursor.com)