### PR TITLE
OCPBUGS-104570: Pin argcomplete<3.7 to fix Python 3.9 incompatibility

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -127,7 +127,7 @@ esac
 # overwrite an existing installation of the golang version, though,
 # so check if we have a yq before installing.
 if ! which yq >/dev/null 2>&1; then
-    sudo python -m pip install 'yq>=3,<4'
+    sudo python -m pip install 'yq>=3,<4' 'argcomplete<3.7'
 else
     echo "Using yq from $(which yq)"
 fi


### PR DESCRIPTION
argcomplete 3.7.1 dropped Python 3.9 support and uses union type syntax (str | bytes) that requires Python 3.10+. Since dev-scripts runs on RHEL 9 with Python 3.9, this crashes ansible-galaxy on import, failing make requirements and breaking all metal-IPI CI jobs.

Pin argcomplete below 3.7 when installing yq to prevent the incompatible version from being pulled in as a transitive dependency.

Bug: https://issues.redhat.com/browse/OCPBUGS-104570

Signed-off-by: Jamo Luhrsen <jluhrsen@gmail.com>

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED