### PR TITLE
BGP VIP management: render an IPv6 ToR peer on dual-stack deployments

### DIFF
--- a/bgp/configure_bgp_tor.sh
+++ b/bgp/configure_bgp_tor.sh
@@ -62,6 +62,8 @@ router bgp ${BGP_TOR_ASN}
  no bgp ebgp-requires-policy
  neighbor CLUSTER peer-group
  neighbor CLUSTER remote-as ${BGP_CLUSTER_ASN}
+ neighbor CLUSTER password ${BGP_VIP_PASSWORD:-dev-scripts-bgp}
+ neighbor CLUSTER bfd
 ${LISTEN_RANGES}${ADDRESS_FAMILIES}!
 EOF
 
@@ -80,7 +82,7 @@ eigrpd=no
 babeld=no
 sharpd=no
 pbrd=no
-bfdd=no
+bfdd=yes
 fabricd=no
 vrrpd=no
 pathd=no
@@ -88,10 +90,16 @@ pathd=no
 vtysh_enable=yes
 zebra_options="  -A 127.0.0.1 -s 90000000"
 bgpd_options="   -A 127.0.0.1"
+bfdd_options="   -A 127.0.0.1"
 EOF
 
 sudo firewall-cmd --zone=libvirt --permanent --add-port=179/tcp
 sudo firewall-cmd --zone=libvirt --add-port=179/tcp
+# BFD control and echo (single hop, RFC 5881)
+for port in 3784 3785; do
+    sudo firewall-cmd --zone=libvirt --permanent --add-port=${port}/udp
+    sudo firewall-cmd --zone=libvirt --add-port=${port}/udp
+done
 
 sudo podman run -d --replace --name "${BGP_TOR_NAME}" --net host --privileged \
     -v "${BGP_TOR_DIR}/frr.conf:/etc/frr/frr.conf:z" \

--- a/config_example.sh
+++ b/config_example.sh
@@ -253,11 +253,14 @@ set -x
 # BGPBasedVIPManagement gate (DevPreviewNoUpgrade). The local ASN defaults
 # to BGP_CLUSTER_ASN, the peer ASN to BGP_TOR_ASN, and the peer address to
 # the ToR address on the external subnet; override the peer address with
-# BGP_VIP_PEER_ADDRESS if your topology differs.
+# BGP_VIP_PEER_ADDRESS if your topology differs. On dual-stack deployments
+# a second peer is rendered for the ToR's IPv6 address on the external v6
+# subnet (override with BGP_VIP_PEER_ADDRESS_V6).
 # Default is unset.
 #
 #export BGP_VIP_MANAGEMENT=true
 #export BGP_VIP_PEER_ADDRESS=
+#export BGP_VIP_PEER_ADDRESS_V6=
 #
 # FRR container image:
 #export BGP_TOR_IMAGE=quay.io/frrouting/frr:9.1.0

--- a/config_example.sh
+++ b/config_example.sh
@@ -262,6 +262,14 @@ set -x
 #export BGP_VIP_PEER_ADDRESS=
 #export BGP_VIP_PEER_ADDRESS_V6=
 #
+# Every optional peer field (port, timers, password, BFD, eBGP multihop)
+# is set on purpose so the full rendering path is exercised end to end;
+# the ToR is configured to match. Timers are Go durations of whole
+# seconds; the session password must match on both ends.
+#export BGP_VIP_HOLD_TIME=90s
+#export BGP_VIP_KEEPALIVE_TIME=30s
+#export BGP_VIP_PASSWORD=dev-scripts-bgp
+#
 # FRR container image:
 #export BGP_TOR_IMAGE=quay.io/frrouting/frr:9.1.0
 

--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -202,12 +202,25 @@ function bgp_vip_config() {
     if [[ "${BGP_VIP_MANAGEMENT:-false}" == "true" ]]; then
         local peer_address peer_address_v6
         peer_address="${BGP_VIP_PEER_ADDRESS:-$(nth_ip "${EXTERNAL_SUBNET_V4}" 1)}"
+        # Set every optional peer field so e2e exercises the full
+        # rendering path (dead fields and format bugs are invisible on
+        # the defaults-only happy path). The ToR side is configured to
+        # match by bgp/configure_bgp_tor.sh; the verify CI step asserts
+        # the negotiated timers and BFD state at the ToR.
+        local peer_options
+        peer_options="        port: 179
+        holdTime: \"${BGP_VIP_HOLD_TIME:-90s}\"
+        keepaliveTime: \"${BGP_VIP_KEEPALIVE_TIME:-30s}\"
+        password: \"${BGP_VIP_PASSWORD:-dev-scripts-bgp}\"
+        bfdEnabled: \"true\"
+        ebgpMultiHop: \"true\""
 cat <<EOF
     bgpVIPConfig:
       localASN: ${BGP_CLUSTER_ASN:-64512}
       peers:
       - peerAddress: ${peer_address}
         peerASN: ${BGP_TOR_ASN:-64513}
+${peer_options}
 EOF
         # dual-stack: peer with the ToR over IPv6 as well, so the
         # secondary-family VIPs have a same-family BGP session
@@ -216,6 +229,7 @@ EOF
 cat <<EOF
       - peerAddress: ${peer_address_v6}
         peerASN: ${BGP_TOR_ASN:-64513}
+${peer_options}
 EOF
         fi
     fi

--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -200,7 +200,7 @@ EOF
 
 function bgp_vip_config() {
     if [[ "${BGP_VIP_MANAGEMENT:-false}" == "true" ]]; then
-        local peer_address
+        local peer_address peer_address_v6
         peer_address="${BGP_VIP_PEER_ADDRESS:-$(nth_ip "${EXTERNAL_SUBNET_V4}" 1)}"
 cat <<EOF
     bgpVIPConfig:
@@ -209,6 +209,15 @@ cat <<EOF
       - peerAddress: ${peer_address}
         peerASN: ${BGP_TOR_ASN:-64513}
 EOF
+        # dual-stack: peer with the ToR over IPv6 as well, so the
+        # secondary-family VIPs have a same-family BGP session
+        if [[ -n "${EXTERNAL_SUBNET_V6:-}" ]]; then
+            peer_address_v6="${BGP_VIP_PEER_ADDRESS_V6:-$(nth_ip "${EXTERNAL_SUBNET_V6}" 1)}"
+cat <<EOF
+      - peerAddress: ${peer_address_v6}
+        peerASN: ${BGP_TOR_ASN:-64513}
+EOF
+        fi
     fi
 }
 


### PR DESCRIPTION
Follow-up to #1939: with `IP_STACK=v4v6` the install-config carries one API/ingress VIP per address family, but `bgpVIPConfig` only rendered the IPv4 ToR peer — the secondary-family VIPs had no same-family BGP session to be advertised over. Render a second peer for the ToR's address on the external IPv6 subnet when one exists (override: `BGP_VIP_PEER_ADDRESS_V6`). The ToR speaker from #1929 already listens on both families.

Validated on a live dual-stack dev-scripts cluster: both sessions establish per node and both VIP families are advertised to the ToR (v4 /32s and v6 /128s).

Needed for the dual-stack conversion of the `e2e-metal-ipi-bgp-vip*` CI lanes (openshift/release#82912).

---
This PR description was generated using AI. Please verify before acting on it.