### PR TITLE
fix(agent): skip DHCPv4 default gateway option for IPv6 networks

### DIFF
--- a/agent/05_agent_configure.sh
+++ b/agent/05_agent_configure.sh
@@ -690,7 +690,10 @@ function enable_isolated_baremetal_network() {
     # Remove the forward block
     sudo sed -i "/<forward\( [^>]*\)\?>/,/<\/forward>/d" "${WORKING_DIR}/${BAREMETAL_NETWORK_NAME}"
     # Add a default route (will be required by assisted-service pre-flight validations)
-    sudo sed -i "/<\/dnsmasq:options>/i   <dnsmasq:option value='dhcp-option=3,${PROVISIONING_HOST_EXTERNAL_IP}'/>" "${WORKING_DIR}/${BAREMETAL_NETWORK_NAME}"
+    # dhcp-option=3 (router) is DHCPv4-only; IPv6 uses Router Advertisements instead.
+    if [[ "${IP_STACK}" != "v6" ]]; then
+      sudo sed -i "/<\/dnsmasq:options>/i   <dnsmasq:option value='dhcp-option=3,${PROVISIONING_HOST_EXTERNAL_IP}'/>" "${WORKING_DIR}/${BAREMETAL_NETWORK_NAME}"
+    fi
 
     # Update the baremetal network
     sudo virsh net-destroy "${BAREMETAL_NETWORK_NAME}"


### PR DESCRIPTION
`enable_isolated_baremetal_network()` unconditionally adds `dhcp-option=3`  using `PROVISIONING_HOST_EXTERNAL_IP`. On IPv6 single-stack environments  (`HOST_IP_STACK=v6`), this variable contains an IPv6 address, causing  dnsmasq to fail on network start with a "bad IP address" error.

In IPv6 environments, default routes are handled via Router Advertisements  (RA) rather than DHCP options. Skip setting `dhcp-option=3` when operating  on an IPv6 stack.

When using 
```
export OPENSHIFT_RELEASE_IMAGE=quay.io/openshift-release-dev/ocp-release:4.22.12-x86_64
export AGENT_E2E_TEST_SCENARIO=SNO_IPV6
export AGENT_E2E_TEST_BOOT_MODE=ISO_NO_REGISTRY
export AGENT_CLEANUP_ISO_BUILDER_CACHE_LOCAL_DEV=true
export AGENT_PLATFORM_TYPE=none
```

Without this fix the dev-scripts fails with error

```
2026-08-29 09:22:31 +(./agent/05_agent_configure.sh:699): enable_isolated_baremetal_network(): sudo virsh net-start ostestbm
2026-08-29 09:22:31 error: Failed to start network ostestbm
2026-08-29 09:22:31 error: internal error: Child process (VIR_BRIDGE_NAME=ostestbm /usr/sbin/dnsmasq --conf-file=/var/lib/libvirt/dnsmasq/ostestbm.conf --leasefile-ro --dhcp-script=/usr/libexec/libvirt_leaseshelper) unexpected exit status 1:
2026-08-29 09:22:31 dnsmasq: bad IP address at line 25 of /var/lib/libvirt/dnsmasq/ostestbm.conf

