### PR TITLE
Revert argcomplete manual pinning. Was fixed in pypi

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -127,12 +127,7 @@ esac
 # overwrite an existing installation of the golang version, though,
 # so check if we have a yq before installing.
 if ! which yq >/dev/null 2>&1; then
-    if python3 -c 'import sys; sys.exit(0 if sys.version_info < (3, 10) else 1)'; then
-        echo "Python version is < 3.10. Installing argcomplete < 3.7"
-        sudo python -m pip install 'yq>=3,<4' 'argcomplete<3.7'
-    else
-        sudo python -m pip install 'yq>=3,<4'
-    fi
+    sudo python -m pip install 'yq>=3,<4'
 else
     echo "Using yq from $(which yq)"
 fi


### PR DESCRIPTION
3.7.2 requires Python 3.10+ and 3.7.1 was yanked

This reverts commit 0a4d7c70ad7c423d00496315062b91f94417dd0b. This reverts commit f68bc574f57a75402a010184be7e0fcbbced6a3c.