### PR TITLE
fix(agent): Fix IPv6 default route for isolated network and single-stack IPV6 UI selection

### DIFF
--- a/agent/05_agent_configure.sh
+++ b/agent/05_agent_configure.sh
@@ -695,6 +695,17 @@ function enable_isolated_baremetal_network() {
       sudo sed -i "/<\/dnsmasq:options>/i   <dnsmasq:option value='dhcp-option=3,${PROVISIONING_HOST_EXTERNAL_IP}'/>" "${WORKING_DIR}/${BAREMETAL_NETWORK_NAME}"
     fi
 
+    # For IPv6, libvirt generates ra-param=*,0,0 for isolated networks (no
+    # <forward> block), which sets router-lifetime to 0 in all Router
+    # Advertisements. This means dnsmasq never advertises a default route,
+    # causing the assisted-service "default route" validation to fail.
+    # Override this by appending ra-param with a non-zero lifetime (1800s).
+    # Options in <dnsmasq:options> are placed after libvirt's auto-generated
+    # config, so the last ra-param wins.
+    if [[ "${IP_STACK}" == "v6" || "${IP_STACK}" == "v4v6" || "${IP_STACK}" == "v6v4" ]]; then
+      sudo sed -i "/<\/dnsmasq:options>/i   <dnsmasq:option value='ra-param=*,0,1800'/>" "${WORKING_DIR}/${BAREMETAL_NETWORK_NAME}"
+    fi
+
     # Update the baremetal network
     sudo virsh net-destroy "${BAREMETAL_NETWORK_NAME}"
     sudo virsh net-undefine "${BAREMETAL_NETWORK_NAME}"

--- a/agent/isobuilder/ui_driven_cluster_installation/main.go
+++ b/agent/isobuilder/ui_driven_cluster_installation/main.go
@@ -574,7 +574,7 @@ func networkingDetails(page *rod.Page, path string) error {
 	apiVip := apiVips
 	ingressVip := ingressVips
 
-	if ipStack == "v4" {
+	if ipStack == "v4" || ipStack == "v6" {
 		page.MustElement("#form-radio-stackType-singleStack-field")
 		logrus.Info("Selected IPV4 networking stack")
 		if getControlPlaneCount() == 1 {


### PR DESCRIPTION
Fix SNO IPv6 cluster deployment with ISO_NO_REGISTRY failing the assisted-service "default route" pre-flight validation.

For isolated networks (no <forward> block), libvirt auto-generates ra-param=*,0,0 in the dnsmasq config, which sets router-lifetime to 0 in all Router Advertisements. This causes dnsmasq to never advertise a default route via RA, and IPv6 hosts fail validation with: "Host has not yet been configured with a default route."

Fix this by overriding ra-param in the network XML's <dnsmasq:options> with a non-zero router lifetime. Options in this section are appended after libvirt's auto-generated config, so the last ra-param wins.

Additionally, fix the UI-driven installer to select single-stack networking for IPv6-only clusters, matching the existing IPv4 behavior.