### PR TITLE
Pin argcomplete<3.7.1 to fix Python 3.9 compatibility

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -170,6 +170,9 @@ fi
 # and lxml for the pyxpath script
 sudo python -m pip install netaddr lxml
 
+# argcomplete 3.7.1 uses PEP 604 type unions (str | bytes) which require
+# Python 3.10+, breaking on the Python 3.9 shipped with CentOS Stream 9.
+sudo python -m pip install 'argcomplete<3.7.1'
 sudo python -m pip install ansible=="${ANSIBLE_VERSION}"
 
 pushd "${METAL3_DEV_ENV_PATH}"


### PR DESCRIPTION
## Summary

- Pin `argcomplete<3.7.1` before the ansible install to prevent pip from pulling in the incompatible version
- `argcomplete` 3.7.1 uses PEP 604 type union syntax (`str | bytes`) which requires Python 3.10+
- CentOS Stream 9 ships Python 3.9, causing all metal-IPI CI jobs to permafail at `baremetalds-devscripts-setup`

## Test plan

- [ ] Verify metal-IPI CI jobs pass with this fix
- [ ] Confirm `argcomplete` 3.7.0 or earlier is installed after `make requirements`

Fixes: OCPBUGS-104570

🤖 Generated with [Claude Code](https://claude.com/claude-code)